### PR TITLE
quantize: drop maxe*=gsize tonal scaling in bmask

### DIFF
--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -172,7 +172,6 @@ static void bmask(CoderInfo * __restrict coderInfo, faac_real * __restrict xr0, 
     bandenrg[sfb] = avge;
     /* Track peak magnitude to identify potential Huffman overflows. */
     bandmaxe[sfb] = FAAC_SQRT(maxe);
-    maxe *= gsize;
 
     avgenrg = (totenrg / last) * (end - start);
 


### PR DESCRIPTION
## Summary

`bmask()`'s tonal-masking term scaled the per-band peak energy by `gsize` (the number of grouped short windows). This one-line `maxe *= gsize;` dates to the 2017 *"initial windows grouping support"* commit (577c649): at that point `avge` changed from a single-window average to a `gsize`-summed total, and `maxe` (still a single-window peak) was multiplied by `gsize` to put it on the same scale.

The quantizer was later rewritten so the masking target uses `avge/avgenrg` and `maxe/avgenrg` as **ratios** against a separately-scaled `avgenrg` (`totenrg/last * (end-start)`). In that form the `gsize` multiply no longer matches anything — it just inflates the tonal term on grouped short blocks and quantizes transients too coarsely.

## Change

Delete the single line. It's self-contained: `gsize` is still used for the energy sums (`totenrg`, `enrgcnt`, per-band `avge`) and in `qlevel()`, so nothing else is affected. AAC-LC only path; no SBR/HE dependency.

## Measured impact (+0.019 avg MOS)

https://github.com/nschimme/faac/actions/runs/27898166269
<img width="698" height="998" alt="image" src="https://github.com/user-attachments/assets/e1794d48-b834-462c-8adc-affc4f135aed" />


Net positive across the corpus; gains concentrate in speech and standard/high-rate music, with the only regressions being statistical noise on the higher-bitrate music points.
