### PR TITLE
reduce MAX_CHANNELS to 8 for ADTS compliance

### DIFF
--- a/TODO
+++ b/TODO
@@ -6,3 +6,4 @@
 - Add resampler and downmixer (hans-juergen, Oct 17, 2004)
 - Add HE AAC (hans-juergen, Oct 17, 2004)
 - Test TNS(arcen, Apr 8th, 2012)
+- add PCE (Program Config Element) or 4-bit AudioSpecificConfig

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,5 +13,5 @@ option('max-channels',
     description: 'Maximum number of channels',
     type: 'integer',
     min: 1,
-    max: 64,
-    value: 64)
+    max: 8,
+    value: 8)


### PR DESCRIPTION
Limits the maximum channel count to 8 to align with the 3-bit channel_configuration field in the ADTS fixed header (ISO/IEC 13818-7). Since the implementation does not currently support Program Config Elements (PCE) or 4-bit AudioSpecificConfig (MP4) structures, any value above 8 is unreachable. Reducing this constant optimizes memory allocation for channel-based buffers.

8 channels is more than enough for 7.1 surround audio. Anyone who wants more will likely use FDK-AAC.