### PR TITLE
Add album artist and various sort order MP4 tags.

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -80,15 +80,20 @@ enum flags
     SHORTCTL_FLAG = 300,
     MPEGVERS_FLAG,
     ARTIST_FLAG,
+    ARTIST_SORT_FLAG,
     TITLE_FLAG,
     GENRE_FLAG,
     ALBUM_FLAG,
+    ALBUM_SORT_FLAG,
+    ALBUM_ARTIST_FLAG,
+    ALBUM_ARTIST_SORT_FLAG,
     TRACK_FLAG,
     DISC_FLAG,
     YEAR_FLAG,
     COVER_ART_FLAG,
     COMMENT_FLAG,
     WRITER_FLAG,
+    WRITER_SORT_FLAG,
     TAG_FLAG,
     HELP_QUAL,
     HELP_IO,
@@ -168,10 +173,15 @@ static help_t help_mp4[] = {
     "\t\t*.m4b)\n"},
     {"--tag <tagname,tagvalue> Add named tag (iTunes '----')\n"},
     {"--artist <name>\tSet artist name\n"},
+    {"--artistsort <name>\tSet artist sort order\n"},
     {"--composer <name>\tSet composer name\n"},
+    {"--composersort <name>\tSet composer sort order\n"},
     {"--title <name>\tSet title/track name\n"},
     {"--genre <number>\tSet genre number\n"},
     {"--album <name>\tSet album/performer\n"},
+    {"--albumartist <name>\tSet album artist\n"},
+    {"--albumartistsort <name>\tSet album artist sort order\n"},
+    {"--albumsort <name>\tSet album sort order\n"},
     {"--compilation\tMark as compilation\n"},
     {"--track <number/total>\tSet track number\n"},
     {"--disc <number/total>\tSet disc number\n"},
@@ -461,8 +471,11 @@ int main(int argc, char *argv[])
     unsigned int ntracks = 0, trackno = 0;
     unsigned int ndiscs = 0, discno = 0;
     static int compilation = 0;
-    const char *artist = NULL, *title = NULL, *album = NULL, *year = NULL,
-        *comment = NULL, *composer = NULL, *tagname = 0, *tagval = 0;
+    const char *artist = NULL, *artistsort = NULL, *title = NULL,
+        *album = NULL, *albumartist = NULL,
+        *albumartistsort = NULL, *albumsort = NULL,
+        *year = NULL, *comment = NULL, *composer = NULL,
+        *composersort = NULL, *tagname = 0, *tagval = 0;
     int genre = 0;
     uint8_t *artData = NULL;
     uint64_t artSize = 0;
@@ -526,8 +539,12 @@ int main(int argc, char *argv[])
             {"license", 0, 0, 'L'},
             {"createmp4", 0, 0, 'w'},
             {"artist", 1, 0, ARTIST_FLAG},
+            {"artistsort", 1, 0, ARTIST_SORT_FLAG},
             {"title", 1, 0, TITLE_FLAG},
             {"album", 1, 0, ALBUM_FLAG},
+            {"albumartist", 1, 0, ALBUM_ARTIST_FLAG},
+            {"albumartistsort", 1, 0, ALBUM_ARTIST_SORT_FLAG},
+            {"albumsort", 1, 0, ALBUM_SORT_FLAG},
             {"track", 1, 0, TRACK_FLAG},
             {"disc", 1, 0, DISC_FLAG},
             {"genre", 1, 0, GENRE_FLAG},
@@ -535,6 +552,7 @@ int main(int argc, char *argv[])
             {"cover-art", 1, 0, COVER_ART_FLAG},
             {"comment", 1, 0, COMMENT_FLAG},
             {"composer", 1, 0, WRITER_FLAG},
+            {"composersort", 1, 0, WRITER_SORT_FLAG},
             {"compilation", 0, &compilation, 1},
             {"pcmswapbytes", 0, 0, 'X'},
             {"ignorelength", 0, &ignorelen, 1},
@@ -641,14 +659,29 @@ int main(int argc, char *argv[])
         case ARTIST_FLAG:
             artist = optarg;
             break;
+        case ARTIST_SORT_FLAG:
+            artistsort = optarg;
+            break;
         case WRITER_FLAG:
             composer = optarg;
+            break;
+        case WRITER_SORT_FLAG:
+            composersort = optarg;
             break;
         case TITLE_FLAG:
             title = optarg;
             break;
         case ALBUM_FLAG:
             album = optarg;
+            break;
+        case ALBUM_ARTIST_FLAG:
+            albumartist = optarg;
+            break;
+        case ALBUM_ARTIST_SORT_FLAG:
+            albumartistsort = optarg;
+            break;
+        case ALBUM_SORT_FLAG:
+            albumsort = optarg;
             break;
         case TRACK_FLAG:
             if (sscanf(optarg, "%d/%d", &trackno, &ntracks) < 1)
@@ -845,9 +878,13 @@ int main(int argc, char *argv[])
     }
 
     if (container != MP4_CONTAINER && (ntracks || trackno || artist ||
-                                       title || album || year || artData ||
+                                       artistsort || title ||
+                                       album || albumartist ||
+                                       albumartistsort ||
+                                       albumsort || year || artData ||
                                        genre || comment || discno || ndiscs ||
-                                       composer || compilation))
+                                       composer || composersort ||
+                                       compilation))
     {
         fprintf(stderr, "Metadata requires MP4 output!\n");
         return 1;
@@ -1181,9 +1218,14 @@ int main(int argc, char *argv[])
 
 #define SETTAG(x) if(x)mp4config.tag.x=x
         SETTAG(artist);
+        SETTAG(artistsort);
         SETTAG(composer);
+        SETTAG(composersort);
         SETTAG(title);
         SETTAG(album);
+        SETTAG(albumartist);
+        SETTAG(albumartistsort);
+        SETTAG(albumsort);
         SETTAG(trackno);
         SETTAG(ntracks);
         SETTAG(discno);

--- a/frontend/mp4write.c
+++ b/frontend/mp4write.c
@@ -626,8 +626,12 @@ static int ilstout(void)
     size += tagtxt("\xa9" "too", mp4config.tag.encoder);
     if (mp4config.tag.artist)
         size += tagtxt("\xa9" "ART", mp4config.tag.artist);
+    if (mp4config.tag.artistsort)
+        size += tagtxt("soar", mp4config.tag.artistsort);
     if (mp4config.tag.composer)
         size += tagtxt("\xa9" "wrt", mp4config.tag.composer);
+    if (mp4config.tag.composersort)
+        size += tagtxt("soco", mp4config.tag.composersort);
     if (mp4config.tag.title)
         size += tagtxt("\xa9" "nam", mp4config.tag.title);
     if (mp4config.tag.genre)
@@ -637,6 +641,12 @@ static int ilstout(void)
     }
     if (mp4config.tag.album)
         size += tagtxt("\xa9" "alb", mp4config.tag.album);
+    if (mp4config.tag.albumartist)
+        size += tagtxt("aART", mp4config.tag.albumartist);
+    if (mp4config.tag.albumartistsort)
+        size += tagtxt("soaa", mp4config.tag.albumartistsort);
+    if (mp4config.tag.albumsort)
+        size += tagtxt("soal", mp4config.tag.albumsort);
     if (mp4config.tag.compilation)
     {
         size += tagu8("cpil", 1);

--- a/frontend/mp4write.h
+++ b/frontend/mp4write.h
@@ -58,9 +58,14 @@ typedef struct
         // meta fields
         const char *encoder;
         const char *artist;
+        const char *artistsort;
         const char *composer;
+        const char *composersort;
         const char *title;
         const char *album;
+        const char *albumartist;
+        const char *albumartistsort;
+        const char *albumsort;
         uint8_t compilation;
         uint32_t trackno;
         uint32_t ntracks;


### PR DESCRIPTION
Hi, please consider this pull request which adds some additional MP4 tags.  The albumartist tags is need for iTunes/iPhone to keep albums together and the sort order tags are pretty much essential for classical music if files are tagged with the full artist/composer name whereas these would usually be ordered by surname.

I got the fourcc for these tags by filling in the fields concerned in iTunes then inspecting the resulting file with AtomicParsley.