### PR TITLE
optimize FFT reordering by combining real and imaginary passes

### DIFF
--- a/libfaac/fft.c
+++ b/libfaac/fft.c
@@ -216,11 +216,11 @@ void fft_terminate( FFT_Tables *fft_tables )
 	fft_tables->reordertbl	= NULL;
 }
 
-static void reorder( FFT_Tables *fft_tables, faac_real *x, int logm)
+static void reorder2( FFT_Tables *fft_tables, faac_real *xr, faac_real *xi, int logm)
 {
 	int i;
 	int size = 1 << logm;
-	unsigned short *r;	//size
+	const unsigned short *r;
 
 
 	if ( fft_tables->reordertbl[logm] == NULL ) // create bit reversing table
@@ -252,9 +252,13 @@ static void reorder( FFT_Tables *fft_tables, faac_real *x, int logm)
 		if (j <= i)
 			continue;
 
-		tmp = x[i];
-		x[i] = x[j];
-		x[j] = tmp;
+		tmp = xr[i];
+		xr[i] = xr[j];
+		xr[j] = tmp;
+
+		tmp = xi[i];
+		xi[i] = xi[j];
+		xi[j] = tmp;
 	}
 }
 
@@ -340,8 +344,7 @@ void fft( FFT_Tables *fft_tables, faac_real *xr, faac_real *xi, int logm)
 
 	check_tables( fft_tables, logm);
 
-	reorder( fft_tables, xr, logm);
-	reorder( fft_tables, xi, logm);
+	reorder2( fft_tables, xr, xi, logm);
 
 	fft_proc( xr, xi, fft_tables->costbl[logm], fft_tables->negsintbl[logm], 1 << logm );
 }


### PR DESCRIPTION
This PR refactors the bit-reversal reordering step in the FFT implementation. By replacing the dual-call `reorder()` pattern with a unified `reorder2()` function, we now process both the real (`xr`) and imaginary (`xi`) arrays within a single pass over the bit-reversal lookup table.

### Performance Gains
Benchmarked using average user time for 2-minute stereo baselines:
* **Double Precision:** 2.158s -> 1.984s (~8.05% improvement)
* **Single Precision:** 2.069s -> 1.965s (~5.03% improvement)

### Technical Justification & L1 Optimization
The primary driver for these gains—beyond simply halving the loop overhead—is improved **L1 Data Cache (L1d)** efficiency and **TLB (Translation Lookaside Buffer)** utilization.



1. **Bit-Reversal Table Locality:** In the original implementation, the `reordertbl` (the bit-reversal indices) had to be read from memory twice. In `reorder2`, the table is read once and stays "hot" in the L1 cache for both array swaps, effectively halving the cache bandwidth required for the lookup table.

2. **Temporal Locality:** By interleaving the swaps (`xr[i]/xr[j]` followed immediately by `xi[i]/xi[j]`), we capitalize on the fact that `xr` and `xi` are often allocated near each other or are already partially present in higher-level caches. 

3. **Reduced Control Flow Overhead:** The `if (j <= i) continue;` logic is a frequent branch in the reordering loop. By combining the work, we execute this branch logic half as many times per FFT call.
