### PR TITLE
refactor channel elements, improve bitstream robustness, and add tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -107,6 +107,7 @@ jobs:
           mkdir -p build temp
           cd build
           meson setup .. -Dprefix=$(realpath ../temp) ${{ matrix.config.options }}
+          meson test
           meson install
 
       - name: Build (General)
@@ -116,6 +117,7 @@ jobs:
           CFLAGS: ${{ matrix.config.cflags }}
         run: |
           meson setup build -Dprefix="${{ github.workspace }}/temp" ${{ matrix.config.options }}
+          meson test -C build
           meson install -C build
 
       - name: Upload artifacts (Windows)

--- a/TODO
+++ b/TODO
@@ -6,3 +6,6 @@
 - Add resampler and downmixer (hans-juergen, Oct 17, 2004)
 - Add HE AAC (hans-juergen, Oct 17, 2004)
 - Test TNS(arcen, Apr 8th, 2012)
+- Test 3.0 and 5.1 channel numbers
+- add PCE (Program Config Element) for 7.1 channel surround sound
+

--- a/libfaac/bitstream.c
+++ b/libfaac/bitstream.c
@@ -39,9 +39,10 @@ static int CountBitstream(faacEncStruct* hEncoder,
                           ChannelInfo *channelInfo,
                           BitStream *bitStream,
                           int numChannels);
-static int WriteADTSHeader(faacEncStruct* hEncoder,
-                           BitStream *bitStream,
-                           int writeFlag);
+FAAC_INTERNAL
+int WriteADTSHeader(faacEncStruct* hEncoder,
+                    BitStream *bitStream,
+                    int writeFlag);
 static int WriteCPE(CoderInfo *coderInfoL,
                     CoderInfo *coderInfoR,
                     ChannelInfo *channelInfo,
@@ -155,9 +156,9 @@ int WriteBitstream(faacEncStruct* hEncoder,
         if (channelInfo[channel].present) {
 
             /* Write out a single_channel_element */
-            if (!channelInfo[channel].cpe) {
+            if (channelInfo[channel].type != ELEMENT_CPE) {
 
-                if (channelInfo[channel].lfe) {
+                if (channelInfo[channel].type == ELEMENT_LFE) {
                     /* Write out lfe */
                     bits += WriteLFE(&coderInfo[channel],
                         &channelInfo[channel],
@@ -242,9 +243,9 @@ static int CountBitstream(faacEncStruct* hEncoder,
         if (channelInfo[channel].present) {
 
             /* Write out a single_channel_element */
-            if (!channelInfo[channel].cpe) {
+            if (channelInfo[channel].type != ELEMENT_CPE) {
 
-                if (channelInfo[channel].lfe) {
+                if (channelInfo[channel].type == ELEMENT_LFE) {
                     /* Write out lfe */
                     bits += WriteLFE(&coderInfo[channel],
                         &channelInfo[channel],
@@ -311,9 +312,10 @@ static int CountBitstream(faacEncStruct* hEncoder,
     return bits;
 }
 
-static int WriteADTSHeader(faacEncStruct* hEncoder,
-                           BitStream *bitStream,
-                           int writeFlag)
+FAAC_INTERNAL
+int WriteADTSHeader(faacEncStruct* hEncoder,
+                    BitStream *bitStream,
+                    int writeFlag)
 {
     int bits = 56;
 
@@ -800,14 +802,30 @@ static long BufferNumBit(BitStream *bitStream)
     return bitStream->numBit;
 }
 
+static const uint32_t bitmask[] = {
+    0x00000000, 0x00000001, 0x00000003, 0x00000007,
+    0x0000000f, 0x0000001f, 0x0000003f, 0x0000007f,
+    0x000000ff, 0x000001ff, 0x000003ff, 0x000007ff,
+    0x00000fff, 0x00001fff, 0x00003fff, 0x00007fff,
+    0x0000ffff, 0x0001ffff, 0x0003ffff, 0x0007ffff,
+    0x000fffff, 0x001fffff, 0x003fffff, 0x007fffff,
+    0x00ffffff, 0x01ffffff, 0x03ffffff, 0x07ffffff,
+    0x0fffffff, 0x1fffffff, 0x3fffffff, 0x7fffffff,
+    0xffffffff
+};
+
 int PutBit(BitStream *bitStream,
-           unsigned long data,
+           uint32_t data,
            int numBit)
 {
     /* write bits in packets according to buffer byte boundaries */
 
-    if (numBit == 0)
+    if (numBit <= 0)
         return 0;
+
+    /* Range guard: Prevent out-of-bounds access on bitmask table */
+    if (numBit > 32)
+        numBit = 32;
 
     /* Hoist bitstream state for faster access */
     unsigned int currentBit = (unsigned int)bitStream->currentBit;
@@ -819,7 +837,7 @@ int PutBit(BitStream *bitStream,
     bitStream->numBit = bitStream->currentBit;
 
     /* Mask input data to ensure no extra bits are set */
-    data &= (1UL << numBit) - 1;
+    data &= bitmask[numBit];
 
     /* Fast path: bit write fits within the current byte */
     if (bitOffset + numBit <= 8) {

--- a/libfaac/bitstream.h
+++ b/libfaac/bitstream.h
@@ -35,6 +35,8 @@ Copyright (c) 1996.
 #ifndef BITSTREAM_H
 #define BITSTREAM_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -86,7 +88,7 @@ extern "C" {
 #define ID_END 7
 
 #define BYTE_NUMBIT 8       /* bits in byte (char) */
-#define LONG_NUMBIT 32      /* bits in unsigned long */
+#define LONG_NUMBIT 32      /* bits in uint32_t */
 #define bit2byte(a) (((a)+BYTE_NUMBIT-1)/BYTE_NUMBIT)
 
 enum {ADTS_FRAMESIZE = 1 << 13};
@@ -114,8 +116,13 @@ BitStream *OpenBitStream(int size, unsigned char *buffer);
 int CloseBitStream(BitStream *bitStream);
 
 int PutBit(BitStream *bitStream,
-           unsigned long data,
+           uint32_t data,
            int numBit);
+
+FAAC_INTERNAL
+int WriteADTSHeader(faacEncStruct* hEncoder,
+                    BitStream *bitStream,
+                    int writeFlag);
 
 #ifdef __cplusplus
 }

--- a/libfaac/blockswitch.c
+++ b/libfaac/blockswitch.c
@@ -30,23 +30,6 @@
 #include "filtbank.h"
 #include <faac.h>
 
-typedef float psyfloat;
-
-typedef struct
-{
-  /* bandwidth */
-  int bandS;
-  int lastband;
-
-  /* band volumes */
-  psyfloat *engPrev[8];
-  psyfloat *eng[8];
-  psyfloat *engNext[8];
-  psyfloat *engNext2[8];
-}
-psydata_t;
-
-
 static void Hann(GlobalPsyInfo * gpsyInfo, faac_real *inSamples, int size)
 {
   int i;
@@ -72,7 +55,8 @@ static struct {
 } frames;
 #endif
 
-static void PsyCheckShort(PsyInfo * psyInfo, faac_real quality)
+FAAC_INTERNAL
+void PsyCheckShort(PsyInfo * psyInfo, faac_real quality)
 {
   enum {PREVS = 2, NEXTS = 2};
   psydata_t *psydata = psyInfo->data;
@@ -246,7 +230,7 @@ static void PsyCalculate(ChannelInfo * channelInfo, GlobalPsyInfo * gpsyInfo,
     if (channelInfo[channel].present)
     {
 
-      if (channelInfo[channel].cpe &&
+      if (channelInfo[channel].type == ELEMENT_CPE &&
 	  channelInfo[channel].ch_is_left)
       {				/* CPE */
 
@@ -256,13 +240,12 @@ static void PsyCalculate(ChannelInfo * channelInfo, GlobalPsyInfo * gpsyInfo,
 	PsyCheckShort(&psyInfo[leftChan], quality);
 	PsyCheckShort(&psyInfo[rightChan], quality);
       }
-      else if (!channelInfo[channel].cpe &&
-	       channelInfo[channel].lfe)
+      else if (channelInfo[channel].type == ELEMENT_LFE)
       {				/* LFE */
         // Only set block type and it should be OK
 	psyInfo[channel].block_type = ONLY_LONG_WINDOW;
       }
-      else if (!channelInfo[channel].cpe)
+      else if (channelInfo[channel].type == ELEMENT_SCE)
       {				/* SCE */
 	PsyCheckShort(&psyInfo[channel], quality);
       }

--- a/libfaac/blockswitch.h
+++ b/libfaac/blockswitch.h
@@ -36,6 +36,22 @@ extern "C" {
 #include "channels.h"
 #include "fft.h"
 
+typedef float psyfloat;
+
+typedef struct
+{
+  /* bandwidth */
+  int bandS;
+  int lastband;
+
+  /* band volumes */
+  psyfloat *engPrev[8];
+  psyfloat *eng[8];
+  psyfloat *engNext[8];
+  psyfloat *engNext2[8];
+}
+psydata_t;
+
 typedef struct {
 	int size;
 	int sizeS;
@@ -84,6 +100,9 @@ void (*BlockSwitch) (CoderInfo *coderInfo, PsyInfo *psyInfo,
 } psymodel_t;
 
 extern psymodel_t psymodel2;
+
+FAAC_INTERNAL
+void PsyCheckShort(PsyInfo * psyInfo, faac_real quality);
 
 #ifdef __cplusplus
 }

--- a/libfaac/channels.c
+++ b/libfaac/channels.c
@@ -53,6 +53,7 @@ Copyright(c)1996.
 /*      2*N                2                2*(N-1)         0           */
 /*      2*N+1              1                2*N             0           */
 
+FAAC_INTERNAL
 void GetChannelInfo(ChannelInfo *channelInfo, int numChannels, int useLfe)
 {
     int sceTag = 0;
@@ -65,8 +66,7 @@ void GetChannelInfo(ChannelInfo *channelInfo, int numChannels, int useLfe)
     if (numChannelsLeft != 2) {
         channelInfo[numChannels-numChannelsLeft].present = 1;
         channelInfo[numChannels-numChannelsLeft].tag = sceTag++;
-        channelInfo[numChannels-numChannelsLeft].cpe = 0;
-        channelInfo[numChannels-numChannelsLeft].lfe = 0;
+        channelInfo[numChannels-numChannelsLeft].type = ELEMENT_SCE;
         numChannelsLeft--;
     }
 
@@ -75,20 +75,18 @@ void GetChannelInfo(ChannelInfo *channelInfo, int numChannels, int useLfe)
         /* Left channel info */
         channelInfo[numChannels-numChannelsLeft].present = 1;
         channelInfo[numChannels-numChannelsLeft].tag = cpeTag++;
-        channelInfo[numChannels-numChannelsLeft].cpe = 1;
         channelInfo[numChannels-numChannelsLeft].common_window = 0;
         channelInfo[numChannels-numChannelsLeft].ch_is_left = 1;
         channelInfo[numChannels-numChannelsLeft].paired_ch = numChannels-numChannelsLeft+1;
-        channelInfo[numChannels-numChannelsLeft].lfe = 0;
+        channelInfo[numChannels-numChannelsLeft].type = ELEMENT_CPE;
         numChannelsLeft--;
 
         /* Right channel info */
         channelInfo[numChannels-numChannelsLeft].present = 1;
-        channelInfo[numChannels-numChannelsLeft].cpe = 1;
         channelInfo[numChannels-numChannelsLeft].common_window = 0;
         channelInfo[numChannels-numChannelsLeft].ch_is_left = 0;
         channelInfo[numChannels-numChannelsLeft].paired_ch = numChannels-numChannelsLeft-1;
-        channelInfo[numChannels-numChannelsLeft].lfe = 0;
+        channelInfo[numChannels-numChannelsLeft].type = ELEMENT_CPE;
         numChannelsLeft--;
     }
 
@@ -97,13 +95,11 @@ void GetChannelInfo(ChannelInfo *channelInfo, int numChannels, int useLfe)
         if (useLfe) {
             channelInfo[numChannels-numChannelsLeft].present = 1;
             channelInfo[numChannels-numChannelsLeft].tag = lfeTag++;
-            channelInfo[numChannels-numChannelsLeft].cpe = 0;
-            channelInfo[numChannels-numChannelsLeft].lfe = 1;
+            channelInfo[numChannels-numChannelsLeft].type = ELEMENT_LFE;
         } else {
             channelInfo[numChannels-numChannelsLeft].present = 1;
             channelInfo[numChannels-numChannelsLeft].tag = sceTag++;
-            channelInfo[numChannels-numChannelsLeft].cpe = 0;
-            channelInfo[numChannels-numChannelsLeft].lfe = 0;
+            channelInfo[numChannels-numChannelsLeft].type = ELEMENT_SCE;
         }
         numChannelsLeft--;
     }

--- a/libfaac/channels.h
+++ b/libfaac/channels.h
@@ -33,18 +33,23 @@ typedef struct {
     int ms_used[MAX_SCFAC_BANDS];
 } MSInfo;
 
+typedef enum {
+    ELEMENT_SCE,
+    ELEMENT_CPE,
+    ELEMENT_LFE
+} ElementType;
+
 typedef struct {
     int tag;
     int present;
     int ch_is_left;
     int paired_ch;
     int common_window;
-    int cpe;
-    int sce;
-    int lfe;
+    ElementType type;
     MSInfo msInfo;
 } ChannelInfo;
 
+FAAC_INTERNAL
 void GetChannelInfo(ChannelInfo *channelInfo, int numChannels, int useLfe);
 
 #ifdef __cplusplus

--- a/libfaac/filtbank.c
+++ b/libfaac/filtbank.c
@@ -45,10 +45,6 @@ Copyright(c)1996.
 #define  TWOPI       2*M_PI
 
 
-static void		CalculateKBDWindow	( faac_real* win, faac_real alpha, int length );
-static faac_real	Izero				( faac_real x);
-
-
 void FilterBankInit(faacEncStruct* hEncoder)
 {
     unsigned int i, channel;
@@ -230,7 +226,8 @@ static faac_real Izero(faac_real x)
     return(sum);
 }
 
-static void CalculateKBDWindow(faac_real* win, faac_real alpha, int length)
+FAAC_INTERNAL
+void CalculateKBDWindow(faac_real* win, faac_real alpha, int length)
 {
     int i;
     faac_real IBeta;

--- a/libfaac/filtbank.h
+++ b/libfaac/filtbank.h
@@ -50,6 +50,9 @@ void			FilterBank( faacEncStruct* hEncoder,
 						faac_real *p_overlap,
 						int overlap_select );
 
+FAAC_INTERNAL
+void			CalculateKBDWindow	( faac_real* win, faac_real alpha, int length );
+
 
 #ifdef __cplusplus
 }

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -461,7 +461,7 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
 		/* Psychoacoustics */
 		/* Update buffers and run FFT on new samples */
 		/* LFE psychoacoustic can run without it */
-		if (!channelInfo[channel].lfe || channelInfo[channel].cpe)
+		if (channelInfo[channel].type != ELEMENT_LFE)
 		{
 			hEncoder->psymodel->PsyBufferUpdate(
 					&hEncoder->fft_tables,
@@ -541,7 +541,7 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
 
     /* Perform TNS analysis and filtering */
     for (channel = 0; channel < numChannels; channel++) {
-        if ((!channelInfo[channel].lfe) && (useTns)) {
+        if ((channelInfo[channel].type != ELEMENT_LFE) && (useTns)) {
             TnsEncode(&(coderInfo[channel].tnsInfo),
                       coderInfo[channel].sfbn,
                       coderInfo[channel].sfbn,
@@ -555,7 +555,7 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
 
     for (channel = 0; channel < numChannels; channel++) {
       // reduce LFE bandwidth
-		if (!channelInfo[channel].cpe && channelInfo[channel].lfe)
+		if (channelInfo[channel].type == ELEMENT_LFE)
 		{
                     coderInfo[channel].sfbn = 3;
 		}
@@ -573,7 +573,7 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
     for (channel = 0; channel < numChannels; channel++)
     {
 		if (channelInfo[channel].present
-				&& (channelInfo[channel].cpe)
+				&& (channelInfo[channel].type == ELEMENT_CPE)
 				&& (channelInfo[channel].ch_is_left))
 		{
 			CoderInfo *cil, *cir;

--- a/libfaac/huff2.c
+++ b/libfaac/huff2.c
@@ -56,10 +56,11 @@ static int escape(int x, int *code)
 
 #define arrlen(array) (sizeof(array) / sizeof(*array))
 
-static int huffcode(int *qs /* quantized spectrum */,
-                    int len,
-                    int bnum,
-                    CoderInfo *coder)
+FAAC_INTERNAL
+int huffcode(int *qs /* quantized spectrum */,
+             int len,
+             int bnum,
+             CoderInfo *coder)
 {
     static hcode16_t * const hmap[12] = {0, book01, book02, book03, book04,
       book05, book06, book07, book08, book09, book10, book11};

--- a/libfaac/huff2.h
+++ b/libfaac/huff2.h
@@ -17,6 +17,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ****************************************************************************/
 
+#ifndef HUFF2_H
+#define HUFF2_H
+
 #include "bitstream.h"
 
 enum {
@@ -31,5 +34,9 @@ enum {
 int huffbook(CoderInfo *coderInfo,
              int *qs /* quantized spectrum */,
              int len);
+FAAC_INTERNAL
+int huffcode(int *qs, int len, int bnum, CoderInfo *coder);
 int writebooks(CoderInfo *coder, BitStream *stream, int writeFlag);
 int writesf(CoderInfo *coder, BitStream *bitStream, int writeFlag);
+
+#endif /* HUFF2_H */

--- a/libfaac/meson.build
+++ b/libfaac/meson.build
@@ -4,6 +4,12 @@ if host_machine.system() == 'windows' and meson.get_compiler('c').get_id() == 'g
     link_args += '-Wl,--add-stdcall-alias'
 endif
 
+if cc.get_id() == 'msvc'
+  # MSVC doesn't have a direct 'hidden' attribute equivalent in C
+  prod_visibility = '-DFAAC_INTERNAL=' 
+else
+  prod_visibility = '-DFAAC_INTERNAL=__attribute__((visibility("hidden")))'
+endif
 
 quantize_simd_libs = []
 
@@ -11,8 +17,9 @@ if config_h.get('HAVE_SSE2')
     sse2_flag = (cc.get_argument_syntax() == 'msvc') ? ['/arch:SSE2'] : ['-msse2']
     quantize_sse = static_library('quantize_sse', 'quantize_sse.c',
         include_directories: ['..', '../include'],
-        c_args: c_args + sse2_flag,
-        gnu_symbol_visibility: 'hidden'
+        c_args: c_args + sse2_flag + [prod_visibility],
+        gnu_symbol_visibility: 'hidden',
+        pic: true
     )
     quantize_simd_libs += quantize_sse
 endif
@@ -47,9 +54,9 @@ common_src = [
     'util.h',
 ]
 
-libfaac = library('faac', common_src,
+libfaac = shared_library('faac', common_src,
     include_directories: ['..', '../include'],
-    c_args: c_args,
+    c_args: c_args + [prod_visibility],
     link_args: link_args,
     dependencies: [ libm ],
     link_with: quantize_simd_libs,
@@ -59,6 +66,22 @@ libfaac = library('faac', common_src,
     gnu_symbol_visibility: 'hidden'
 )
 
+if get_option('tests')
+    faac_static = static_library('faac_static',
+        common_src,
+        include_directories: ['..', '../include'],
+        c_args: c_args + ['-DFAAC_INTERNAL=extern'],
+        dependencies: [ libm ],
+        link_with: quantize_simd_libs,
+        pic: true
+    )
+
+    faac_internal = declare_dependency(
+        link_with: faac_static,
+        compile_args: ['-DFAAC_INTERNAL=extern'],
+        include_directories: include_directories('.')
+    )
+endif
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(

--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -34,11 +34,8 @@
 
 typedef void (*QuantizeFunc)(const faac_real * __restrict xr, int * __restrict xi, int n, faac_real sfacfix);
 
-#if defined(HAVE_SSE2)
-extern void quantize_sse2(const faac_real * __restrict xr, int * __restrict xi, int n, faac_real sfacfix);
-#endif
-
-static void quantize_scalar(const faac_real * __restrict xr, int * __restrict xi, int n, faac_real sfacfix)
+FAAC_INTERNAL
+void quantize_scalar(const faac_real * __restrict xr, int * __restrict xi, int n, faac_real sfacfix)
 {
     const faac_real magic = MAGIC_NUMBER;
     int cnt;
@@ -70,8 +67,9 @@ void QuantizeInit(void)
 #define NOISEFLOOR 0.4
 
 // band sound masking
-static void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, faac_real * __restrict bandqual,
-                  faac_real * __restrict bandenrg, int gnum, faac_real quality)
+FAAC_INTERNAL
+void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, faac_real * __restrict bandqual,
+           faac_real * __restrict bandenrg, int gnum, faac_real quality)
 {
   int sfb, start, end, cnt;
   int *cb_offset = coderInfo->sfb_offset;
@@ -162,13 +160,14 @@ static void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, 
 
 enum {MAXSHORTBAND = 36};
 // use band quality levels to quantize a group of windows
-static void qlevel(CoderInfo * __restrict coderInfo,
-                   const faac_real * __restrict xr0,
-                   const faac_real * __restrict bandqual,
-                   const faac_real * __restrict bandenrg,
-                   int gnum,
-                   int pnslevel
-                  )
+FAAC_INTERNAL
+void qlevel(CoderInfo * __restrict coderInfo,
+            const faac_real * __restrict xr0,
+            const faac_real * __restrict bandqual,
+            const faac_real * __restrict bandenrg,
+            int gnum,
+            int pnslevel
+            )
 {
     int sb;
 #if !defined(__clang__) && defined(__GNUC__) && (GCC_VERSION >= 40600)

--- a/libfaac/quantize.h
+++ b/libfaac/quantize.h
@@ -53,4 +53,18 @@ void BlocGroup(faac_real *xr, CoderInfo *coderInfo, AACQuantCfg *aacquantCfg);
 void BlocStat(void);
 void QuantizeInit(void);
 
+#if defined(HAVE_SSE2)
+FAAC_INTERNAL
+void quantize_sse2(const faac_real * xr, int * xi, int n, faac_real sfacfix);
 #endif
+FAAC_INTERNAL
+void quantize_scalar(const faac_real * xr, int * xi, int n, faac_real sfacfix);
+FAAC_INTERNAL
+void bmask(CoderInfo * coderInfo, faac_real * xr0, faac_real * bandqual,
+           faac_real * bandenrg, int gnum, faac_real quality);
+FAAC_INTERNAL
+void qlevel(CoderInfo * coderInfo, const faac_real * xr0,
+            const faac_real * bandqual, const faac_real * bandenrg,
+            int gnum, int pnslevel);
+
+#endif /* QUANTIZE_H */

--- a/libfaac/quantize_sse.c
+++ b/libfaac/quantize_sse.c
@@ -25,6 +25,7 @@
 #include "faac_real.h"
 #include "quantize.h"
 
+FAAC_INTERNAL
 void quantize_sse2(const faac_real * __restrict xr, int * __restrict xi, int n, faac_real sfacfix)
 {
     const __m128 zero = _mm_setzero_ps();

--- a/libfaac/stereo.c
+++ b/libfaac/stereo.c
@@ -327,7 +327,7 @@ void AACstereo(CoderInfo *coder,
 
         if (!channel[chn].present)
             continue;
-        if (!((channel[chn].cpe) && (channel[chn].ch_is_left)))
+        if (!((channel[chn].type == ELEMENT_CPE) && (channel[chn].ch_is_left)))
             continue;
 
         rch = channel[chn].paired_ch;

--- a/libfaac/tns.c
+++ b/libfaac/tns.c
@@ -57,24 +57,6 @@ static unsigned short tnsMaxOrderLongLow = 12;
 static unsigned short tnsMaxOrderShortMainLow = 7;
 
 
-/*************************/
-/* Function prototypes   */
-/*************************/
-static void Autocorrelation(int maxOrder,        /* Maximum autocorr order */
-                     int dataSize,        /* Size of the data array */
-                     faac_real* data,        /* Data array */
-                     faac_real* rArray);     /* Autocorrelation array */
-
-static faac_real LevinsonDurbin(int maxOrder,        /* Maximum filter order */
-                      int dataSize,        /* Size of the data array */
-                      faac_real* data,        /* Data array */
-                      faac_real* kArray);     /* Reflection coeff array */
-
-static void StepUp(int fOrder, faac_real* kArray, faac_real* aArray);
-
-static void QuantizeReflectionCoeffs(int fOrder,int coeffRes,faac_real* rArray,int* indexArray);
-static int TruncateCoeffs(int fOrder,faac_real threshold,faac_real* kArray);
-static void TnsInvFilter(int length,faac_real* spec,TnsFilterData* filter, faac_real *temp);
 
 
 /*****************************************************/
@@ -282,7 +264,8 @@ void TnsEncodeFilterOnly(TnsInfo* tnsInfo,           /* TNS info */
 /*   Not that the order and direction are specified     */
 /*   withing the TNS_FILTER_DATA structure.             */
 /********************************************************/
-static void TnsInvFilter(int length,faac_real* spec,TnsFilterData* filter, faac_real *temp)
+FAAC_INTERNAL
+void TnsInvFilter(int length,faac_real* spec,TnsFilterData* filter, faac_real *temp)
 {
     int i,j,k=0;
     int order=filter->order;
@@ -342,7 +325,8 @@ static void TnsInvFilter(int length,faac_real* spec,TnsFilterData* filter, faac_
 /*   less than the specified threshold.  Return the  */
 /*   truncated filter order.                         */
 /*****************************************************/
-static int TruncateCoeffs(int fOrder,faac_real threshold,faac_real* kArray)
+FAAC_INTERNAL
+int TruncateCoeffs(int fOrder,faac_real threshold,faac_real* kArray)
 {
     int i;
 
@@ -359,7 +343,8 @@ static int TruncateCoeffs(int fOrder,faac_real threshold,faac_real* kArray)
 /*   Quantize the given array of reflection coeffs   */
 /*   to the specified resolution in bits.            */
 /*****************************************************/
-static void QuantizeReflectionCoeffs(int fOrder,
+FAAC_INTERNAL
+void QuantizeReflectionCoeffs(int fOrder,
                               int coeffRes,
                               faac_real* kArray,
                               int* indexArray)
@@ -382,7 +367,8 @@ static void QuantizeReflectionCoeffs(int fOrder,
 /*   Compute the autocorrelation function            */
 /*   estimate for the given data.                    */
 /*****************************************************/
-static void Autocorrelation(int maxOrder,        /* Maximum autocorr order */
+FAAC_INTERNAL
+void Autocorrelation(int maxOrder,        /* Maximum autocorr order */
                      int dataSize,        /* Size of the data array */
                      faac_real* data,        /* Data array */
                      faac_real* rArray)      /* Autocorrelation array */
@@ -406,7 +392,8 @@ static void Autocorrelation(int maxOrder,        /* Maximum autocorr order */
 /*   given data using LevinsonDurbin recursion.      */
 /*   Return the prediction gain.                     */
 /*****************************************************/
-static faac_real LevinsonDurbin(int fOrder,          /* Filter order */
+FAAC_INTERNAL
+faac_real LevinsonDurbin(int fOrder,          /* Filter order */
                       int dataSize,        /* Size of the data array */
                       faac_real* data,        /* Data array */
                       faac_real* kArray)      /* Reflection coeff array */
@@ -458,6 +445,8 @@ static faac_real LevinsonDurbin(int fOrder,          /* Filter order */
                 aPtr[i] = aLastPtr[i] + kTemp*aLastPtr[order-i];
             }
             error = error * (1 - kTemp*kTemp);
+            /* Prevent numerical instability or division-by-zero with highly correlated signals */
+            if (error < 1e-10) error = 1e-10;
 
             /* Now make current iteration the last one */
             aTemp=aLastPtr;
@@ -474,7 +463,8 @@ static faac_real LevinsonDurbin(int fOrder,          /* Filter order */
 /*   Convert reflection coefficients into            */
 /*   predictor coefficients.                         */
 /*****************************************************/
-static void StepUp(int fOrder,faac_real* kArray,faac_real* aArray)
+FAAC_INTERNAL
+void StepUp(int fOrder,faac_real* kArray,faac_real* aArray)
 {
     faac_real aTemp[TNS_MAX_ORDER+2];
     int i,order;

--- a/libfaac/tns.h
+++ b/libfaac/tns.h
@@ -31,6 +31,7 @@ Copyright (c) 1997.
 #define TNS_H
 
 #include "faac_real.h"
+#include "frame.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +43,19 @@ void TnsEncode(TnsInfo* tnsInfo, int numberOfBands,int maxSfb,enum WINDOW_TYPE b
                int* sfbOffsetTable,faac_real* spec, faac_real* temp);
 void TnsEncodeFilterOnly(TnsInfo* tnsInfo, int numberOfBands, int maxSfb,
                          enum WINDOW_TYPE blockType, int *sfbOffsetTable, faac_real *spec, faac_real *temp);
+
+FAAC_INTERNAL
+void Autocorrelation(int maxOrder, int dataSize, faac_real* data, faac_real* rArray);
+FAAC_INTERNAL
+faac_real LevinsonDurbin(int maxOrder, int dataSize, faac_real* data, faac_real* kArray);
+FAAC_INTERNAL
+void StepUp(int fOrder, faac_real* kArray, faac_real* aArray);
+FAAC_INTERNAL
+void QuantizeReflectionCoeffs(int fOrder, int coeffRes, faac_real* rArray, int* indexArray);
+FAAC_INTERNAL
+int TruncateCoeffs(int fOrder, faac_real threshold, faac_real* kArray);
+FAAC_INTERNAL
+void TnsInvFilter(int length, faac_real* spec, TnsFilterData* filter, faac_real *temp);
 
 #ifdef __cplusplus
 }

--- a/libfaac/util.c
+++ b/libfaac/util.c
@@ -77,5 +77,7 @@ unsigned int BitAllocation(faac_real pe, int short_block)
 /* Returns the maximum bit reservoir size */
 unsigned int MaxBitresSize(unsigned long bitRate, unsigned long sampleRate)
 {
-    return 6144 - (unsigned int)((faac_real)bitRate/(faac_real)sampleRate*(faac_real)FRAME_LEN);
+    unsigned int bitsPerFrame = (unsigned int)((faac_real)bitRate / (faac_real)sampleRate * (faac_real)FRAME_LEN);
+    /* Prevent unsigned underflow; return a safe minimum of 1 bit for rate control stability */
+    return (bitsPerFrame >= 6143) ? 1 : 6144 - bitsPerFrame;
 }

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,9 @@ project('faac', 'c',
         'default_library=both',
         'buildtype=debugoptimized',
         'warning_level=1',
-        'c_std=gnu99,c99'
+        'c_std=gnu99,c99',
+        'b_lto=true',
+        'b_pie=true'
     ])
 
 add_global_arguments('-DHAVE_CONFIG_H', language: 'c')
@@ -50,6 +52,10 @@ configure_file(
 subdir('docs')
 subdir('include')
 subdir('libfaac')
+
+if get_option('tests')
+    subdir('tests')
+endif
 
 if get_option('frontend')
     subdir('frontend')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,3 +15,8 @@ option('max-channels',
     min: 1,
     max: 64,
     value: 64)
+
+option('tests',
+    description: 'Build unit tests',
+    type: 'boolean',
+    value: true)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,35 @@
+test_inc = include_directories(
+    '../include',
+    '../libfaac',
+    '..'
+)
+
+# Internal component tests link against 'faac_internal' to verify functions
+# that are normally static in production but promoted for testing/LTO.
+internal_tests = [
+    'util',
+    'bitstream',
+    'fft',
+    'channels',
+    'tns',
+    'mdct',
+    'huffman',
+    'blockswitch',
+    'quantize'
+]
+
+foreach t : internal_tests
+    exe = executable('test_' + t, 'test_' + t + '.c',
+        include_directories: test_inc,
+        dependencies: [ libm, faac_internal ]
+    )
+    test(t, exe)
+endforeach
+
+# Public API test links against the official shared library
+test_api = executable('test_api', 'test_api.c',
+    include_directories: test_inc,
+    dependencies: [ libm ],
+    link_with: [ libfaac ]
+)
+test('api', test_api)

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -1,0 +1,186 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <faac.h>
+#include <assert.h>
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+void test_api_config(unsigned long samplerate, unsigned int channels, int tns, int pns, int joint) {
+    faacEncHandle h;
+    unsigned long inputSamples, maxOutputBytes;
+    faacEncConfigurationPtr config;
+
+    printf("Testing API config: %lu Hz, %u ch, TNS:%d, PNS:%d, Joint:%d\n", samplerate, channels, tns, pns, joint);
+    h = faacEncOpen(samplerate, channels, &inputSamples, &maxOutputBytes);
+    assert(h != NULL);
+
+    config = faacEncGetCurrentConfiguration(h);
+    assert(config != NULL);
+
+    /* Test configuration matrix for varied encoder parameters */
+    config->bitRate = 128000 / channels;
+    config->inputFormat = FAAC_INPUT_FLOAT;
+    config->outputFormat = 1; /* ADTS */
+    config->useTns = tns;
+    config->pnslevel = pns;
+    config->jointmode = joint;
+
+    int ret = faacEncSetConfiguration(h, config);
+    assert(ret == 1);
+
+    faacEncClose(h);
+}
+
+void test_encode_max_signal(unsigned long samplerate, unsigned int channels) {
+    faacEncHandle h;
+    unsigned long inputSamples, maxOutputBytes;
+    faacEncConfigurationPtr config;
+
+    printf("Testing encode max signal: %lu Hz, %u ch\n", samplerate, channels);
+    h = faacEncOpen(samplerate, channels, &inputSamples, &maxOutputBytes);
+    assert(h != NULL);
+
+    config = faacEncGetCurrentConfiguration(h);
+    config->bitRate = 128000 / channels;
+    config->inputFormat = FAAC_INPUT_FLOAT;
+    faacEncSetConfiguration(h, config);
+
+    float *input_f = malloc(inputSamples * sizeof(float));
+    int32_t *input_i = (int32_t *)input_f;
+    unsigned char *output = malloc(maxOutputBytes);
+
+    /* 0 dBFS sine sweep (full dynamic range) */
+    for (unsigned long i = 0; i < inputSamples; i++) {
+        input_f[i] = (float)sin(2.0 * M_PI * 1000.0 * i / samplerate);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        int bytes = faacEncEncode(h, input_i, inputSamples, output, maxOutputBytes);
+        assert(bytes >= 0);
+    }
+
+    /* Verify DC stability at full scale */
+    for (unsigned long i = 0; i < inputSamples; i++) {
+        input_f[i] = 1.0f;
+    }
+
+    for (int i = 0; i < 5; i++) {
+        int bytes = faacEncEncode(h, input_i, inputSamples, output, maxOutputBytes);
+        assert(bytes >= 0);
+    }
+
+    free(input_f);
+    free(output);
+    faacEncClose(h);
+}
+
+void test_encode_silence(unsigned long samplerate, unsigned int channels) {
+    faacEncHandle h;
+    unsigned long inputSamples, maxOutputBytes;
+    faacEncConfigurationPtr config;
+
+    printf("Testing encode silence: %lu Hz, %u ch\n", samplerate, channels);
+    h = faacEncOpen(samplerate, channels, &inputSamples, &maxOutputBytes);
+    assert(h != NULL);
+
+    config = faacEncGetCurrentConfiguration(h);
+    config->bitRate = 64000;
+    config->inputFormat = FAAC_INPUT_FLOAT;
+    faacEncSetConfiguration(h, config);
+
+    float *input_f = calloc(inputSamples, sizeof(float));
+    int32_t *input_i = (int32_t *)input_f;
+    unsigned char *output = malloc(maxOutputBytes);
+
+    for (int i = 0; i < 10; i++) {
+        int bytes = faacEncEncode(h, input_i, inputSamples, output, maxOutputBytes);
+        assert(bytes >= 0);
+    }
+
+    /* Verify encoder flush behavior */
+    int bytes;
+    do {
+        bytes = faacEncEncode(h, NULL, 0, output, maxOutputBytes);
+        assert(bytes >= 0);
+    } while (bytes > 0);
+
+    free(input_f);
+    free(output);
+    faacEncClose(h);
+}
+
+void test_encode_noise(unsigned long samplerate, unsigned int channels) {
+    faacEncHandle h;
+    unsigned long inputSamples, maxOutputBytes;
+    faacEncConfigurationPtr config;
+
+    printf("Testing encode noise: %lu Hz, %u ch\n", samplerate, channels);
+    h = faacEncOpen(samplerate, channels, &inputSamples, &maxOutputBytes);
+    assert(h != NULL);
+
+    config = faacEncGetCurrentConfiguration(h);
+    config->bitRate = 128000 / channels;
+    config->inputFormat = FAAC_INPUT_FLOAT;
+    faacEncSetConfiguration(h, config);
+
+    float *input_f = malloc(inputSamples * sizeof(float));
+    int32_t *input_i = (int32_t *)input_f;
+    unsigned char *output = malloc(maxOutputBytes);
+
+    /* Perceptual model stress test with random signals */
+    for (unsigned long i = 0; i < inputSamples; i++) {
+        input_f[i] = (float)((rand() % 20000) - 10000) / 10000.0f;
+    }
+
+    for (int i = 0; i < 5; i++) {
+        int bytes = faacEncEncode(h, input_i, inputSamples, output, maxOutputBytes);
+        assert(bytes >= 0);
+    }
+
+    free(input_f);
+    free(output);
+    faacEncClose(h);
+}
+
+int main() {
+    unsigned long rates[] = {8000, 16000, 44100, 48000};
+    unsigned int channels[] = {1, 2, 6};
+
+    for (int r = 0; r < 4; r++) {
+        for (int c = 0; c < 3; c++) {
+            test_api_config(rates[r], channels[c], 1, 4, 1);
+            test_api_config(rates[r], channels[c], 0, 0, 0);
+            test_api_config(rates[r], channels[c], 1, 10, 2);
+
+            test_encode_silence(rates[r], channels[c]);
+            test_encode_noise(rates[r], channels[c]);
+            test_encode_max_signal(rates[r], channels[c]);
+        }
+    }
+
+    printf("All API tests passed!\n");
+    return 0;
+}

--- a/tests/test_bitstream.c
+++ b/tests/test_bitstream.c
@@ -1,0 +1,113 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include "coder.h"
+#include "bitstream.h"
+
+void test_PutBit_Standard() {
+    unsigned char buffer[100];
+    memset(buffer, 0, 100);
+    BitStream *bs = OpenBitStream(100, buffer);
+    assert(bs != NULL);
+
+    /* Verify 8-bit packing */
+    PutBit(bs, 0xAA, 8);
+    assert(buffer[0] == 0xAA);
+
+    /* Verify partial byte packing (aligned start) */
+    PutBit(bs, 0x5, 4);
+    assert(buffer[1] == 0x50);
+
+    /* Verify multi-byte boundary crossing */
+    PutBit(bs, 0x1F, 5);
+    assert(buffer[1] == 0x5F);
+    assert(buffer[2] == 0x80);
+
+    CloseBitStream(bs);
+}
+
+void test_PutBit_Robustness() {
+    unsigned char buffer[100];
+    memset(buffer, 0, 100);
+    BitStream *bs = OpenBitStream(100, buffer);
+
+    /* Validate zero-length writes (No state change expected) */
+    PutBit(bs, 0x1234, 0);
+    assert(bs->numBit == 0);
+
+    /* Validate negative bit count resilience (Underflow guard) */
+    PutBit(bs, 0xFFFF, -1);
+    assert(bs->numBit == 0);
+
+    /* Validate 32-bit word masking and packing */
+    PutBit(bs, 0xDEADBEEF, 32);
+    assert(bs->numBit == 32);
+    assert(buffer[0] == 0xDE);
+    assert(buffer[1] == 0xAD);
+    assert(buffer[2] == 0xBE);
+    assert(buffer[3] == 0xEF);
+
+    /* Validate clamping for bit counts > 32 (Overflow guard) */
+    /* Implementation should clamp to 32 and write valid masked data */
+    long bitsBefore = bs->numBit;
+    PutBit(bs, 0xAAAAAAAA, 64); 
+
+    /* Ensure only 32 bits were actually added to the total */
+    assert(bs->numBit == bitsBefore + 32);
+
+    assert(buffer[4] == 0xAA);
+    assert(buffer[7] == 0xAA);
+
+    CloseBitStream(bs);
+}
+
+void test_WriteADTSHeader() {
+    unsigned char buffer[100];
+    memset(buffer, 0, 100);
+    BitStream *bs = OpenBitStream(100, buffer);
+
+    faacEncStruct encoder;
+    memset(&encoder, 0, sizeof(encoder));
+    encoder.config.mpegVersion = 0;   /* MPEG-4 */
+    encoder.config.aacObjectType = 2; /* LC-AAC */
+    encoder.sampleRateIdx = 4;        /* 44100 Hz */
+    encoder.numChannels = 2;
+    encoder.usedBytes = 100;
+
+    WriteADTSHeader(&encoder, bs, 1);
+
+    /* ADTS Syncword: 0xFFF (12 bits) */
+    assert(buffer[0] == 0xFF);
+    /* ID, Layer, protection_absent */
+    assert(buffer[1] == 0xF1);
+
+    CloseBitStream(bs);
+}
+
+int main() {
+    test_PutBit_Standard();
+    test_PutBit_Robustness();
+    test_WriteADTSHeader();
+    printf("test_bitstream passed.\n");
+    return 0;
+}

--- a/tests/test_blockswitch.c
+++ b/tests/test_blockswitch.c
@@ -1,0 +1,63 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <math.h>
+#include <string.h>
+#include "coder.h"
+#include "blockswitch.h"
+
+void test_PsyCheckShort() {
+    PsyInfo psyInfo;
+    psydata_t psydata;
+    memset(&psyInfo, 0, sizeof(psyInfo));
+    memset(&psydata, 0, sizeof(psydata));
+    psyInfo.data = &psydata;
+
+    psydata.lastband = 10;
+
+    float eng_quiet[NSFB_SHORT];
+    float eng_loud[NSFB_SHORT];
+    for(int i=0; i<NSFB_SHORT; i++) {
+        eng_quiet[i] = 1.0f;
+        eng_loud[i] = 100.0f;
+    }
+
+    for(int i=0; i<8; i++) {
+        psydata.engPrev[i] = eng_quiet;
+        psydata.eng[i] = eng_quiet;
+        psydata.engNext[i] = eng_quiet;
+    }
+
+    /* Steady-state signal should favor ONLY_LONG_WINDOW */
+    PsyCheckShort(&psyInfo, 1.0);
+    assert(psyInfo.block_type == ONLY_LONG_WINDOW);
+
+    /* High volume change ratio (transient) triggers ONLY_SHORT_WINDOW */
+    psydata.engNext[0] = eng_loud;
+    PsyCheckShort(&psyInfo, 1.0);
+    assert(psyInfo.block_type == ONLY_SHORT_WINDOW);
+}
+
+int main() {
+    test_PsyCheckShort();
+    printf("test_blockswitch passed\n");
+    return 0;
+}

--- a/tests/test_channels.c
+++ b/tests/test_channels.c
@@ -1,0 +1,190 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include "channels.h"
+
+void test_GetChannelInfo_Mono() {
+    ChannelInfo channels[1];
+    /* ISO/IEC 14496-3: Single Channel Element (SCE) configuration */
+    GetChannelInfo(channels, 1, 0);
+    assert(channels[0].present == 1);
+    assert(channels[0].type == ELEMENT_SCE);
+}
+
+void test_GetChannelInfo_Stereo() {
+    ChannelInfo channels[2];
+    /* ISO/IEC 14496-3: Channel Pair Element (CPE) configuration */
+    GetChannelInfo(channels, 2, 0);
+    assert(channels[0].present == 1);
+    assert(channels[0].type == ELEMENT_CPE);
+    assert(channels[0].ch_is_left == 1);
+    assert(channels[0].paired_ch == 1);
+
+    assert(channels[1].present == 1);
+    assert(channels[1].type == ELEMENT_CPE);
+    assert(channels[1].ch_is_left == 0);
+    assert(channels[1].paired_ch == 0);
+}
+
+void test_GetChannelInfo_3_0() {
+    /*
+     * 3.0 (3 channels): Validating SCE + CPE layout mapping.
+     * In accordance with ISO/IEC 14496-3, the mapping assigns:
+     * - SCE (Center) as the first element.
+     * - CPE (Front Left/Right) as the second element.
+     */
+    ChannelInfo channels[3];
+    GetChannelInfo(channels, 3, 0);
+
+    /* SCE (Center) */
+    assert(channels[0].present == 1);
+    assert(channels[0].type == ELEMENT_SCE);
+    assert(channels[0].tag == 0);
+
+    /* CPE (Left/Right) */
+    assert(channels[1].present == 1);
+    assert(channels[1].type == ELEMENT_CPE);
+    assert(channels[1].ch_is_left == 1);
+    assert(channels[1].paired_ch == 2);
+    assert(channels[1].tag == 0);
+
+    assert(channels[2].present == 1);
+    assert(channels[2].type == ELEMENT_CPE);
+    assert(channels[2].ch_is_left == 0);
+    assert(channels[2].paired_ch == 1);
+}
+
+void test_GetChannelInfo_5_1() {
+    /*
+     * 5.1 (6 channels): ISO/IEC 14496-3 Channel Configuration 6.
+     * The MPEG standard element sequence is SCE -> 2xCPE -> LFE.
+     * Mapping for 5.1 Surround:
+     * - SCE: Front Center
+     * - CPE 1: Front Left/Right
+     * - CPE 2: Surround Left/Right
+     * - LFE: Low Frequency Effects
+     */
+    ChannelInfo channels[6];
+    GetChannelInfo(channels, 6, 1);
+
+    /* SCE (Center) */
+    assert(channels[0].present == 1);
+    assert(channels[0].type == ELEMENT_SCE);
+    assert(channels[0].tag == 0);
+
+    /* CPE 1 (Front L/R) */
+    assert(channels[1].present == 1);
+    assert(channels[1].type == ELEMENT_CPE);
+    assert(channels[1].ch_is_left == 1);
+    assert(channels[1].paired_ch == 2);
+    assert(channels[1].tag == 0);
+
+    assert(channels[2].present == 1);
+    assert(channels[2].type == ELEMENT_CPE);
+    assert(channels[2].ch_is_left == 0);
+    assert(channels[2].paired_ch == 1);
+
+    /* CPE 2 (Surround L/R) */
+    assert(channels[3].present == 1);
+    assert(channels[3].type == ELEMENT_CPE);
+    assert(channels[3].ch_is_left == 1);
+    assert(channels[3].paired_ch == 4);
+    assert(channels[3].tag == 1);
+
+    assert(channels[4].present == 1);
+    assert(channels[4].type == ELEMENT_CPE);
+    assert(channels[4].ch_is_left == 0);
+    assert(channels[4].paired_ch == 3);
+
+    /* LFE */
+    assert(channels[5].present == 1);
+    assert(channels[5].type == ELEMENT_LFE);
+    assert(channels[5].tag == 0);
+}
+
+void test_GetChannelInfo_7_1() {
+    /*
+     * 7.1 (8 channels): ISO/IEC 14496-3 Channel Configuration 7.
+     * Standard element sequence: SCE -> 3xCPE -> LFE.
+     * Mapping for 7.1 Surround:
+     * - SCE: Front Center
+     * - CPE 1: Front Left/Right
+     * - CPE 2: Side Left/Right
+     * - CPE 3: Back Left/Right
+     * - LFE: Low Frequency Effects
+     */
+    ChannelInfo channels[8];
+    GetChannelInfo(channels, 8, 1);
+
+    /* SCE (Center) */
+    assert(channels[0].present == 1);
+    assert(channels[0].type == ELEMENT_SCE);
+
+    /* CPE 1 (Front L/R) */
+    assert(channels[1].present == 1);
+    assert(channels[1].type == ELEMENT_CPE);
+    assert(channels[1].ch_is_left == 1);
+    assert(channels[1].paired_ch == 2);
+    assert(channels[1].tag == 0);
+
+    assert(channels[2].present == 1);
+    assert(channels[2].type == ELEMENT_CPE);
+    assert(channels[2].ch_is_left == 0);
+    assert(channels[2].paired_ch == 1);
+
+    /* CPE 2 (Side L/R) */
+    assert(channels[3].present == 1);
+    assert(channels[3].type == ELEMENT_CPE);
+    assert(channels[3].ch_is_left == 1);
+    assert(channels[3].paired_ch == 4);
+    assert(channels[3].tag == 1);
+
+    assert(channels[4].present == 1);
+    assert(channels[4].type == ELEMENT_CPE);
+    assert(channels[4].ch_is_left == 0);
+    assert(channels[4].paired_ch == 3);
+
+    /* CPE 3 (Back L/R) */
+    assert(channels[5].present == 1);
+    assert(channels[5].type == ELEMENT_CPE);
+    assert(channels[5].ch_is_left == 1);
+    assert(channels[5].paired_ch == 6);
+    assert(channels[5].tag == 2);
+
+    assert(channels[6].present == 1);
+    assert(channels[6].type == ELEMENT_CPE);
+    assert(channels[6].ch_is_left == 0);
+    assert(channels[6].paired_ch == 5);
+
+    /* LFE */
+    assert(channels[7].present == 1);
+    assert(channels[7].type == ELEMENT_LFE);
+}
+
+int main() {
+    test_GetChannelInfo_Mono();
+    test_GetChannelInfo_Stereo();
+    test_GetChannelInfo_3_0();
+    test_GetChannelInfo_5_1();
+    test_GetChannelInfo_7_1();
+    printf("test_channels passed\n");
+    return 0;
+}

--- a/tests/test_fft.c
+++ b/tests/test_fft.c
@@ -1,0 +1,58 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <math.h>
+#include "fft.h"
+
+void test_fft_tables() {
+    FFT_Tables tables;
+    fft_initialize(&tables);
+
+    /* Initialization confirms allocation for standard sizes */
+    assert(tables.costbl != NULL);
+    assert(tables.negsintbl != NULL);
+    assert(tables.reordertbl != NULL);
+
+    fft_terminate(&tables);
+}
+
+void test_fft_exec() {
+    FFT_Tables tables;
+    fft_initialize(&tables);
+
+    faac_real xr[8] = {1, 0, -1, 0, 1, 0, -1, 0};
+    faac_real xi[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    /* 8-point FFT (log2(8)=3) */
+    fft(&tables, xr, xi, 3);
+
+    /* Input is a complex exponential; result should have peak at k=2 */
+    assert(xr[2] > 3.0);
+
+    fft_terminate(&tables);
+}
+
+int main() {
+    test_fft_tables();
+    test_fft_exec();
+    printf("test_fft passed\n");
+    return 0;
+}

--- a/tests/test_huffman.c
+++ b/tests/test_huffman.c
@@ -1,0 +1,58 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include "coder.h"
+#include "huff2.h"
+
+void test_huffbook_selection() {
+    CoderInfo coder;
+    memset(&coder, 0, sizeof(coder));
+
+    /* 128 quantized samples, all zero */
+    int xi[128];
+    memset(xi, 0, sizeof(xi));
+
+    /* Choose book for zeros: should select book 0 */
+    huffbook(&coder, xi, 128);
+    assert(coder.book[0] == 0);
+
+    /* Verify huffcode return value for zeros */
+    int bits = huffcode(xi, 128, 1, NULL);
+    assert(bits > 0);
+}
+
+void test_huffbook_escape() {
+    CoderInfo coder;
+    memset(&coder, 0, sizeof(coder));
+
+    /* Large values trigger HCB_ESC (book 11) */
+    int xi[4] = {20, 0, 0, 0};
+    huffbook(&coder, xi, 4);
+    assert(coder.book[0] == 11);
+}
+
+int main() {
+    test_huffbook_selection();
+    test_huffbook_escape();
+    printf("test_huffman passed\n");
+    return 0;
+}

--- a/tests/test_mdct.c
+++ b/tests/test_mdct.c
@@ -1,0 +1,61 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <math.h>
+#include <string.h>
+#include "filtbank.h"
+
+void test_MDCT() {
+    FFT_Tables fft_tables;
+    fft_initialize(&fft_tables);
+
+    /* 256-sample MDCT input (N=256) */
+    faac_real data[256];
+    faac_real xr[64], xi[64];
+    for(int i=0; i<256; i++) data[i] = (faac_real)sin(2.0 * M_PI * i / 256.0);
+
+    MDCT(&fft_tables, data, 256, xr, xi);
+
+    /* Check transform produces non-zero energy in expected bands */
+    faac_real energy = 0;
+    for(int i=0; i<64; i++) energy += xr[i]*xr[i] + xi[i]*xi[i];
+    assert(energy > 0.0001);
+
+    fft_terminate(&fft_tables);
+}
+
+void test_CalculateKBDWindow() {
+    faac_real win[16];
+    /* N=16, alpha=4.0 */
+    CalculateKBDWindow(win, 4.0, 16);
+
+    /* MDCT windows must be symmetric: win[i]^2 + win[i+N/2]^2 = 1.0 is for sine,
+       but KBD has its own properties. Basic check: monotonicity. */
+    assert(win[0] < win[1]);
+    assert(win[7] > win[0]);
+}
+
+int main() {
+    test_MDCT();
+    test_CalculateKBDWindow();
+    printf("test_mdct passed\n");
+    return 0;
+}

--- a/tests/test_quantize.c
+++ b/tests/test_quantize.c
@@ -1,0 +1,62 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include "coder.h"
+#include "quantize.h"
+
+void test_CalcBW() {
+    unsigned int bw = 16000;
+    SR_INFO sr;
+    AACQuantCfg cfg;
+
+    sr.num_cb_long = 40;
+    sr.num_cb_short = 10;
+    for(int i=0; i<40; i++) sr.cb_width_long[i] = 20;
+    for(int i=0; i<10; i++) sr.cb_width_short[i] = 4;
+
+    cfg.pnslevel = 0;
+
+    /* 16kHz bandwidth @ 44.1kHz rate */
+    CalcBW(&bw, 44100, &sr, &cfg);
+
+    /* max_cbl should be approx bw / (44100/2048) */
+    assert(cfg.max_cbl > 0);
+    assert(cfg.max_cbs > 0);
+}
+
+void test_quantize_scalar() {
+    faac_real xr[4] = {1.0, 2.0, -1.0, 0.0};
+    int xi[4];
+
+    /* Small fixed scalefactor */
+    quantize_scalar(xr, xi, 4, 1.0);
+
+    assert(xi[0] == 1);
+    assert(xi[2] == -1);
+    assert(xi[3] == 0);
+}
+
+int main() {
+    test_CalcBW();
+    test_quantize_scalar();
+    printf("test_quantize passed\n");
+    return 0;
+}

--- a/tests/test_tns.c
+++ b/tests/test_tns.c
@@ -1,0 +1,65 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <math.h>
+#include "libfaac/tns.h"
+
+void test_Autocorrelation() {
+    faac_real data[10] = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+    faac_real r[5];
+
+    /* 10 samples, order 4 */
+    Autocorrelation(4, 10, data, r);
+
+    /* r[0] is energy: 5.0 */
+    assert(r[0] > 4.9 && r[0] < 5.1);
+    /* data is periodic with period 2; r[2] should be high */
+    assert(r[2] > 3.9);
+}
+
+void test_LevinsonDurbin() {
+    faac_real k[5];
+    /* Constant signal case: r[0]=10, r[1]=9 */
+    faac_real data[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+    faac_real gain = LevinsonDurbin(4, 10, data, k);
+
+    /* Perfect correlation yields high gain */
+    assert(gain > 1.0);
+}
+
+void test_StepUp() {
+    faac_real k[3] = {1.0, -0.5, 0.2};
+    faac_real a[3];
+
+    StepUp(2, k, a);
+
+    /* a[0] is always 1.0 */
+    assert(a[0] == 1.0);
+}
+
+int main() {
+    test_Autocorrelation();
+    test_LevinsonDurbin();
+    test_StepUp();
+    printf("test_tns passed\n");
+    return 0;
+}

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -1,0 +1,93 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <math.h>
+#include "libfaac/util.h"
+
+void test_GetSRIndex() {
+    /* Nominal sample rate mappings */
+    assert(GetSRIndex(96000) == 0);
+    assert(GetSRIndex(88200) == 1);
+    assert(GetSRIndex(64000) == 2);
+    assert(GetSRIndex(48000) == 3);
+    assert(GetSRIndex(44100) == 4);
+    assert(GetSRIndex(32000) == 5);
+    assert(GetSRIndex(24000) == 6);
+    assert(GetSRIndex(22050) == 7);
+    assert(GetSRIndex(16000) == 8);
+    assert(GetSRIndex(12000) == 9);
+    assert(GetSRIndex(11025) == 10);
+    assert(GetSRIndex(8000) == 11);
+
+    /* Out-of-table rates and boundary conditions */
+    assert(GetSRIndex(44200) == 4);
+    assert(GetSRIndex(100000) == 0);
+    assert(GetSRIndex(4000) == 11);
+    assert(GetSRIndex(0) == 11);
+}
+
+void test_MinBitrate() {
+    assert(MinBitrate() == 8000);
+}
+
+void test_MaxBitrate() {
+    /* ADTS frame limit: 0x2000 * 8 * rate / FRAME_LEN */
+    unsigned int rate = MaxBitrate(44100);
+    assert(rate == 2822400);
+}
+
+void test_BitAllocation() {
+    /* Edge cases for Perceptual Entropy mapping */
+    assert(BitAllocation(0.0, 0) == 0);
+    assert(BitAllocation(0.0, 1) == 0);
+
+    /* RD-cost saturation point */
+    assert(BitAllocation(1000000.0, 0) == 6144);
+    assert(BitAllocation(1000000.0, 1) == 6144);
+
+    /* Intermediate PE values */
+    assert(BitAllocation(100.0, 0) == 90);
+    assert(BitAllocation(100.0, 1) == 300);
+}
+
+void test_MaxBitresSize() {
+    /* Bit reservoir capacity accounting */
+    unsigned int size = MaxBitresSize(128000, 44100);
+    assert(size == 3172);
+
+    /* Reservoir depletion (logical safe minimum floor) */
+    unsigned int size2 = MaxBitresSize(264600, 44100);
+    assert(size2 == 1);
+
+    /* Prevent unsigned underflow on extreme bitrates */
+    unsigned int size3 = MaxBitresSize(529200, 44100);
+    assert(size3 == 1);
+}
+
+int main() {
+    test_GetSRIndex();
+    test_MinBitrate();
+    test_MaxBitrate();
+    test_BitAllocation();
+    test_MaxBitresSize();
+    printf("test_util passed\n");
+    return 0;
+}


### PR DESCRIPTION
This commit introduces improvements to internal symbol visibility, adds  robustness to bitstream handling, and establishes a foundation for testing.

Architecture & Refactoring:
* Replaced redundant `cpe`, `sce`, and `lfe` boolean flags in `ChannelInfo` with a unified `ElementType` enum (`ELEMENT_SCE`, `ELEMENT_CPE`, `ELEMENT_LFE`).
* Introduced the `FAAC_INTERNAL` macro to handle internal symbol visibility.  Production builds now hide these symbols, while test builds expose them  as `extern` for component-level testing.
* Refactored static functions across `tns.c`, `quantize.c`, `filtbank.c`,  and `huff2.c` to `FAAC_INTERNAL` to allow unit testing without polluting the public ABI.

Bug Fixes & Robustness:
* Bitstream: Changed the `PutBit` data parameter from `unsigned long` to `uint32_t` to prevent unexpected behavior on 64-bit platforms.
* Bitstream: Replaced dynamic bit-shifting in `PutBit` with a precomputed `bitmask` array and added hard bounds checking (capping `numBit` at 32).
* TNS: Added a numerical stability guard to the Levinson-Durbin recursion to prevent division-by-zero or instability on highly correlated signals (enforcing a floor of `1e-10`).
* Bit Reservoir: Fixed an unsigned underflow risk in `MaxBitresSize` by enforcing a minimum return value of 1.

Build System & CI:
* Added a Meson-based test framework in the `tests/` directory to cover both internal components and the public API.
* Added `meson test` to the GitHub Actions workflow for Linux and Windows.
* Enabled Link-Time Optimization (`b_lto=true`) and Position Independent Executables (`b_pie=true`) by default in the core Meson config.
* Appended 3.0/5.1 testing and 7.1 PCE goals to the TODO.