### PR TITLE
filtbank: reuse shared work buffer for MDCT scratch

### DIFF
--- a/libfaac/blockswitch.h
+++ b/libfaac/blockswitch.h
@@ -45,9 +45,7 @@ typedef struct {
 	faac_real sampleRate;
 
 	/* shared work buffers */
-	faac_real *sharedWorkBuffLong;  /* Used for 2048-sample windows (filtbank, psy, tns) */
-	faac_real *mdctXr;              /* MDCT pre-twiddle work buffer (xr) */
-	faac_real *mdctXi;              /* MDCT pre-twiddle work buffer (xi) */
+	faac_real *sharedWorkBuffLong;  /* Used for 2048-sample windows (filtbank, psy, tns, mdct) */
 } GlobalPsyInfo;
 
 typedef struct 

--- a/libfaac/filtbank.c
+++ b/libfaac/filtbank.c
@@ -73,8 +73,6 @@ void FilterBankInit(faacEncStruct* hEncoder)
     CalculateKBDWindow(hEncoder->kbd_window_short, 6, BLOCK_LEN_SHORT*2);
 
     hEncoder->gpsyInfo.sharedWorkBuffLong = (faac_real*)AllocMemory(2*BLOCK_LEN_LONG*sizeof(faac_real));
-    hEncoder->gpsyInfo.mdctXr = (faac_real*)AllocMemory((BLOCK_LEN_LONG / 2)*sizeof(faac_real));
-    hEncoder->gpsyInfo.mdctXi = (faac_real*)AllocMemory((BLOCK_LEN_LONG / 2)*sizeof(faac_real));
 }
 
 void FilterBankEnd(faacEncStruct* hEncoder)
@@ -92,8 +90,6 @@ void FilterBankEnd(faacEncStruct* hEncoder)
     if (hEncoder->kbd_window_short) FreeMemory(hEncoder->kbd_window_short);
 
     if (hEncoder->gpsyInfo.sharedWorkBuffLong) FreeMemory(hEncoder->gpsyInfo.sharedWorkBuffLong);
-    if (hEncoder->gpsyInfo.mdctXr) FreeMemory(hEncoder->gpsyInfo.mdctXr);
-    if (hEncoder->gpsyInfo.mdctXi) FreeMemory(hEncoder->gpsyInfo.mdctXi);
 }
 
 void FilterBank(faacEncStruct* hEncoder,
@@ -158,7 +154,7 @@ void FilterBank(faacEncStruct* hEncoder,
             p_out_mdct[i] = p_o_buf[i] * first_window[i];
             p_out_mdct[i+BLOCK_LEN_LONG] = p_o_buf[i+BLOCK_LEN_LONG] * second_window[BLOCK_LEN_LONG-i-1];
         }
-        MDCT( &hEncoder->fft_tables, p_out_mdct, 2*BLOCK_LEN_LONG, hEncoder->gpsyInfo.mdctXr, hEncoder->gpsyInfo.mdctXi );
+        MDCT( &hEncoder->fft_tables, p_out_mdct, 2*BLOCK_LEN_LONG, hEncoder->gpsyInfo.sharedWorkBuffLong );
         break;
 
     case LONG_SHORT_WINDOW :
@@ -168,7 +164,7 @@ void FilterBank(faacEncStruct* hEncoder,
         for ( i = 0 ; i < BLOCK_LEN_SHORT ; i++)
             p_out_mdct[i+BLOCK_LEN_LONG+NFLAT_LS] = p_o_buf[i+BLOCK_LEN_LONG+NFLAT_LS] * second_window[BLOCK_LEN_SHORT-i-1];
         SetMemory(p_out_mdct+BLOCK_LEN_LONG+NFLAT_LS+BLOCK_LEN_SHORT,0,NFLAT_LS*sizeof(faac_real));
-        MDCT( &hEncoder->fft_tables, p_out_mdct, 2*BLOCK_LEN_LONG, hEncoder->gpsyInfo.mdctXr, hEncoder->gpsyInfo.mdctXi );
+        MDCT( &hEncoder->fft_tables, p_out_mdct, 2*BLOCK_LEN_LONG, hEncoder->gpsyInfo.sharedWorkBuffLong );
         break;
 
     case SHORT_LONG_WINDOW :
@@ -178,7 +174,7 @@ void FilterBank(faacEncStruct* hEncoder,
         memcpy(p_out_mdct+NFLAT_LS+BLOCK_LEN_SHORT,p_o_buf+NFLAT_LS+BLOCK_LEN_SHORT,NFLAT_LS*sizeof(faac_real));
         for ( i = 0 ; i < BLOCK_LEN_LONG ; i++)
             p_out_mdct[i+BLOCK_LEN_LONG] = p_o_buf[i+BLOCK_LEN_LONG] * second_window[BLOCK_LEN_LONG-i-1];
-        MDCT( &hEncoder->fft_tables, p_out_mdct, 2*BLOCK_LEN_LONG, hEncoder->gpsyInfo.mdctXr, hEncoder->gpsyInfo.mdctXi );
+        MDCT( &hEncoder->fft_tables, p_out_mdct, 2*BLOCK_LEN_LONG, hEncoder->gpsyInfo.sharedWorkBuffLong );
         break;
 
     case ONLY_SHORT_WINDOW :
@@ -188,7 +184,7 @@ void FilterBank(faacEncStruct* hEncoder,
                 p_out_mdct[i] = p_o_buf[i] * first_window[i];
                 p_out_mdct[i+BLOCK_LEN_SHORT] = p_o_buf[i+BLOCK_LEN_SHORT] * second_window[BLOCK_LEN_SHORT-i-1];
             }
-            MDCT( &hEncoder->fft_tables, p_out_mdct, 2*BLOCK_LEN_SHORT, hEncoder->gpsyInfo.mdctXr, hEncoder->gpsyInfo.mdctXi );
+            MDCT( &hEncoder->fft_tables, p_out_mdct, 2*BLOCK_LEN_SHORT, hEncoder->gpsyInfo.sharedWorkBuffLong );
             p_out_mdct += BLOCK_LEN_SHORT;
             p_o_buf += BLOCK_LEN_SHORT;
             first_window = second_window;
@@ -244,7 +240,7 @@ static void CalculateKBDWindow(faac_real* win, faac_real alpha, int length)
     }
 }
 
-void MDCT( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *xr, faac_real *xi )
+void MDCT( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *work )
 {
     faac_real tempr, tempi, c, s, cold, cfreq, sfreq; /* temps for pre and post twiddle */
     faac_real freq = TWOPI / N;
@@ -254,6 +250,10 @@ void MDCT( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *xr, faac_r
     const int N2 = N >> 1;
     const int N4 = N >> 2;
     const int N8 = N >> 3;
+
+    /* Pre/post-twiddle FFT buffers carved from the shared work buffer */
+    faac_real *xr = work;
+    faac_real *xi = work + N4;
 
     /* Base pointers for address simplification */
     faac_real *base0 = data + N4;

--- a/libfaac/filtbank.h
+++ b/libfaac/filtbank.h
@@ -39,7 +39,7 @@ void			FilterBankInit		( faacEncStruct* hEncoder );
 
 void			FilterBankEnd		( faacEncStruct* hEncoder );
 
-void			MDCT				( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *xr, faac_real *xi );
+void			MDCT				( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *work );
 
 void			FilterBank( faacEncStruct* hEncoder,
 						CoderInfo *coderInfo,


### PR DESCRIPTION
Carve the MDCT pre/post-twiddle buffers (xr, xi) out of the existing gpsyInfo.sharedWorkBuffLong instead of using dedicated mdctXr/mdctXi allocations.

This removes two per-encoder heap allocations of BLOCK_LEN_LONG/2 (512) faac_real each, freeing 4-8 KiB per encoder depending on the build's precision.

https://github.com/nschimme/faac/actions/runs/28036175673

<img width="1326" height="756" alt="image" src="https://github.com/user-attachments/assets/8fcbc520-3f78-4499-aa3d-38c7dc5f88bc" />
