### PR TITLE
enable link-time optimization (LTO) in Meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,8 @@ project('faac', 'c',
         'default_library=both',
         'buildtype=release',
         'warning_level=1',
-        'c_std=gnu99,c99'
+        'c_std=gnu99,c99',
+        'b_lto=true'
     ])
 
 add_global_arguments('-DHAVE_CONFIG_H', language: 'c')


### PR DESCRIPTION
This change results in a smaller and potentially more efficient library binary.

Benchmark tests showed an approximately 8% reduction in `libfaac.so` size and a 4% improvement in throughput.

<img width="718" height="893" alt="image" src="https://github.com/user-attachments/assets/b9a1bb60-32cf-4f68-b454-3ea1780d720b" />
