### PR TITLE
implement anchored psychoacoustic parameter interpolation

### DIFF
--- a/libfaac/blockswitch.c
+++ b/libfaac/blockswitch.c
@@ -106,7 +106,8 @@ static void PsyCheckShort(PsyInfo * psyInfo, faac_real quality)
               volchg += FAAC_FABS(eng[sfb] - lasteng[sfb]);
           }
 
-          if ((volchg / toteng * quality) > 3.0)
+          /* Transient sensitivity. Lower: reduces pre-echo. Higher: saves bits. */
+          if ((volchg / toteng * quality) > 2.5)
           {
               psyInfo->block_type = ONLY_SHORT_WINDOW;
               break;

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -219,8 +219,8 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
     #undef POWM_HI
     #undef FP_LO
     #undef FP_HI
-    #undef ANCHOR_LO_BPC
-    #undef ANCHOR_HI_BPC
+    #undef ANCHOR_LO
+    #undef ANCHOR_HI
 
     /* Bandwidth resolution */
     if (!hEncoder->config.bandWidth) {

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -50,12 +50,6 @@ static const psymodellist_t psymodellist[] = {
 
 static SR_INFO srInfo[12+1];
 
-// default bandwidth/samplerate ratio
-static const struct {
-    faac_real fac;
-    faac_real freq;
-} g_bw = {0.42, 18000};
-
 int FAACAPI faacEncGetVersion( char **faac_id_string,
 			      				char **faac_copyright_string)
 {
@@ -156,12 +150,8 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
         return 0;
 #endif
 
-    if (config->bitRate && !config->bandWidth)
+    if (config->bitRate)
     {
-        config->bandWidth = (faac_real)config->bitRate * hEncoder->sampleRate * g_bw.fac / 50000.0;
-        if (config->bandWidth > g_bw.freq)
-            config->bandWidth = g_bw.freq;
-
         if (!config->quantqual)
         {
             config->quantqual = (faac_real)config->bitRate * hEncoder->numChannels / 1280;
@@ -174,19 +164,7 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
         config->quantqual = DEFQUAL;
 
     hEncoder->config.bitRate = config->bitRate;
-
-    if (!config->bandWidth)
-    {
-        config->bandWidth = g_bw.fac * hEncoder->sampleRate;
-    }
-
     hEncoder->config.bandWidth = config->bandWidth;
-
-    // check bandwidth
-    if (hEncoder->config.bandWidth < 100)
-		hEncoder->config.bandWidth = 100;
-    if (hEncoder->config.bandWidth > (hEncoder->sampleRate / 2))
-		hEncoder->config.bandWidth = hEncoder->sampleRate / 2;
 
     if (config->quantqual > maxqual)
         config->quantqual = maxqual;
@@ -194,6 +172,79 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
         config->quantqual = MINQUAL;
 
     hEncoder->config.quantqual = config->quantqual;
+
+    /* Bitrate-dependent parameter interpolation (anchored 16k-128k).
+     * Tuning Guide:
+     * - NF (Noise Floor):  Lower = less quantization noise (more detail).
+     * - FAC (BW Factor):   Higher = extended spectral cutoff frequency.
+     * - POWM (Power Exp):  Lower = flatter masking curve (more transparency).
+     * - FP (Freq Penalty): Lower = better high-frequency sibilance retention. */
+    #define ANCHOR_LO  16000.0
+    #define ANCHOR_HI 128000.0
+
+    #define NF_LO    0.010
+    #define NF_HI    0.001
+    #define FAC_LO   0.90
+    #define FAC_HI   0.99
+    #define POWM_LO  0.27
+    #define POWM_HI  0.30
+    #define FP_LO    0.75
+    #define FP_HI    0.70
+
+    faac_real t = (hEncoder->config.bitRate - (faac_real)ANCHOR_LO)
+                   / ((faac_real)ANCHOR_HI - (faac_real)ANCHOR_LO);
+    if (t < 0.0) t = 0.0;
+    if (t > 1.0) t = 1.0;
+
+    #define INTERP(lo, hi)      ((lo) + t * ((hi) - (lo)))
+    #define INTERP_LOG(lo, hi)  FAAC_POW((lo), 1.0-t) * FAAC_POW((hi), t)
+
+    faac_real nf   = INTERP_LOG(NF_LO,  NF_HI);
+    faac_real fac  = INTERP(FAC_LO,  FAC_HI);
+    faac_real powm = INTERP(POWM_LO, POWM_HI);
+    faac_real fp   = INTERP(FP_LO,   FP_HI);
+
+    #undef INTERP
+    #undef INTERP_LOG
+
+    hEncoder->aacquantCfg.noise_floor  = nf;
+    hEncoder->aacquantCfg.powm         = powm;
+    hEncoder->aacquantCfg.freq_penalty = fp;
+
+    #undef NF_LO
+    #undef NF_HI
+    #undef FAC_LO
+    #undef FAC_HI
+    #undef POWM_LO
+    #undef POWM_HI
+    #undef FP_LO
+    #undef FP_HI
+    #undef ANCHOR_LO_BPC
+    #undef ANCHOR_HI_BPC
+
+    /* Bandwidth resolution */
+    if (!hEncoder->config.bandWidth) {
+        faac_real nyquist      = (faac_real)hEncoder->sampleRate * 0.5;
+
+        /* Cap at 20 kHz: AAC does not efficiently encode near Nyquist */
+        faac_real maxBandwidth = (nyquist > 20000.0) ? 20000.0 : nyquist;
+        hEncoder->config.bandWidth = (unsigned int)(fac * maxBandwidth);
+
+        /* Prevents bandwidth falling below useful speech range.
+           Uses min(3500, 40% of Nyquist) to adapt to low sample rates. */
+        unsigned int bw_floor = 3500;
+        unsigned int sr_frac  = (unsigned int)(nyquist * 0.4);
+        if (sr_frac < bw_floor)
+            bw_floor = sr_frac;
+        if (hEncoder->config.bandWidth < bw_floor)
+            hEncoder->config.bandWidth = bw_floor;
+    }
+
+    /* Ensure bandwidth is within valid Nyquist limits */
+    if (hEncoder->config.bandWidth < 100)
+        hEncoder->config.bandWidth = 100;
+    if (hEncoder->config.bandWidth > (hEncoder->sampleRate / 2))
+        hEncoder->config.bandWidth = hEncoder->sampleRate / 2;
 
     if (config->mpegVersion == MPEG2)
         config->pnslevel = 0;
@@ -265,7 +316,7 @@ faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
     hEncoder->config.useLfe = 1;
     hEncoder->config.useTns = 0;
     hEncoder->config.bitRate = 64000;
-    hEncoder->config.bandWidth = g_bw.fac * hEncoder->sampleRate;
+    hEncoder->config.bandWidth = 0;
     hEncoder->config.quantqual = 0;
     hEncoder->config.psymodellist = (psymodellist_t *)psymodellist;
     hEncoder->config.psymodelidx = 0;

--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -67,23 +67,24 @@ void QuantizeInit(void)
 #endif
         qfunc = quantize_scalar;
 }
-#define NOISEFLOOR 0.4
 
 // band sound masking
 static void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, faac_real * __restrict bandqual,
-                  faac_real * __restrict bandenrg, int gnum, faac_real quality)
+                  faac_real * __restrict bandenrg, int gnum, faac_real quality, AACQuantCfg *aacquantCfg)
 {
   int sfb, start, end, cnt;
   int *cb_offset = coderInfo->sfb_offset;
   int last;
   faac_real avgenrg;
-  faac_real powm = 0.4;
+  /* Masking curve exponent. Lower: quiet passage transparency. */
+  const faac_real powm = aacquantCfg->powm;
   faac_real totenrg = 0.0;
   int gsize = coderInfo->groups.len[gnum];
   const faac_real *xr;
   int win;
   int enrgcnt = 0;
   int total_len = coderInfo->sfb_offset[coderInfo->sfbn];
+  const faac_real noise_floor = aacquantCfg->noise_floor;
 
   for (win = 0; win < gsize; win++)
   {
@@ -94,8 +95,7 @@ static void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, 
       }
   }
   enrgcnt = gsize * total_len;
-
-  if (totenrg < ((NOISEFLOOR * NOISEFLOOR) * (faac_real)enrgcnt))
+  if (totenrg < ((noise_floor * noise_floor) * (faac_real)enrgcnt))
   {
       for (sfb = 0; sfb < coderInfo->sfbn; sfb++)
       {
@@ -132,29 +132,23 @@ static void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, 
     bandenrg[sfb] = avge;
     maxe *= gsize;
 
+    last = (coderInfo->block_type == ONLY_SHORT_WINDOW) ? BLOCK_LEN_SHORT : BLOCK_LEN_LONG;
+    avgenrg = totenrg / last;
+    avgenrg *= end - start;
+
 #define NOISETONE 0.2
+    target = NOISETONE * FAAC_POW(avge/avgenrg, powm);
+    target += (1.0 - NOISETONE) * 0.45 * FAAC_POW(maxe/avgenrg, powm);
+#undef NOISETONE
+
     if (coderInfo->block_type == ONLY_SHORT_WINDOW)
-    {
-        last = BLOCK_LEN_SHORT;
-        avgenrg = totenrg / last;
-        avgenrg *= end - start;
-
-        target = NOISETONE * FAAC_POW(avge/avgenrg, powm);
-        target += (1.0 - NOISETONE) * 0.45 * FAAC_POW(maxe/avgenrg, powm);
-
         target *= 1.5;
-    }
-    else
-    {
-        last = BLOCK_LEN_LONG;
-        avgenrg = totenrg / last;
-        avgenrg *= end - start;
+    /* Global Masking Multiplier. Higher: raises MNR/fidelity. */
+    target *= 15.0 / (1.0 + ((faac_real)(start+end)/last));
 
-        target = NOISETONE * FAAC_POW(avge/avgenrg, powm);
-        target += (1.0 - NOISETONE) * 0.45 * FAAC_POW(maxe/avgenrg, powm);
-    }
-
-    target *= 10.0 / (1.0 + ((faac_real)(start+end)/last));
+    /* HF Sibilance Protection. Lower: prevents high-freq 'smearing'. */
+    if (sfb > 0)
+        target *= aacquantCfg->freq_penalty;
 
     bandqual[sfb] = target * quality;
   }
@@ -167,7 +161,7 @@ static void qlevel(CoderInfo * __restrict coderInfo,
                    const faac_real * __restrict bandqual,
                    const faac_real * __restrict bandenrg,
                    int gnum,
-                   int pnslevel
+                   AACQuantCfg *aacquantCfg
                   )
 {
     int sb;
@@ -178,7 +172,9 @@ static void qlevel(CoderInfo * __restrict coderInfo,
     static const faac_real sfstep = 20 / 1.50515;
 #endif
     int gsize = coderInfo->groups.len[gnum];
-    faac_real pnsthr = 0.1 * pnslevel;
+    const faac_real inv_gsize = 1.0 / (faac_real)gsize;
+    const faac_real noise_floor = aacquantCfg->noise_floor;
+    const faac_real pnsthr = 0.1 * aacquantCfg->pnslevel;
 
     for (sb = 0; sb < coderInfo->sfbn; sb++)
     {
@@ -201,10 +197,10 @@ static void qlevel(CoderInfo * __restrict coderInfo,
       start = coderInfo->sfb_offset[sb];
       end = coderInfo->sfb_offset[sb+1];
 
-      etot = bandenrg[sb] / (faac_real)gsize;
+      etot = bandenrg[sb] * inv_gsize;
       rmsx = FAAC_SQRT(etot / (end - start));
 
-      if ((rmsx < NOISEFLOOR) || (!bandqual[sb]))
+      if ((rmsx < noise_floor) || (!bandqual[sb]))
       {
           coderInfo->book[coderInfo->bandcnt++] = HCB_ZERO;
           continue;
@@ -262,11 +258,11 @@ int BlocQuant(CoderInfo * __restrict coder, faac_real * __restrict xr, AACQuantC
         int lastsf;
 
         gxr = xr;
+        const faac_real qscale = (faac_real)aacquantCfg->quality / DEFQUAL;
         for (cnt = 0; cnt < coder->groups.n; cnt++)
         {
-            bmask(coder, gxr, bandlvl, bandenrg, cnt,
-                  (faac_real)aacquantCfg->quality/DEFQUAL);
-            qlevel(coder, gxr, bandlvl, bandenrg, cnt, aacquantCfg->pnslevel);
+            bmask(coder, gxr, bandlvl, bandenrg, cnt, qscale, aacquantCfg);
+            qlevel(coder, gxr, bandlvl, bandenrg, cnt, aacquantCfg);
             gxr += coder->groups.len[cnt] * BLOCK_LEN_SHORT;
         }
 

--- a/libfaac/quantize.h
+++ b/libfaac/quantize.h
@@ -31,6 +31,9 @@ typedef struct
     int max_cbs;
     int max_l;
     int pnslevel;
+    faac_real noise_floor;
+    faac_real powm;
+    faac_real freq_penalty;
 } AACQuantCfg;
 
 #ifdef FAAC_PRECISION_SINGLE


### PR DESCRIPTION
Refactor static constants into a dynamic model that scales between 16kbps and 128kbps anchors. This improves transparency and high-frequency response across the bitrate spectrum yielding a signficant average MOS delta of 0.475.

Summary of changes:
- Interpolate NF, POWM, and Freq Penalty based on target bitrate.
- Lowered transient threshold to 2.5 to prioritize pre-echo reduction.
- Hoisted quality scaling and group-size divisions out of loops.
- Centralized detailed parameter tuning documentation in frame.c.
- Applied sibilance protection via high-frequency masking penalties.


<img width="704" height="1010" alt="image" src="https://github.com/user-attachments/assets/3650a017-df72-4ccd-9f46-fa29e6f31f29" />

See benchmark results at: https://github.com/nschimme/faac/actions/runs/23403734812