### PR TITLE
bitstream: stop embedding the libfaac version string

### DIFF
--- a/libfaac/bitstream.c
+++ b/libfaac/bitstream.c
@@ -88,45 +88,6 @@ static long BufferNumBit(BitStream *bitStream);
 static int ByteAlign(BitStream* bitStream,
                      int writeFlag, int bitsSoFar);
 
-static int WriteFAACStr(BitStream *bitStream, char *version, int write)
-{
-  int i;
-  char str[200];
-  int len, padbits, count;
-  int bitcnt;
-
-  sprintf(str, "libfaac %s", version);
-
-  len = strlen(str) + 1;
-  padbits = (8 - ((bitStream->numBit + 7) % 8)) % 8;
-  count = len + 3;
-
-  bitcnt = LEN_SE_ID + 4 + ((count < 15) ? 0 : 8) + count * 8;
-  if (!write)
-    return bitcnt;
-
-  PutBit(bitStream, ID_FIL, LEN_SE_ID);
-  if (count < 15)
-  {
-    PutBit(bitStream, count, 4);
-  }
-  else
-  {
-    PutBit(bitStream, 15, 4);
-    PutBit(bitStream, count - 14, 8);
-  }
-
-  PutBit(bitStream, 0, padbits);
-  PutBit(bitStream, 0, 8);
-  PutBit(bitStream, 0, 8); // just in case
-  for (i = 0; i < len; i++)
-    PutBit(bitStream, str[i], 8);
-
-  PutBit(bitStream, 0, 8 - padbits);
-
-  return bitcnt;
-}
-
 int WriteBitstream(faacEncStruct* hEncoder,
                    CoderInfo *coderInfo,
                    ChannelInfo *channelInfo,
@@ -145,10 +106,6 @@ int WriteBitstream(faacEncStruct* hEncoder,
     }else{
         bits = 0; // compilier will remove it, byt anyone will see that current size of bitstream is 0
     }
-
-/* sur: faad2 complains about scalefactor error if we are writing FAAC String */
-    if (hEncoder->frameNum == 4)
-      WriteFAACStr(bitStream, hEncoder->config.name, 1);
 
     for (channel = 0; channel < numChannel; channel++) {
 
@@ -232,10 +189,6 @@ static int CountBitstream(faacEncStruct* hEncoder,
     }else{
         bits = 0; // compilier will remove it, byt anyone will see that current size of bitstream is 0
     }
-
-/* sur: faad2 complains about scalefactor error if we are writing FAAC String */
-    if (hEncoder->frameNum == 4)
-      bits += WriteFAACStr(bitStream, hEncoder->config.name, 0);
 
     for (channel = 0; channel < numChannel; channel++) {
 


### PR DESCRIPTION
WriteFAACStr wrote a "libfaac <version>" tag into the audio bitstream on frame 4. Remove it, for several reasons:

1. Not conformant. It emitted an ID_FIL element but never wrote the 4-bit extension_type that the spec requires at the start of every extension_payload() -- it just padded and dumped raw bytes. Decoders only cope because an unrecognized type is treated as generic fill. With HE-AAC (where an SBR payload shares the fill element) ffmpeg mis-accounts the bytes, reads the SBR element at the wrong offset, and drops a frame.

2. Wrong layer. Encoder identification belongs in the container, not the coded audio -- the MP4 `encoder`/`©too` atom, which is what ffmpeg's muxers, FDK-AAC and Apple's encoder use. Nothing relies on the in-band string (ffprobe surfaces nothing from it); it remains pure vanity.

3. Wastes budget. It spends ~120 bits on frame 4, perturbing that frame's rate control for no benefit.

4. History of trouble: the call site even carried a "faad2 complains about scalefactor error if we are writing FAAC String" workaround comment.

CBR / bit-reservoir padding is unaffected -- that is handled separately by WriteAACFillBits, which writes proper fill_elements and is untouched.