### PR TITLE
add max-channels option to change MAX_CHANNELS from 64

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -60,6 +60,14 @@ jobs:
               options: -Dfloating-point=double,
               cflags: /W4
             }
+          - {
+              name: Linux GCC (2 Channels),
+              os: ubuntu-latest,
+              compiler: gcc,
+              shell: bash,
+              options: -Dmax-channels=2,
+              cflags: -Wall
+            }
 
     steps:
       - name: Install dependencies (Ubuntu)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -60,14 +60,6 @@ jobs:
               options: -Dfloating-point=double,
               cflags: /W4
             }
-          - {
-              name: Linux GCC (2 Channels),
-              os: ubuntu-latest,
-              compiler: gcc,
-              shell: bash,
-              options: -Dmax-channels=2,
-              cflags: -Wall
-            }
 
     steps:
       - name: Install dependencies (Ubuntu)

--- a/libfaac/coder.h
+++ b/libfaac/coder.h
@@ -28,8 +28,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#define MAX_CHANNELS 64
-
 #define FRAME_LEN 1024
 #define BLOCK_LEN_LONG 1024
 #define BLOCK_LEN_SHORT 128

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,8 @@ else
     config_h.set('FAAC_PRECISION_SINGLE', 1)
 endif
 
+config_h.set('MAX_CHANNELS', get_option('max-channels'))
+
 c_args = []
 if cc.get_argument_syntax() == 'msvc'
     c_args += ['-DWIN32', '-DNDEBUG', '-D_WINDOWS', '-D_USRDLL', '-DLIBFAAC_DLL_EXPORTS']

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,10 @@ option('floating-point',
     type: 'combo',
     choices: ['single', 'double'],
     value: 'double')
+
+option('max-channels',
+    description: 'Maximum number of channels',
+    type: 'integer',
+    min: 1,
+    max: 64,
+    value: 64)


### PR DESCRIPTION
This helps save RAM on embedded devices that don't support more than 1 or 2 channels anyway.