### PR TITLE
implement MOS-optimized bandwidth calculation

### DIFF
--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -50,11 +50,40 @@ static const psymodellist_t psymodellist[] = {
 
 static SR_INFO srInfo[12+1];
 
-// default bandwidth/samplerate ratio
-static const struct {
-    faac_real fac;
-    faac_real freq;
-} g_bw = {0.42, 18000};
+static unsigned int CalcBandwidth(unsigned long bitRate, unsigned long sampleRate)
+{
+    const unsigned int nyquist = sampleRate / 2;
+    unsigned int bw;
+
+    if (!bitRate) return nyquist;
+
+    if (bitRate <= 16000) {
+        /* Segment 1: Telephony (4kHz to 6kHz) */
+        bw = 4000 + (bitRate / 8);
+    }
+    else if (bitRate <= 32000) {
+        /* Segment 2: Low-tier (6kHz to 11kHz)
+         */
+        bw = 6000 + ((bitRate - 16000) * 5 / 16);
+    }
+    else if (bitRate <= 64000) {
+        /* Segment 3: Mid-tier expansion (11kHz to 18.5kHz)
+         */
+        bw = 11000 + ((bitRate - 32000) * 15 / 64);
+    }
+    else if (bitRate <= 128000) {
+        /* Segment 4: High-fidelity catch-up (18.5kHz to 20kHz) */
+        bw = 18500 + ((bitRate - 64000) * 3 / 128);
+    }
+    else {
+        /* Segment 5: Transparency plateau (20kHz+) */
+        bw = 20000 + ((bitRate - 128000) / 16);
+        if (bw > 20000) bw = 20000;
+    }
+
+    /* Safety clamp to Shannon-Nyquist limit */
+    return (bw > nyquist) ? nyquist : bw;
+}
 
 int FAACAPI faacEncGetVersion( char **faac_id_string,
 			      				char **faac_copyright_string)
@@ -158,9 +187,7 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
 
     if (config->bitRate && !config->bandWidth)
     {
-        config->bandWidth = (faac_real)config->bitRate * hEncoder->sampleRate * g_bw.fac / 50000.0;
-        if (config->bandWidth > g_bw.freq)
-            config->bandWidth = g_bw.freq;
+        config->bandWidth = CalcBandwidth(config->bitRate, hEncoder->sampleRate);
 
         if (!config->quantqual)
         {
@@ -177,7 +204,7 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
 
     if (!config->bandWidth)
     {
-        config->bandWidth = g_bw.fac * hEncoder->sampleRate;
+        config->bandWidth = CalcBandwidth(config->bitRate, hEncoder->sampleRate);
     }
 
     hEncoder->config.bandWidth = config->bandWidth;
@@ -265,7 +292,7 @@ faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
     hEncoder->config.useLfe = 1;
     hEncoder->config.useTns = 0;
     hEncoder->config.bitRate = 64000;
-    hEncoder->config.bandWidth = g_bw.fac * hEncoder->sampleRate;
+    hEncoder->config.bandWidth = CalcBandwidth(hEncoder->config.bitRate, sampleRate);
     hEncoder->config.quantqual = 0;
     hEncoder->config.psymodellist = (psymodellist_t *)psymodellist;
     hEncoder->config.psymodelidx = 0;


### PR DESCRIPTION
Replace the simplistic static bandwidth/samplerate ratio with a piecewise linear model based on Mean Opinion Score (MOS) optimization.

The new `CalcBandwidth` function implements five distinct segments:
- Telephony (up to 16kbps)
- Low-tier (16-32kbps)
- Mid-tier (32-64kbps)
- High-fidelity (64-128kbps)
- Transparency plateau (128kbps+)

This ensures better audio quality across different bitrates while maintaining a safety clamp at the Shannon-Nyquist limit.

This drastically improves performance on the low and high end: https://github.com/nschimme/faac/actions/runs/23465103853

<img width="679" height="895" alt="image" src="https://github.com/user-attachments/assets/8205f634-129c-4974-a714-208452b53847" />

There are more MOS improvements to add after we get this initially framework merged as we can still tune the transient threshold and the noise floor.