### PR TITLE
Error C2065

### DIFF
--- a/libfaac/stereo.c
+++ b/libfaac/stereo.c
@@ -17,6 +17,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ****************************************************************************/
 
+#define _USE_MATH_DEFINES
+
 #include <math.h>
 #include "stereo.h"
 #include "huff2.h"


### PR DESCRIPTION
For the math method, the math constants aren't defined in Standard C/C++. 
To use them, you must first define `_USE_MATH_DEFINES`, and then include `<cmath>` or `<math.h>`.

https://github.com/knik0/faac/blob/9a8b43fd079b71c647738612b6875a3c767dbf8f/libfaac/stereo.c#L20

https://github.com/knik0/faac/blob/9a8b43fd079b71c647738612b6875a3c767dbf8f/libfaac/stereo.c#L263