### PR TITLE
update for Visual Studio 2017 project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Makefile*
 .vs/
 /project/msvc/bin/
 /project/msvc/intermediate/
+*.user

--- a/frontend/input.c
+++ b/frontend/input.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 #ifdef _WIN32

--- a/include/faac.h
+++ b/include/faac.h
@@ -47,6 +47,7 @@ typedef struct {
 psymodellist_t;
 
 #include "faaccfg.h"
+#include <stdint.h>
 
 
 typedef void *faacEncHandle;

--- a/project/msvc/libfaac.vcxproj
+++ b/project/msvc/libfaac.vcxproj
@@ -78,23 +78,22 @@
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\libfaac\aacquant.c" />
     <ClCompile Include="..\..\libfaac\bitstream.c" />
     <ClCompile Include="..\..\libfaac\blockswitch.c" />
     <ClCompile Include="..\..\libfaac\channels.c" />
     <ClCompile Include="..\..\libfaac\fft.c" />
     <ClCompile Include="..\..\libfaac\filtbank.c" />
     <ClCompile Include="..\..\libfaac\frame.c" />
-    <ClCompile Include="..\..\libfaac\huffman.c" />
-    <ClCompile Include="..\..\libfaac\midside.c" />
+    <ClCompile Include="..\..\libfaac\huff2.c" />
+    <ClCompile Include="..\..\libfaac\huffdata.c" />
     <ClCompile Include="..\..\libfaac\quantize.c" />
+    <ClCompile Include="..\..\libfaac\stereo.c" />
     <ClCompile Include="..\..\libfaac\tns.c" />
     <ClCompile Include="..\..\libfaac\util.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\faac.h" />
     <ClInclude Include="..\..\include\faaccfg.h" />
-    <ClInclude Include="..\..\libfaac\aacquant.h" />
     <ClInclude Include="..\..\libfaac\bitstream.h" />
     <ClInclude Include="..\..\libfaac\blockswitch.h" />
     <ClInclude Include="..\..\libfaac\channels.h" />
@@ -102,10 +101,10 @@
     <ClInclude Include="..\..\libfaac\fft.h" />
     <ClInclude Include="..\..\libfaac\filtbank.h" />
     <ClInclude Include="..\..\libfaac\frame.h" />
-    <ClInclude Include="..\..\libfaac\huffman.h" />
-    <ClInclude Include="..\..\libfaac\hufftab.h" />
-    <ClInclude Include="..\..\libfaac\midside.h" />
+    <ClInclude Include="..\..\libfaac\huff2.h" />
+    <ClInclude Include="..\..\libfaac\huffdata.h" />
     <ClInclude Include="..\..\libfaac\quantize.h" />
+    <ClInclude Include="..\..\libfaac\stereo.h" />
     <ClInclude Include="..\..\libfaac\tns.h" />
     <ClInclude Include="..\..\libfaac\util.h" />
     <ClInclude Include="..\..\libfaac\version.h" />

--- a/project/msvc/libfaac.vcxproj.filters
+++ b/project/msvc/libfaac.vcxproj.filters
@@ -11,9 +11,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\libfaac\aacquant.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\libfaac\bitstream.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -29,12 +26,6 @@
     <ClCompile Include="..\..\libfaac\frame.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libfaac\huffman.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\libfaac\midside.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\libfaac\tns.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -47,11 +38,17 @@
     <ClCompile Include="..\..\libfaac\quantize.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libfaac\huff2.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libfaac\huffdata.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libfaac\stereo.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\libfaac\aacquant.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\libfaac\bitstream.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -73,15 +70,6 @@
     <ClInclude Include="..\..\libfaac\frame.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\libfaac\huffman.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\libfaac\hufftab.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\libfaac\midside.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\libfaac\quantize.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -98,6 +86,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\faaccfg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libfaac\huff2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libfaac\huffdata.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libfaac\stereo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/project/msvc/libfaac_dll.vcxproj
+++ b/project/msvc/libfaac_dll.vcxproj
@@ -88,23 +88,22 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\libfaac\aacquant.c" />
     <ClCompile Include="..\..\libfaac\bitstream.c" />
     <ClCompile Include="..\..\libfaac\blockswitch.c" />
     <ClCompile Include="..\..\libfaac\channels.c" />
     <ClCompile Include="..\..\libfaac\fft.c" />
     <ClCompile Include="..\..\libfaac\filtbank.c" />
     <ClCompile Include="..\..\libfaac\frame.c" />
-    <ClCompile Include="..\..\libfaac\huffman.c" />
-    <ClCompile Include="..\..\libfaac\midside.c" />
+    <ClCompile Include="..\..\libfaac\huff2.c" />
+    <ClCompile Include="..\..\libfaac\huffdata.c" />
     <ClCompile Include="..\..\libfaac\quantize.c" />
+    <ClCompile Include="..\..\libfaac\stereo.c" />
     <ClCompile Include="..\..\libfaac\tns.c" />
     <ClCompile Include="..\..\libfaac\util.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\faac.h" />
     <ClInclude Include="..\..\include\faaccfg.h" />
-    <ClInclude Include="..\..\libfaac\aacquant.h" />
     <ClInclude Include="..\..\libfaac\bitstream.h" />
     <ClInclude Include="..\..\libfaac\blockswitch.h" />
     <ClInclude Include="..\..\libfaac\channels.h" />
@@ -112,13 +111,12 @@
     <ClInclude Include="..\..\libfaac\fft.h" />
     <ClInclude Include="..\..\libfaac\filtbank.h" />
     <ClInclude Include="..\..\libfaac\frame.h" />
-    <ClInclude Include="..\..\libfaac\huffman.h" />
-    <ClInclude Include="..\..\libfaac\hufftab.h" />
-    <ClInclude Include="..\..\libfaac\midside.h" />
+    <ClInclude Include="..\..\libfaac\huff2.h" />
+    <ClInclude Include="..\..\libfaac\huffdata.h" />
     <ClInclude Include="..\..\libfaac\quantize.h" />
+    <ClInclude Include="..\..\libfaac\stereo.h" />
     <ClInclude Include="..\..\libfaac\tns.h" />
     <ClInclude Include="..\..\libfaac\util.h" />
-    <ClInclude Include="..\..\libfaac\version.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="libfaac.def" />

--- a/project/msvc/libfaac_dll.vcxproj.filters
+++ b/project/msvc/libfaac_dll.vcxproj.filters
@@ -11,9 +11,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\libfaac\aacquant.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\libfaac\bitstream.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -29,12 +26,6 @@
     <ClCompile Include="..\..\libfaac\frame.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libfaac\huffman.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\libfaac\midside.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\libfaac\tns.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -47,11 +38,17 @@
     <ClCompile Include="..\..\libfaac\quantize.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libfaac\huff2.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libfaac\huffdata.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libfaac\stereo.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\libfaac\aacquant.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\libfaac\bitstream.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -73,15 +70,6 @@
     <ClInclude Include="..\..\libfaac\frame.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\libfaac\huffman.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\libfaac\hufftab.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\libfaac\midside.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\libfaac\quantize.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -91,13 +79,19 @@
     <ClInclude Include="..\..\libfaac\util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\libfaac\version.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\include\faac.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\faaccfg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libfaac\huff2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libfaac\huffdata.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libfaac\stereo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/project/msvc/libfaac_dll_drm.vcxproj
+++ b/project/msvc/libfaac_dll_drm.vcxproj
@@ -90,18 +90,18 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\libfaac\aacquant.c" />
     <ClCompile Include="..\..\libfaac\bitstream.c" />
     <ClCompile Include="..\..\libfaac\blockswitch.c" />
     <ClCompile Include="..\..\libfaac\channels.c" />
     <ClCompile Include="..\..\libfaac\fft.c" />
     <ClCompile Include="..\..\libfaac\filtbank.c" />
     <ClCompile Include="..\..\libfaac\frame.c" />
-    <ClCompile Include="..\..\libfaac\huffman.c" />
+    <ClCompile Include="..\..\libfaac\huff2.c" />
+    <ClCompile Include="..\..\libfaac\huffdata.c" />
     <ClCompile Include="..\..\libfaac\kiss_fft\kiss_fft.c" />
     <ClCompile Include="..\..\libfaac\kiss_fft\kiss_fftr.c" />
-    <ClCompile Include="..\..\libfaac\midside.c" />
     <ClCompile Include="..\..\libfaac\quantize.c" />
+    <ClCompile Include="..\..\libfaac\stereo.c" />
     <ClCompile Include="..\..\libfaac\tns.c" />
     <ClCompile Include="..\..\libfaac\util.c" />
   </ItemGroup>
@@ -116,13 +116,13 @@
     <ClInclude Include="..\..\libfaac\fft.h" />
     <ClInclude Include="..\..\libfaac\filtbank.h" />
     <ClInclude Include="..\..\libfaac\frame.h" />
-    <ClInclude Include="..\..\libfaac\huffman.h" />
-    <ClInclude Include="..\..\libfaac\hufftab.h" />
+    <ClInclude Include="..\..\libfaac\huff2.h" />
+    <ClInclude Include="..\..\libfaac\huffdata.h" />
     <ClInclude Include="..\..\libfaac\kiss_fft\kiss_fft.h" />
     <ClInclude Include="..\..\libfaac\kiss_fft\kiss_fftr.h" />
     <ClInclude Include="..\..\libfaac\kiss_fft\_kiss_fft_guts.h" />
-    <ClInclude Include="..\..\libfaac\midside.h" />
     <ClInclude Include="..\..\libfaac\quantize.h" />
+    <ClInclude Include="..\..\libfaac\stereo.h" />
     <ClInclude Include="..\..\libfaac\tns.h" />
     <ClInclude Include="..\..\libfaac\util.h" />
     <ClInclude Include="..\..\libfaac\version.h" />

--- a/project/msvc/libfaac_dll_drm.vcxproj.filters
+++ b/project/msvc/libfaac_dll_drm.vcxproj.filters
@@ -29,12 +29,6 @@
     <ClCompile Include="..\..\libfaac\frame.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libfaac\huffman.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\libfaac\midside.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\libfaac\tns.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -53,7 +47,13 @@
     <ClCompile Include="..\..\libfaac\quantize.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libfaac\aacquant.c">
+    <ClCompile Include="..\..\libfaac\huff2.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libfaac\huffdata.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libfaac\stereo.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -82,15 +82,6 @@
     <ClInclude Include="..\..\libfaac\frame.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\libfaac\huffman.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\libfaac\hufftab.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\libfaac\midside.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\libfaac\quantize.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -116,6 +107,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\faaccfg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libfaac\huff2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libfaac\huffdata.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libfaac\stereo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Here's a quick update of the Visual Studio 2017 project files, reflecting the changes in the source files. Unfortunately the projects don't build due to some errors in the SSE2 code, which seem not to compile under VS 2017.