### PR TITLE
Fix broken Joint Stereo coding, issue #11

### DIFF
--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -338,7 +338,7 @@ int BlocQuant(CoderInfo *coder, double *xr, AACQuantCfg *aacquantCfg)
                 lastis += diff;
                 coder->sf[cnt] = lastis;
             }
-            else if (book != HCB_PNS)
+            else if (book == HCB_ESC)
             {
                 int diff = coder->sf[cnt] - lastsf;
 


### PR DESCRIPTION
This fixes broken Joint Stereo coding after the introduction of PNS coding, reported in issue #11.