### PR TITLE
set libfaac library name to "faac" rather than "libfaac"l

### DIFF
--- a/project/msvc/libfaac.vcxproj
+++ b/project/msvc/libfaac.vcxproj
@@ -74,6 +74,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>.\bin\$(Configuration)\</OutDir>
     <IntDir>.\intermediate\$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>faac</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>


### PR DESCRIPTION
So we can re-use unix `.pc` file unchanged with MSVC compiiler.
MSVC compiler does not automatically prepend `lib` to the library
name, as is the case for gcc.