### PR TITLE
build: add pkg-config file, and get VS 2019 build working

### DIFF
--- a/project/msvc/faac.pc
+++ b/project/msvc/faac.pc
@@ -1,0 +1,9 @@
+prefix=c:/Users/aaron
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: faac
+Description: FAAC AAC encoder library
+Version: 1.30.0
+Libs: -L${libdir} -llibfaac
+Cflags: -I${includedir}

--- a/project/msvc/faac.sln
+++ b/project/msvc/faac.sln
@@ -10,8 +10,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libfaac", "libfaac.vcxproj"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "faac", "faac.vcxproj", "{92992E74-AEDE-46DC-AD8C-ADEA876F1A4C}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "faacgui", "faacgui.vcxproj", "{B4FD0E50-5379-48C3-8D3E-D948A8921CA8}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -53,14 +51,6 @@ Global
 		{92992E74-AEDE-46DC-AD8C-ADEA876F1A4C}.Release|Win32.Build.0 = Release|Win32
 		{92992E74-AEDE-46DC-AD8C-ADEA876F1A4C}.Release|x64.ActiveCfg = Release|x64
 		{92992E74-AEDE-46DC-AD8C-ADEA876F1A4C}.Release|x64.Build.0 = Release|x64
-		{B4FD0E50-5379-48C3-8D3E-D948A8921CA8}.Debug|Win32.ActiveCfg = Debug|Win32
-		{B4FD0E50-5379-48C3-8D3E-D948A8921CA8}.Debug|Win32.Build.0 = Debug|Win32
-		{B4FD0E50-5379-48C3-8D3E-D948A8921CA8}.Debug|x64.ActiveCfg = Debug|x64
-		{B4FD0E50-5379-48C3-8D3E-D948A8921CA8}.Debug|x64.Build.0 = Debug|x64
-		{B4FD0E50-5379-48C3-8D3E-D948A8921CA8}.Release|Win32.ActiveCfg = Release|Win32
-		{B4FD0E50-5379-48C3-8D3E-D948A8921CA8}.Release|Win32.Build.0 = Release|Win32
-		{B4FD0E50-5379-48C3-8D3E-D948A8921CA8}.Release|x64.ActiveCfg = Release|x64
-		{B4FD0E50-5379-48C3-8D3E-D948A8921CA8}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
pkg-config file can be used by other projects such as gstreamer
to link to faac on windows