### PR TITLE
quantize: keep global_gain a valid regular scalefactor (fix decoder OOR)

### DIFF
--- a/libfaac/huff2.c
+++ b/libfaac/huff2.c
@@ -432,7 +432,8 @@ int writesf(CoderInfo *coder, BitStream *stream, int write)
     lastis = 0;
     lastpns = coder->global_gain - SF_PNS_OFFSET;
 
-    // fixme: move range check to quantizer
+    /* qlevel() bounds every stored sf[] and global_gain to [0, SF_MAX_ABS], so
+     * the running reconstruction below cannot leave the decoder's range. */
     for (cnt = 0; cnt < coder->bandcnt; cnt++)
     {
         int book = coder->book[cnt];

--- a/libfaac/huff2.h
+++ b/libfaac/huff2.h
@@ -46,6 +46,8 @@ enum {
     SF_PNS_OFFSET = SF_OFFSET - SF_MIN,
     /* Max allowed difference between successive scalefactors (AAC spec) */
     SF_DELTA = 60,
+    /* Max absolute scalefactor / global_gain (8-bit bitstream field) */
+    SF_MAX_ABS = 255,
 };
 
 /**

--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -293,6 +293,23 @@ static void qlevel(CoderInfo * __restrict coderInfo,
                   }
               }
           }
+
+          /* Bound to the decoder's 8-bit scalefactor range. The delta clamp
+           * keeps each step legal but not the running total, so a band can
+           * still land outside [0, SF_MAX_ABS]; pin it here. Covers every
+           * active band, including the first, which seeds global_gain and
+           * skips the delta clamp above. */
+          if (sf_abs < 0 || sf_abs > SF_MAX_ABS)
+          {
+              sf_abs = (sf_abs < 0) ? 0 : SF_MAX_ABS;
+              sf_rel = sf_abs - sf_bias;
+              sfac   = SF_OFFSET - sf_rel;
+              /* Clamping toward 0 raises gain (recheck Huffman overflow);
+               * clamping toward 255 lowers gain (recheck is a harmless no-op). */
+              sfacfix = gain_with_overflow_clamp(&sfac, bandmaxe[sb]);
+              sf_rel  = SF_OFFSET - sfac;
+              sf_abs  = sf_bias + sf_rel;
+          }
       }
 
       end -= start;
@@ -345,13 +362,18 @@ int BlocQuant(CoderInfo * __restrict coder, faac_real * __restrict xr, AACQuantC
         gxr += coder->groups.len[cnt] * BLOCK_LEN_SHORT;
     }
 
+    /* global_gain seeds the decoder's regular scalefactor chain and is written
+     * as 8 bits, so it must be a regular band's sf in [0, SF_MAX_ABS]. Intensity
+     * and PNS bands store stereo-position / noise-energy on a different scale
+     * (PNS can be negative); seeding from one truncates on the 8-bit write and
+     * desyncs the encoder and decoder chains. */
     coder->global_gain = 0;
     for (cnt = 0; cnt < coder->bandcnt; cnt++)
     {
         int book = coder->book[cnt];
         if (!book)
             continue;
-        if ((book != HCB_INTENSITY) && (book != HCB_INTENSITY2))
+        if ((book != HCB_INTENSITY) && (book != HCB_INTENSITY2) && (book != HCB_PNS))
         {
             coder->global_gain = coder->sf[cnt];
             break;


### PR DESCRIPTION
## Problem

FAAC produces an undecodable bitstream on some content; FFmpeg rejects it with:

```
[aac] Scalefactor (315) out of range.
Error submitting packet to decoder: Invalid data found when processing input
```

Surfaced by the faac-benchmark suite (scenarios `music_40` / `music_48`) on
`27-last-song-drums-and-trampets.441.16b48k.wav`.

## Root cause

`global_gain` seeds the decoder's **regular** scalefactor chain (`offset[0]`)
and is transmitted as an 8-bit field, so it must hold a regular band's
scalefactor in `[0, 255]`. The selection loop in `BlocQuant` picked the first
active *non-intensity* band — which **also matches PNS bands**.

PNS bands store noise-energy on a different scale and can be **negative**. Here
the first active band was PNS with a value of `-1`. Writing `-1` to the 8-bit
field truncates it to `255`, so:

- the **encoder** seeds its chain from `-1`,
- the **decoder** seeds from `255`,

and the first regular band's `+60`-clamped delta drives the decoder to
`255 + 60 = 315` → out of range.

Confirmed by instrumenting `writesf`: the encoder's own running reconstruction
never exceeded 255, while `global_gain` printed `-1` with `book[0] = 13`
(HCB_PNS).

## Fix

- **Primary:** exclude `HCB_PNS` (alongside intensity) when choosing
  `global_gain`, so it comes from a regular band and stays in range.
- **Defense-in-depth:** add `SF_MAX_ABS` and clamp every regular band's
  absolute scalefactor to `[0, SF_MAX_ABS]` in `qlevel()`, recomputing the gain
  consistently. This realizes the long-standing `// fixme: move range check to
  quantizer` in `writesf()`.

This is a latent, pre-existing defect (not introduced by #107); #107's masking
changes merely shifted band classification on this sample enough to expose it.

## Verification

- The failing sample now decodes cleanly at 40 and 48 kbps.
- Sweep of the full benchmark corpus × 6 bitrates (32–128 kbps): **0 / 294**
  encode+decode combinations produce decode errors.

<img width="703" height="499" alt="image" src="https://github.com/user-attachments/assets/7efd7ebe-f4c4-42b4-8dd6-f5e5433040b9" />

https://github.com/nschimme/faac/actions/runs/27481351725