### PR TITLE
Fix compilation with older versions of GCC (and on big-endian systems)

### DIFF
--- a/frontend/mp4write.c
+++ b/frontend/mp4write.c
@@ -17,6 +17,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ****************************************************************************/
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -40,6 +40,12 @@
 # define bit_SSE2 (1 << 26)
 #endif
 
+#ifdef __GNUC__
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+#endif
+
 #define MAGIC_NUMBER  0.4054
 #define NOISEFLOOR 0.4
 
@@ -147,7 +153,7 @@ static void qlevel(CoderInfo *coderInfo,
                   )
 {
     int sb, cnt;
-#ifndef __clang__
+#if !defined(__clang__) && (!defined(__GNUC__) || GCC_VERSION >= 40600)
     /* 2^0.25 (1.50515 dB) step from AAC specs */
     static const double sfstep = 1.0 / log10(sqrt(sqrt(2.0)));
 #else


### PR DESCRIPTION
faac fails to compile with older versions of GCC (< 4.6). In addition some endianness checks return an incorrect result.

This pull request fixes the endianness checks in `mp4write` and compilation with older versions of GCC.
The patch has been tested with GCC 4.0, 4.2, 4.6 and 7.2.