### PR TITLE
blockswitch: move detection to time domain

### DIFF
--- a/libfaac/blockswitch.c
+++ b/libfaac/blockswitch.c
@@ -15,136 +15,87 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- * $Id: psychkni.c,v 1.19 2012/03/01 18:34:17 knik Exp $
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
 
 #include "blockswitch.h"
 #include "coder.h"
-#include "fft.h"
 #include "util.h"
-#include "filtbank.h"
 #include <faac.h>
 
 typedef float psyfloat;
 
 typedef struct
 {
-  /* bandwidth */
-  int bandS;
-  int lastband;
-
-  /* band volumes */
-  psyfloat *engPrev[8];
-  psyfloat *eng[8];
-  psyfloat *engNext[8];
-  psyfloat *engNext2[8];
+  /* Per-sub-block high-pass energy, oldest to newest. The four-deep history
+     is what PsyCheckShort's +-2 sub-block lookahead reaches across. */
+  psyfloat engPrev[8];
+  psyfloat eng[8];
+  psyfloat engNext[8];
+  psyfloat engNext2[8];
 }
 psydata_t;
 
+/* The high-pass first difference (d[n]=x[n]-x[n-1]) de-weights bass, whose
+ * broadband energy would otherwise mask HF attacks and false-trigger short
+ * blocks on stationary music; what's left tracks the band where pre-echo is
+ * audible. A relative energy jump between sub-blocks past this threshold is a
+ * transient. */
+#define PSY_TD_THRESH ((faac_real)0.5)
 
-static void Hann(GlobalPsyInfo * gpsyInfo, faac_real *inSamples, int size)
-{
-  int i;
-
-  /* Applying Hann window */
-  if (size == BLOCK_LEN_LONG * 2)
-  {
-    for (i = 0; i < size; i++)
-      inSamples[i] *= gpsyInfo->hannWindow[i];
-  }
-  else
-  {
-    for (i = 0; i < size; i++)
-      inSamples[i] *= gpsyInfo->hannWindowS[i];
-  }
-}
-
-#define PRINTSTAT 0
-#if PRINTSTAT
-static struct {
-    int tot;
-    int s;
-} frames;
-#endif
-
-static void PsyCheckShort(PsyInfo * psyInfo, faac_real quality)
+static void PsyCheckShort(PsyInfo * psyInfo)
 {
   enum {PREVS = 2, NEXTS = 2};
-  psydata_t *psydata = psyInfo->data;
-  int lastband = psydata->lastband;
-  int firstband = 2;
-  int sfb, win;
-  psyfloat *lasteng;
+  psydata_t *psydata = (psydata_t *)psyInfo->data;
+  int win, haveprev = 0;
+  faac_real lasteng = 0.0;
 
   psyInfo->block_type = ONLY_LONG_WINDOW;
 
-  lasteng = NULL;
   for (win = 0; win < PREVS + 8 + NEXTS; win++)
   {
-      psyfloat *eng;
+      faac_real eng;
 
       if (win < PREVS)
-          eng = psydata->engPrev[win + 8 - PREVS];
+          eng = (faac_real)psydata->engPrev[win + 8 - PREVS];
       else if (win < (PREVS + 8))
-          eng = psydata->eng[win - PREVS];
+          eng = (faac_real)psydata->eng[win - PREVS];
       else
-          eng = psydata->engNext[win - PREVS - 8];
+          eng = (faac_real)psydata->engNext[win - PREVS - 8];
 
-      if (lasteng)
+      if (haveprev)
       {
-          faac_real toteng = 0.0;
-          faac_real volchg = 0.0;
+          faac_real toteng = (eng < lasteng) ? eng : lasteng;
+          faac_real volchg = FAAC_FABS(eng - lasteng);
 
-          for (sfb = firstband; sfb < lastband; sfb++)
-          {
-              toteng += (eng[sfb] < lasteng[sfb]) ? eng[sfb] : lasteng[sfb];
-              volchg += FAAC_FABS(eng[sfb] - lasteng[sfb]);
-          }
-
-          if ((volchg / toteng * quality) > 3.0)
+          /* Relying on IEEE divide: silence beside energy gives inf (fires
+             short on the onset/offset), two silent sub-blocks give 0/0=NaN
+             (compares false, stays long). */
+          if (volchg / toteng > PSY_TD_THRESH)
           {
               psyInfo->block_type = ONLY_SHORT_WINDOW;
               break;
           }
       }
       lasteng = eng;
+      haveprev = 1;
   }
-
-#if PRINTSTAT
-  frames.tot++;
-  if (psyInfo->block_type == ONLY_SHORT_WINDOW)
-      frames.s++;
-#endif
 }
 
 static void PsyInit(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo, unsigned int numChannels,
-		    unsigned int sampleRate, int *cb_width_long, int num_cb_long,
-		    int *cb_width_short, int num_cb_short)
+		    unsigned int sampleRate)
 {
   unsigned int channel;
-  int i, j, size;
+  int size;
 
-  gpsyInfo->hannWindow =
-    (faac_real *) AllocMemory(2 * BLOCK_LEN_LONG * sizeof(faac_real));
-  gpsyInfo->hannWindowS =
-    (faac_real *) AllocMemory(2 * BLOCK_LEN_SHORT * sizeof(faac_real));
-
-  for (i = 0; i < BLOCK_LEN_LONG * 2; i++)
-    gpsyInfo->hannWindow[i] = 0.5 * (1 - FAAC_COS(2.0 * M_PI * (i + 0.5) /
-					     (BLOCK_LEN_LONG * 2)));
-  for (i = 0; i < BLOCK_LEN_SHORT * 2; i++)
-    gpsyInfo->hannWindowS[i] = 0.5 * (1 - FAAC_COS(2.0 * M_PI * (i + 0.5) /
-					      (BLOCK_LEN_SHORT * 2)));
   gpsyInfo->sampleRate = (faac_real) sampleRate;
 
   for (channel = 0; channel < numChannels; channel++)
   {
-    psydata_t *psydata = AllocMemory(sizeof(psydata_t));
+    psydata_t *psydata = (psydata_t *)AllocMemory(sizeof(psydata_t));
+    memset(psydata, 0, sizeof(psydata_t));
     psyInfo[channel].data = psydata;
   }
 
@@ -160,38 +111,12 @@ static void PsyInit(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo, unsigned int nu
 
   size = BLOCK_LEN_SHORT;
   for (channel = 0; channel < numChannels; channel++)
-  {
-    psydata_t *psydata = psyInfo[channel].data;
-
     psyInfo[channel].sizeS = size;
-
-    for (j = 0; j < 8; j++)
-    {
-      psydata->engPrev[j] =
-            (psyfloat *) AllocMemory(NSFB_SHORT * sizeof(psyfloat));
-      memset(psydata->engPrev[j], 0, NSFB_SHORT * sizeof(psyfloat));
-      psydata->eng[j] =
-          (psyfloat *) AllocMemory(NSFB_SHORT * sizeof(psyfloat));
-      memset(psydata->eng[j], 0, NSFB_SHORT * sizeof(psyfloat));
-      psydata->engNext[j] =
-          (psyfloat *) AllocMemory(NSFB_SHORT * sizeof(psyfloat));
-      memset(psydata->engNext[j], 0, NSFB_SHORT * sizeof(psyfloat));
-      psydata->engNext2[j] =
-          (psyfloat *) AllocMemory(NSFB_SHORT * sizeof(psyfloat));
-      memset(psydata->engNext2[j], 0, NSFB_SHORT * sizeof(psyfloat));
-    }
-  }
 }
 
-static void PsyEnd(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo, unsigned int numChannels)
+static void PsyEnd(PsyInfo * psyInfo, unsigned int numChannels)
 {
   unsigned int channel;
-  int j;
-
-  if (gpsyInfo->hannWindow)
-    FreeMemory(gpsyInfo->hannWindow);
-  if (gpsyInfo->hannWindowS)
-    FreeMemory(gpsyInfo->hannWindowS);
 
   for (channel = 0; channel < numChannels; channel++)
   {
@@ -201,45 +126,17 @@ static void PsyEnd(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo, unsigned int num
 
   for (channel = 0; channel < numChannels; channel++)
   {
-    psydata_t *psydata = psyInfo[channel].data;
-
-    for (j = 0; j < 8; j++)
-    {
-        if (psydata->engPrev[j])
-            FreeMemory(psydata->engPrev[j]);
-        if (psydata->eng[j])
-            FreeMemory(psydata->eng[j]);
-        if (psydata->engNext[j])
-            FreeMemory(psydata->engNext[j]);
-        if (psydata->engNext2[j])
-            FreeMemory(psydata->engNext2[j]);
-    }
-  }
-
-  for (channel = 0; channel < numChannels; channel++)
-  {
     if (psyInfo[channel].data)
       FreeMemory(psyInfo[channel].data);
   }
-
-#if PRINTSTAT
-  printf("short frames: %d/%d (%.2f %%)\n", frames.s, frames.tot, 100.0*frames.s/frames.tot);
-#endif
 }
 
 /* Do psychoacoustical analysis */
-static void PsyCalculate(ChannelInfo * channelInfo, GlobalPsyInfo * gpsyInfo,
-			 PsyInfo * psyInfo, int *cb_width_long, int
-			 num_cb_long, int *cb_width_short,
-			 int num_cb_short, unsigned int numChannels,
-			 faac_real quality
+static void PsyCalculate(ChannelInfo * channelInfo, PsyInfo * psyInfo,
+			 unsigned int numChannels
 			)
 {
   unsigned int channel;
-
-  // limit switching threshold
-  if (quality < 0.4)
-      quality = 0.4;
 
   for (channel = 0; channel < numChannels; channel++)
   {
@@ -253,8 +150,8 @@ static void PsyCalculate(ChannelInfo * channelInfo, GlobalPsyInfo * gpsyInfo,
 	int leftChan = channel;
 	int rightChan = channelInfo[channel].paired_ch;
 
-	PsyCheckShort(&psyInfo[leftChan], quality);
-	PsyCheckShort(&psyInfo[rightChan], quality);
+	PsyCheckShort(&psyInfo[leftChan]);
+	PsyCheckShort(&psyInfo[rightChan]);
       }
       else if (channelInfo[channel].type == ELEMENT_LFE)
       {				/* LFE */
@@ -263,71 +160,41 @@ static void PsyCalculate(ChannelInfo * channelInfo, GlobalPsyInfo * gpsyInfo,
       }
       else if (channelInfo[channel].type == ELEMENT_SCE)
       {				/* SCE */
-	PsyCheckShort(&psyInfo[channel], quality);
+	PsyCheckShort(&psyInfo[channel]);
       }
     }
   }
 }
 
-static void PsyBufferUpdate( FFT_Tables *fft_tables, GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo,
-			    faac_real *newSamples, unsigned int bandwidth,
-			    int *cb_width_short, int num_cb_short)
+static void PsyBufferUpdate(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo,
+			    faac_real *newSamples)
 {
   int win;
   faac_real *transBuff = gpsyInfo->sharedWorkBuffLong;
-  faac_real *transBuffS = gpsyInfo->sharedWorkBuffShort;
-  psydata_t *psydata = psyInfo->data;
-  psyfloat *tmp;
-  int sfb;
-
-  psydata->bandS = psyInfo->sizeS * bandwidth * 2 / gpsyInfo->sampleRate;
+  psydata_t *psydata = (psydata_t *)psyInfo->data;
 
   memcpy(transBuff, psyInfo->prevSamples, psyInfo->size * sizeof(faac_real));
   memcpy(transBuff + psyInfo->size, newSamples, psyInfo->size * sizeof(faac_real));
 
+  // shift bufs
+  memcpy(psydata->engPrev, psydata->eng, 8 * sizeof(psyfloat));
+  memcpy(psydata->eng, psydata->engNext, 8 * sizeof(psyfloat));
+  memcpy(psydata->engNext, psydata->engNext2, 8 * sizeof(psyfloat));
+
   for (win = 0; win < 8; win++)
   {
-    int first = 0;
-    int last = 0;
+    /* seg[-1] is in bounds (seg starts >= 448 samples in), so the first
+     * difference carries across the sub-block boundary instead of resetting. */
+    faac_real *seg = transBuff + (win * BLOCK_LEN_SHORT) + (BLOCK_LEN_LONG - BLOCK_LEN_SHORT) / 2;
+    faac_real e = 0.0;
+    int l, n = 2 * psyInfo->sizeS;
 
-    memcpy(transBuffS, transBuff + (win * BLOCK_LEN_SHORT) + (BLOCK_LEN_LONG - BLOCK_LEN_SHORT) / 2,
-	   2 * psyInfo->sizeS * sizeof(faac_real));
-
-    Hann(gpsyInfo, transBuffS, 2 * psyInfo->sizeS);
-    MDCT( fft_tables, transBuffS, 2 * psyInfo->sizeS, gpsyInfo->mdctXr, gpsyInfo->mdctXi);
-
-    // shift bufs
-    tmp = psydata->engPrev[win];
-    psydata->engPrev[win] = psydata->eng[win];
-    psydata->eng[win] = psydata->engNext[win];
-    psydata->engNext[win] = psydata->engNext2[win];
-    psydata->engNext2[win] = tmp;
-
-    for (sfb = 0; sfb < num_cb_short; sfb++)
+    for (l = 0; l < n; l++)
     {
-      faac_real e;
-      int l;
-
-      first = last;
-      last = first + cb_width_short[sfb];
-
-      if (first < 1)
-          first = 1;
-
-      if (first >= psydata->bandS) // band out of range
-          break;
-
-      e = 0.0;
-      for (l = first; l < last; l++)
-          e += transBuffS[l] * transBuffS[l];
-
-      psydata->engNext2[win][sfb] = e;
+      faac_real d = seg[l] - seg[l - 1];
+      e += d * d;
     }
-    psydata->lastband = sfb;
-    for (; sfb < num_cb_short; sfb++)
-    {
-        psydata->engNext2[win][sfb] = 0;
-    }
+    psydata->engNext2[win] = (psyfloat)e;
   }
 
   memcpy(psyInfo->prevSamples, newSamples, psyInfo->size * sizeof(faac_real));

--- a/libfaac/blockswitch.h
+++ b/libfaac/blockswitch.h
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- * $Id: psych.h,v 1.15 2009/06/05 16:32:15 menno Exp $
  */
 
-#ifndef PSYCH_H
-#define PSYCH_H
+#ifndef BLOCKSWITCH_H
+#define BLOCKSWITCH_H
 
 #include "faac_real.h"
 
@@ -28,13 +26,8 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#ifndef M_PI
-#define M_PI        3.14159265358979323846
-#endif
-
 #include "coder.h"
 #include "channels.h"
-#include "fft.h"
 
 typedef struct {
 	int size;
@@ -51,34 +44,21 @@ typedef struct {
 typedef struct {
 	faac_real sampleRate;
 
-	/* Hann window */
-	faac_real *hannWindow;
-	faac_real *hannWindowS;
-
 	/* shared work buffers */
 	faac_real *sharedWorkBuffLong;  /* Used for 2048-sample windows (filtbank, psy, tns) */
-	faac_real *sharedWorkBuffShort; /* Used for 256-sample windows (psy) */
 	faac_real *mdctXr;              /* MDCT pre-twiddle work buffer (xr) */
 	faac_real *mdctXi;              /* MDCT pre-twiddle work buffer (xi) */
-
-        void *data;
 } GlobalPsyInfo;
 
 typedef struct 
 {
 void (*PsyInit) (GlobalPsyInfo *gpsyInfo, PsyInfo *psyInfo,
-		unsigned int numChannels, unsigned int sampleRate,
-		int *cb_width_long, int num_cb_long,
-		int *cb_width_short, int num_cb_short);
-void (*PsyEnd) (GlobalPsyInfo *gpsyInfo, PsyInfo *psyInfo,
+		unsigned int numChannels, unsigned int sampleRate);
+void (*PsyEnd) (PsyInfo *psyInfo, unsigned int numChannels);
+void (*PsyCalculate) (ChannelInfo *channelInfo, PsyInfo *psyInfo,
 		unsigned int numChannels);
-void (*PsyCalculate) (ChannelInfo *channelInfo, GlobalPsyInfo *gpsyInfo,
-		PsyInfo *psyInfo, int *cb_width_long, int num_cb_long,
-		int *cb_width_short, int num_cb_short,
-		unsigned int numChannels, faac_real quality);
-void (*PsyBufferUpdate) ( FFT_Tables *fft_tables, GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo,
-		faac_real *newSamples, unsigned int bandwidth,
-		int *cb_width_short, int num_cb_short);
+void (*PsyBufferUpdate) (GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo,
+		faac_real *newSamples);
 void (*BlockSwitch) (CoderInfo *coderInfo, PsyInfo *psyInfo,
 		unsigned int numChannels);
 } psymodel_t;
@@ -89,4 +69,4 @@ extern psymodel_t psymodel2;
 }
 #endif /* __cplusplus */
 
-#endif /* PSYCH_H */
+#endif /* BLOCKSWITCH_H */

--- a/libfaac/filtbank.c
+++ b/libfaac/filtbank.c
@@ -73,7 +73,6 @@ void FilterBankInit(faacEncStruct* hEncoder)
     CalculateKBDWindow(hEncoder->kbd_window_short, 6, BLOCK_LEN_SHORT*2);
 
     hEncoder->gpsyInfo.sharedWorkBuffLong = (faac_real*)AllocMemory(2*BLOCK_LEN_LONG*sizeof(faac_real));
-    hEncoder->gpsyInfo.sharedWorkBuffShort = (faac_real*)AllocMemory(2*BLOCK_LEN_SHORT*sizeof(faac_real));
     hEncoder->gpsyInfo.mdctXr = (faac_real*)AllocMemory((BLOCK_LEN_LONG / 2)*sizeof(faac_real));
     hEncoder->gpsyInfo.mdctXi = (faac_real*)AllocMemory((BLOCK_LEN_LONG / 2)*sizeof(faac_real));
 }
@@ -93,7 +92,6 @@ void FilterBankEnd(faacEncStruct* hEncoder)
     if (hEncoder->kbd_window_short) FreeMemory(hEncoder->kbd_window_short);
 
     if (hEncoder->gpsyInfo.sharedWorkBuffLong) FreeMemory(hEncoder->gpsyInfo.sharedWorkBuffLong);
-    if (hEncoder->gpsyInfo.sharedWorkBuffShort) FreeMemory(hEncoder->gpsyInfo.sharedWorkBuffShort);
     if (hEncoder->gpsyInfo.mdctXr) FreeMemory(hEncoder->gpsyInfo.mdctXr);
     if (hEncoder->gpsyInfo.mdctXi) FreeMemory(hEncoder->gpsyInfo.mdctXi);
 }

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
  */
 
 #include <stdio.h>
@@ -242,16 +241,14 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
               &hEncoder->aacquantCfg);
 
     // reset psymodel
-    hEncoder->psymodel->PsyEnd(&hEncoder->gpsyInfo, hEncoder->psyInfo, hEncoder->numChannels);
+    hEncoder->psymodel->PsyEnd(hEncoder->psyInfo, hEncoder->numChannels);
     if (config->psymodelidx >= (sizeof(psymodellist) / sizeof(psymodellist[0]) - 1))
 		config->psymodelidx = (sizeof(psymodellist) / sizeof(psymodellist[0])) - 2;
 
     hEncoder->config.psymodelidx = config->psymodelidx;
     hEncoder->psymodel = (psymodel_t *)psymodellist[hEncoder->config.psymodelidx].ptr;
     hEncoder->psymodel->PsyInit(&hEncoder->gpsyInfo, hEncoder->psyInfo, hEncoder->numChannels,
-			hEncoder->sampleRate, hEncoder->srInfo->cb_width_long,
-			hEncoder->srInfo->num_cb_long, hEncoder->srInfo->cb_width_short,
-			hEncoder->srInfo->num_cb_short);
+			hEncoder->sampleRate);
 
 	/* load channel_map */
 	for( i = 0; i < MAX_CHANNELS; i++ )
@@ -334,9 +331,7 @@ faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
 	fft_initialize( &hEncoder->fft_tables );
 
 	hEncoder->psymodel->PsyInit(&hEncoder->gpsyInfo, hEncoder->psyInfo, hEncoder->numChannels,
-        hEncoder->sampleRate, hEncoder->srInfo->cb_width_long,
-        hEncoder->srInfo->num_cb_long, hEncoder->srInfo->cb_width_short,
-        hEncoder->srInfo->num_cb_short);
+        hEncoder->sampleRate);
 
     FilterBankInit(hEncoder);
 
@@ -354,7 +349,7 @@ int FAACAPI faacEncClose(faacEncHandle hpEncoder)
     unsigned int channel;
 
     /* Deinitialize coder functions */
-    hEncoder->psymodel->PsyEnd(&hEncoder->gpsyInfo, hEncoder->psyInfo, hEncoder->numChannels);
+    hEncoder->psymodel->PsyEnd(hEncoder->psyInfo, hEncoder->numChannels);
 
     FilterBankEnd(hEncoder);
 
@@ -398,7 +393,6 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
     unsigned int useLfe = hEncoder->config.useLfe;
     unsigned int useTns = hEncoder->config.useTns;
     unsigned int jointmode = hEncoder->config.jointmode;
-    unsigned int bandWidth = hEncoder->config.bandWidth;
     unsigned int shortctl = hEncoder->config.shortctl;
     int maxqual = hEncoder->config.outputFormat ? MAXQUALADTS : MAXQUAL;
 
@@ -494,13 +488,9 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
 		if (channelInfo[channel].type != ELEMENT_LFE)
 		{
 			hEncoder->psymodel->PsyBufferUpdate(
-					&hEncoder->fft_tables,
 					&hEncoder->gpsyInfo,
 					&hEncoder->psyInfo[channel],
-					hEncoder->next3SampleBuff[channel],
-					bandWidth,
-					hEncoder->srInfo->cb_width_short,
-					hEncoder->srInfo->num_cb_short);
+					hEncoder->next3SampleBuff[channel]);
 		}
     }
 
@@ -508,10 +498,7 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
         return 0;
 
     /* Psychoacoustics */
-    hEncoder->psymodel->PsyCalculate(channelInfo, &hEncoder->gpsyInfo, hEncoder->psyInfo,
-        hEncoder->srInfo->cb_width_long, hEncoder->srInfo->num_cb_long,
-        hEncoder->srInfo->cb_width_short,
-        hEncoder->srInfo->num_cb_short, numChannels, (faac_real)hEncoder->aacquantCfg.quality / DEFQUAL);
+    hEncoder->psymodel->PsyCalculate(channelInfo, hEncoder->psyInfo, numChannels);
 
     hEncoder->psymodel->BlockSwitch(coderInfo, hEncoder->psyInfo, numChannels);
 


### PR DESCRIPTION
## Summary

Replaces the FFT/MDCT-based block-switch detector inherited from `psychkni.c` with a direct time-domain transient detector, and prunes the dead spectral plumbing that fell out with it. This further frees up CPU for quality changes like upcoming HE-AAC v1 support.

## Why the old detector was complex — and why it's now removable

This module is `psymodel2`, descended from a full psychoacoustic model where block switching was one output among many: it ran a short-window MDCT over all 8 sub-blocks of every channel, banded the spectrum into SFBs, and derived both masking data and the long/short decision from it.

That masking role has since moved entirely into the quantizer, which the code makes verifiable:

- `bmask()` (`quantize.c:111`) computes the masking target straight from the MDCT coefficients (its own tonality/noise weighting, `NOISETONE`).
- `BlocQuant()` (`quantize.c:340`) takes only `(CoderInfo, xr, AACQuantCfg)` — no `PsyInfo`. `grep -c 'PsyInfo\|GlobalPsyInfo\|psymodel\|blockswitch' quantize.c` → **0**.
- In the encode loop, `frame.c:503` (`BlockSwitch`) is the **last** read of `psyInfo`; everything downstream (FilterBank, TnsEncode, AACstereo, BlocQuant) consumes only `coderInfo[].block_type`.

So the entire psymodel's only surviving product is a single bit per channel per frame. `PsyCalculate` computes no thresholds. The short MDCTs, Hann windows, and per-SFB banding were a vestige — a full spectral transform computed and discarded to recover one bit.

## The new detector

A transient is a time-domain event. The high-pass first difference `d[n] = x[n] − x[n−1]` de-weights bass — whose broadband energy otherwise dominates the band sum, masking HF attacks (→ pre-echo) and false-triggering short blocks on stationary bass-heavy music. Summing that high-pass energy per 256-sample sub-block and comparing neighbours measures the abrupt rise directly: no window, no FFT, no banding. (IEEE divide handles the edges: energy beside silence → inf fires on the onset; two silent sub-blocks → 0/0 NaN stays long.)

## Results (benchmark CI)

- **Throughput +~20%** (runs span +18.9% to +25.6%). Biggest gains where block-switch is the largest pipeline slice: silence +25–28%, sine +19–23%, noise +16–22%, sweep +11–16%.
- **Avg MOS +0.036**, 354 significant wins — better long/short decisions, not just faster ones.
- **Library size −0.11%**, bitrate flat (+0.21%).
- Diff: **−238 / +70** lines; `psymodel_t` sheds 6 dead params; per-encoder loses 2 Hann tables + the short work buffer; per-channel energy drops from 32 heap arrays to 4 flat scalar arrays.

https://github.com/nschimme/faac/actions/runs/27926035715

<img width="759" height="1137" alt="image" src="https://github.com/user-attachments/assets/b5bda4d3-fd3b-4d73-9261-0aff00118490" />
