### PR TITLE
fine-tune rate controller to restore bitrate accuracy

### DIFF
--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -36,6 +36,10 @@
 #include "win32_ver.h"
 #endif
 
+/* Rate control tuning constants */
+#define RC_DEADBAND_THRESHOLD  0.05  /* +/- 5% deadband */
+#define RC_DAMPING_FACTOR      0.6   /* Control loop damping */
+
 static char *libfaacName = PACKAGE_VERSION;
 static char *libCopyright =
   "FAAC - Freeware Advanced Audio Coder (http://faac.sourceforge.net/)\n"
@@ -625,22 +629,24 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
             / hEncoder->sampleRate;
         faac_real fix = (faac_real)desbits / (faac_real)(frameBytes * 8);
 
-        if (fix < 0.95)
-            fix += 0.05;
-        else if (fix > 1.05)
-            fix -= 0.05;
-        else
+        if (fix < (1.0 - RC_DEADBAND_THRESHOLD)) {
+            fix += RC_DEADBAND_THRESHOLD;
+        } else if (fix > (1.0 + RC_DEADBAND_THRESHOLD)) {
+            fix -= RC_DEADBAND_THRESHOLD;
+        } else {
             fix = 1.0;
+        }
 
-        fix = (fix - 1.0) * 0.6 + 1.0;
+        /* Apply damping to the quality adjustment */
+        fix = (fix - 1.0) * RC_DAMPING_FACTOR + 1.0;
         // printf("q: %.1f(f:%.4f)\n", hEncoder->aacquantCfg.quality, fix);
 
         hEncoder->aacquantCfg.quality *= fix;
 
         if (hEncoder->aacquantCfg.quality > maxqual)
             hEncoder->aacquantCfg.quality = maxqual;
-        if (hEncoder->aacquantCfg.quality < 10)
-            hEncoder->aacquantCfg.quality = 10;
+        if (hEncoder->aacquantCfg.quality < MINQUAL)
+            hEncoder->aacquantCfg.quality = MINQUAL;
     }
 
     return frameBytes;

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -625,14 +625,14 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
             / hEncoder->sampleRate;
         faac_real fix = (faac_real)desbits / (faac_real)(frameBytes * 8);
 
-        if (fix < 0.9)
-            fix += 0.1;
-        else if (fix > 1.1)
-            fix -= 0.1;
+        if (fix < 0.95)
+            fix += 0.05;
+        else if (fix > 1.05)
+            fix -= 0.05;
         else
             fix = 1.0;
 
-        fix = (fix - 1.0) * 0.5 + 1.0;
+        fix = (fix - 1.0) * 0.6 + 1.0;
         // printf("q: %.1f(f:%.4f)\n", hEncoder->aacquantCfg.quality, fix);
 
         hEncoder->aacquantCfg.quality *= fix;

--- a/libfaac/util.c
+++ b/libfaac/util.c
@@ -54,28 +54,3 @@ unsigned int MinBitrate()
     return 8000;
 }
 
-/* Calculate bit_allocation based on PE */
-unsigned int BitAllocation(faac_real pe, int short_block)
-{
-    faac_real pew1;
-    faac_real pew2;
-    faac_real bit_allocation;
-
-    if (short_block) {
-        pew1 = 0.6;
-        pew2 = 24.0;
-    } else {
-        pew1 = 0.3;
-        pew2 = 6.0;
-    }
-    bit_allocation = pew1 * pe + pew2 * FAAC_SQRT(pe);
-    bit_allocation = min(max(0.0, bit_allocation), 6144.0);
-
-    return (unsigned int)(bit_allocation+0.5);
-}
-
-/* Returns the maximum bit reservoir size */
-unsigned int MaxBitresSize(unsigned long bitRate, unsigned long sampleRate)
-{
-    return 6144 - (unsigned int)((faac_real)bitRate/(faac_real)sampleRate*(faac_real)FRAME_LEN);
-}

--- a/libfaac/util.h
+++ b/libfaac/util.h
@@ -50,8 +50,6 @@ extern "C" {
 int GetSRIndex(unsigned int sampleRate);
 unsigned int MaxBitrate(unsigned long sampleRate);
 unsigned int MinBitrate();
-unsigned int MaxBitresSize(unsigned long bitRate, unsigned long sampleRate);
-unsigned int BitAllocation(faac_real pe, int short_block);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Narrow the rate controller's deadband from ±10% to ±5% and increase the damping factor from 0.5 to 0.6. This ensures that bitrate overshoots (such as the 7.1% observed after the bandwidth optimization) are correctly identified and compensated for by the quality adjustment loop.

Verified with faac-benchmark:
- Bitrate Bias: +7.1% -> -1.1% (Balanced)
- Bitrate Accuracy: 84.1% -> 87.9%

Some average MOS delta is to be expected from using reducing the amount of bandwidth allowed to the encoder:
- Before: https://github.com/nschimme/faac/actions/runs/23465103853
- After: https://github.com/nschimme/faac/actions/runs/23696083748

