### PR TITLE
quantize: restore short-window masking penalty to fix energy drops

### DIFF
--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -162,7 +162,9 @@ static void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, 
     bandmaxe[sfb] = FAAC_SQRT(maxe);
     maxe *= gsize;
 
-#define NOISETONE 0.2
+#define NOISETONE     0.2   /* noise-floor weight in masking target */
+#define TONEMASK      0.45  /* tone-masking component weight */
+#define SHORT_PENALTY 0.45  /* tightens masking target for short-window blocks */
     if (coderInfo->block_type == ONLY_SHORT_WINDOW)
     {
         last = BLOCK_LEN_SHORT;
@@ -170,9 +172,9 @@ static void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, 
         avgenrg *= end - start;
 
         target = NOISETONE * FAAC_POW(avge/avgenrg, powm);
-        target += (1.0 - NOISETONE) * 0.45 * FAAC_POW(maxe/avgenrg, powm);
+        target += (1.0 - NOISETONE) * TONEMASK * FAAC_POW(maxe/avgenrg, powm);
 
-        target *= 1.5;
+        target *= SHORT_PENALTY;
     }
     else
     {
@@ -181,7 +183,7 @@ static void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, 
         avgenrg *= end - start;
 
         target = NOISETONE * FAAC_POW(avge/avgenrg, powm);
-        target += (1.0 - NOISETONE) * 0.45 * FAAC_POW(maxe/avgenrg, powm);
+        target += (1.0 - NOISETONE) * TONEMASK * FAAC_POW(maxe/avgenrg, powm);
     }
 
     target *= 10.0 / (1.0 + ((faac_real)(start+end)/last));


### PR DESCRIPTION
Commit 577c6499 ("initial windows grouping support") split bmask() into short- and long-window branches and introduced `target *= 1.5` for short blocks. This inflated the psychoacoustic masking threshold 50%, causing the quantizer to allocate too few bits during transients and producing audible energy drops.

Restore the pre-577c6499 multiplier of SHORT_PENALTY (0.45), which tightens the masking target for short-window blocks. Extract the formula constants as named macros: NOISETONE (noise-floor weight), TONEMASK (tone-masking component weight), and SHORT_PENALTY (short-window quality penalty) — keeping them separate so each can be tuned independently.

Benchmark report shows no performance changes but some changes in psychoacoustic model as expected where the benefits outweigh the negatives: https://github.com/nschimme/faac/actions/runs/25871625558