### PR TITLE
huffman: readability cleanup of the Huffman stage

### DIFF
--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -590,6 +590,12 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
 		}
 	}
 
+    /* Clear each channel's section state before AACstereo pre-loads intensity
+     * bands and BlocQuant resolves the rest. */
+    for (channel = 0; channel < numChannels; channel++)
+        if (channelInfo[channel].present)
+            ResetCoderSections(&coderInfo[channel]);
+
     AACstereo(coderInfo, channelInfo, hEncoder->freqBuff, numChannels,
               (faac_real)hEncoder->aacquantCfg.quality/DEFQUAL, jointmode, hEncoder->sampleRate);
 

--- a/libfaac/huff2.c
+++ b/libfaac/huff2.c
@@ -23,11 +23,16 @@
 #include "huffdata.h"
 #include "huff2.h"
 #include "bitstream.h"
+#include "util.h"
 
+/* Escape suffix for HCB_ESC: a magnitude |q| >= LAV_ESC is sent as the pair index
+ * LAV_ESC (emitted by the caller) plus this suffix - a unary prefix of `preflen`
+ * ones and a zero, then the low `preflen+4` bits of x. preflen counts how far x is
+ * past the 16-window, so the suffix is 2*preflen+5 bits. */
 static int escape(int x, int *code)
 {
-    int preflen = 0;
-    int base = 32;
+    int preflen;
+    int base;
 
     if (x > MAX_HUFF_ESC_VAL)
     {
@@ -35,19 +40,10 @@ static int escape(int x, int *code)
         return 0;
     }
 
-    *code = 0;
-    while (base <= x)
-    {
-        base <<= 1;
-        *code <<= 1;
-        *code |= 1;
-        preflen++;
-    }
-    base >>= 1;
+    preflen = 31 - CountLeadingZeros(x) - 4;
+    base = 1 << (preflen + 4);
 
-    // separator
-    *code <<= 1;
-
+    *code = (1 << (preflen + 1)) - 2; /* preflen 1s and a 0 */
     *code <<= (preflen + 4);
     *code |= (x - base);
 
@@ -56,6 +52,11 @@ static int escape(int x, int *code)
 
 #define arrlen(array) (sizeof(array) / sizeof(*array))
 
+/* Code `len` coeffs under book `bnum`, returning the bit count. coder == NULL only
+ * sizes (the per-band cost trials in huffbook); else also emits codewords to
+ * coder->s[]. Signed books fold sign into the index and emit book[idx].data
+ * verbatim; magnitude books look up the |coef| index then append one sign bit per
+ * nonzero coefficient. HCB_ESC additionally spills |q| >= LAV_ESC into escape(). */
 static int huffcode(int *qs /* quantized spectrum */,
                     int len,
                     int bnum,
@@ -79,12 +80,12 @@ static int huffcode(int *qs /* quantized spectrum */,
     book = hmap[bnum];
     switch (bnum)
     {
-    case 1:
-    case 2:
+    case HCB_1:
+    case HCB_2:
         for(ofs = 0; ofs < len; ofs += 4)
         {
             qp = qs+ofs;
-            idx = 27 * qp[0] + 9 * qp[1] + 3 * qp[2] + qp[3] + 40;
+            idx = DIM_S4*DIM_S4*DIM_S4 * qp[0] + DIM_S4*DIM_S4 * qp[1] + DIM_S4 * qp[2] + qp[3] + 40;
             if (idx < 0 || idx >= arrlen(book01))
             {
                 return -1;
@@ -99,12 +100,12 @@ static int huffcode(int *qs /* quantized spectrum */,
             bits += blen;
         }
         break;
-    case 3:
-    case 4:
+    case HCB_3:
+    case HCB_4:
         for(ofs = 0; ofs < len; ofs += 4)
         {
             qp = qs+ofs;
-            idx = 27 * abs(qp[0]) + 9 * abs(qp[1]) + 3 * abs(qp[2]) + abs(qp[3]);
+            idx = DIM_M4*DIM_M4*DIM_M4 * abs(qp[0]) + DIM_M4*DIM_M4 * abs(qp[1]) + DIM_M4 * abs(qp[2]) + abs(qp[3]);
             if (idx < 0 || idx >= arrlen(book03))
             {
                 return -1;
@@ -137,12 +138,12 @@ static int huffcode(int *qs /* quantized spectrum */,
             bits += blen;
         }
         break;
-    case 5:
-    case 6:
+    case HCB_5:
+    case HCB_6:
         for(ofs = 0; ofs < len; ofs += 2)
         {
             qp = qs+ofs;
-            idx = 9 * qp[0] + qp[1] + 40;
+            idx = DIM_S2 * qp[0] + qp[1] + 40;
             if (idx < 0 || idx >= arrlen(book05))
             {
                 return -1;
@@ -157,12 +158,12 @@ static int huffcode(int *qs /* quantized spectrum */,
             bits += blen;
         }
         break;
-    case 7:
-    case 8:
+    case HCB_7:
+    case HCB_8:
         for(ofs = 0; ofs < len; ofs += 2)
         {
             qp = qs+ofs;
-            idx = 8 * abs(qp[0]) + abs(qp[1]);
+            idx = DIM_M2_7 * abs(qp[0]) + abs(qp[1]);
             if (idx < 0 || idx >= arrlen(book07))
             {
                 return -1;
@@ -193,12 +194,12 @@ static int huffcode(int *qs /* quantized spectrum */,
             bits += blen;
         }
         break;
-    case 9:
-    case 10:
+    case HCB_9:
+    case HCB_10:
         for(ofs = 0; ofs < len; ofs += 2)
         {
             qp = qs+ofs;
-            idx = 13 * abs(qp[0]) + abs(qp[1]);
+            idx = DIM_M2_12 * abs(qp[0]) + abs(qp[1]);
             if (idx < 0 || idx >= arrlen(book09))
             {
                 return -1;
@@ -238,11 +239,11 @@ static int huffcode(int *qs /* quantized spectrum */,
 
             x0 = abs(qp[0]);
             x1 = abs(qp[1]);
-            if (x0 > 16)
-                x0 = 16;
-            if (x1 > 16)
-                x1 = 16;
-            idx = 17 * x0 + x1;
+            if (x0 > LAV_ESC)
+                x0 = LAV_ESC;
+            if (x1 > LAV_ESC)
+                x1 = LAV_ESC;
+            idx = DIM_ESC * x0 + x1;
             if (idx < 0 || idx >= arrlen(book11))
             {
                 return -1;
@@ -273,7 +274,7 @@ static int huffcode(int *qs /* quantized spectrum */,
             }
             bits += blen;
 
-            if (x0 >= 16)
+            if (x0 >= LAV_ESC)
             {
                 blen = escape(abs(qp[0]), &data);
                 if (coder)
@@ -284,7 +285,7 @@ static int huffcode(int *qs /* quantized spectrum */,
                 bits += blen;
             }
 
-            if (x1 >= 16)
+            if (x1 >= LAV_ESC)
             {
                 blen = escape(abs(qp[1]), &data);
                 if (coder)
@@ -308,6 +309,9 @@ static int huffcode(int *qs /* quantized spectrum */,
 }
 
 
+/* Per-band codebook selection: scan |maxq| to pick the lowest range-pair that can
+ * represent it, keep whichever book of the pair {base, base+1} codes the band
+ * shorter, emit it, and record the choice in coder->book[]. */
 int huffbook(CoderInfo *coder,
              int *qs /* quantized spectrum */,
              int len)
@@ -323,6 +327,7 @@ int huffbook(CoderInfo *coder,
             maxq = q;
     }
 
+    /* Size the band under both books of the covering pair; keep the cheaper. */
 #define BOOKMIN(n)bookmin=n;lenmin=huffcode(qs,len,bookmin,0);if(huffcode(qs,len,bookmin+1,0)<lenmin)bookmin++;
 
     if (maxq < 1)
@@ -330,25 +335,25 @@ int huffbook(CoderInfo *coder,
         bookmin = HCB_ZERO;
         lenmin = 0;
     }
-    else if (maxq < 2)
+    else if (maxq < LAV_1 + 1)
     {
-        BOOKMIN(1);
+        BOOKMIN(HCB_1);
     }
-    else if (maxq < 3)
+    else if (maxq < LAV_2 + 1)
     {
-        BOOKMIN(3);
+        BOOKMIN(HCB_3);
     }
-    else if (maxq < 5)
+    else if (maxq < LAV_4 + 1)
     {
-        BOOKMIN(5);
+        BOOKMIN(HCB_5);
     }
-    else if (maxq < 8)
+    else if (maxq < LAV_7 + 1)
     {
-        BOOKMIN(7);
+        BOOKMIN(HCB_7);
     }
-    else if (maxq < 13)
+    else if (maxq < LAV_12 + 1)
     {
-        BOOKMIN(9);
+        BOOKMIN(HCB_9);
     }
     else
     {
@@ -362,6 +367,9 @@ int huffbook(CoderInfo *coder,
     return 0;
 }
 
+/* Write (or size) the section layout: a 4-bit book + run length per maximal run of
+ * equal adjacent books. The count field is cntbits wide (5 long / 3 short), so a
+ * run past maxcnt splits into repeated full sections under the same book. */
 int writebooks(CoderInfo *coder, BitStream *stream, int write)
 {
     int bits = 0;
@@ -428,6 +436,10 @@ int writesf(CoderInfo *coder, BitStream *stream, int write)
     int lastpns;
     int initpns = 1;
 
+    /* Three independent DPCM chains share HCB_DELTA, each seeded so its first delta
+     * is self-contained: intensity positions from 0, scalefactors from global_gain
+     * (itself the first regular sf), PNS energies from global_gain - SF_PNS_OFFSET.
+     * The decoder rebuilds each by the same running sum, so deltas match. */
     lastsf = coder->global_gain;
     lastis = 0;
     lastpns = coder->global_gain - SF_PNS_OFFSET;
@@ -457,6 +469,9 @@ int writesf(CoderInfo *coder, BitStream *stream, int write)
 
             if (initpns)
             {
+                /* First PNS band has no prior energy to delta against, so the spec
+                 * sends a raw 9-bit value (diff + 256) instead of an HCB_DELTA code;
+                 * later PNS bands delta off this one. */
                 initpns = 0;
 
                 length = 9;

--- a/libfaac/huff2.h
+++ b/libfaac/huff2.h
@@ -25,14 +25,39 @@
 /* Huffman Codebooks */
 enum {
     HCB_ZERO = 0,
+    HCB_1, HCB_2, HCB_3, HCB_4, HCB_5,
+    HCB_6, HCB_7, HCB_8, HCB_9, HCB_10,
     HCB_ESC = 11,
+    HCB_DELTA = 12,   /* scalefactor-delta book (book12) */
     HCB_PNS = 13,
     HCB_INTENSITY2 = 14,
     HCB_INTENSITY = 15,
     HCB_NONE
 };
 
-/* Maximum value representable by Huffman Book 11 escape sequences.
+/* Spectral books come in range-pairs {base, base+1} sharing a tuple shape but a
+ * different codeword table; the pair's reach is its Largest Absolute Value. */
+enum {
+    LAV_1   = 1,    /* HCB_1, HCB_2  */
+    LAV_2   = 2,    /* HCB_3, HCB_4  */
+    LAV_4   = 4,    /* HCB_5, HCB_6  */
+    LAV_7   = 7,    /* HCB_7, HCB_8  */
+    LAV_12  = 12,   /* HCB_9, HCB_10 */
+    LAV_ESC = 16    /* HCB_ESC: |q| >= 16 spills into an escape suffix */
+};
+
+/* Radix of each book's positional codeword index (so the magic 27/9/13/17 read
+ * as the powers they are). 4-tuples pack as radix^3..^0, 2-tuples as radix^1..^0. */
+enum {
+    DIM_S4    = 3,  /* HCB_1, HCB_2:  signed 4-tuple, 3^4 = 81  */
+    DIM_M4    = 3,  /* HCB_3, HCB_4:  mag 4-tuple,    3^4 = 81  */
+    DIM_S2    = 9,  /* HCB_5, HCB_6:  signed 2-tuple, 9^2 = 81  */
+    DIM_M2_7  = 8,  /* HCB_7, HCB_8:  mag 2-tuple,    8^2 = 64  */
+    DIM_M2_12 = 13, /* HCB_9, HCB_10: mag 2-tuple,   13^2 = 169 */
+    DIM_ESC   = 17  /* HCB_ESC:       mag 2-tuple,   17^2 = 289 */
+};
+
+/* Maximum value representable by HCB_ESC escape sequences.
  * Values >= 8192 would cause bitstream overflow/sync loss. */
 #define MAX_HUFF_ESC_VAL 8191
 
@@ -52,7 +77,7 @@ enum {
 
 /**
  * Restrict scalefactor delta to the spec-defined +/- SF_DELTA range.
- * This ensures the delta remains valid for Book 12 Huffman encoding.
+ * This ensures the delta remains valid for HCB_DELTA Huffman encoding.
  */
 static inline int clamp_sf_diff(int diff)
 {

--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -336,6 +336,20 @@ static void qlevel(CoderInfo * __restrict coderInfo,
     }
 }
 
+/* Per-frame reset of a channel's section state: every band starts with no codebook
+ * (HCB_NONE) and zero scalefactor. AACstereo() then pre-loads intensity bands and
+ * qlevel() resolves the rest. */
+void ResetCoderSections(CoderInfo *coder)
+{
+    int band, nband = coder->groups.n * coder->sfbn;
+
+    for (band = 0; band < nband; band++)
+    {
+        coder->book[band] = HCB_NONE;
+        coder->sf[band] = 0;
+    }
+}
+
 int BlocQuant(CoderInfo * __restrict coder, faac_real * __restrict xr, AACQuantCfg *aacquantCfg)
 {
     faac_real bandlvl[MAX_SCFAC_BANDS];

--- a/libfaac/quantize.h
+++ b/libfaac/quantize.h
@@ -46,6 +46,7 @@ enum {
     MINQUAL = 10,
 };
 
+void ResetCoderSections(CoderInfo *coderInfo);
 int BlocQuant(CoderInfo *coderInfo, faac_real *xr, AACQuantCfg *aacquantCfg);
 void CalcBW(unsigned *bw, int rate, SR_INFO *sr, AACQuantCfg *aacquantCfg);
 void BlocGroup(faac_real *xr, CoderInfo *coderInfo, AACQuantCfg *aacquantCfg);

--- a/libfaac/stereo.c
+++ b/libfaac/stereo.c
@@ -551,26 +551,6 @@ void AACstereo(CoderInfo *coder,
 
     for (chn = 0; chn < maxchan; chn++)
     {
-        int group;
-        int bookcnt = 0;
-        CoderInfo *cp = coder + chn;
-
-        if (!channel[chn].present)
-            continue;
-
-        for (group = 0; group < cp->groups.n; group++)
-        {
-            int band;
-            for (band = 0; band < cp->sfbn; band++)
-            {
-                cp->book[bookcnt] = HCB_NONE;
-                cp->sf[bookcnt] = 0;
-                bookcnt++;
-            }
-        }
-    }
-    for (chn = 0; chn < maxchan; chn++)
-    {
         int rch;
         int cnt;
         int group;

--- a/libfaac/util.c
+++ b/libfaac/util.c
@@ -23,6 +23,10 @@
 #include "util.h"
 #include "coder.h"  // FRAME_LEN
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
 /* Returns the sample rate index */
 int GetSRIndex(unsigned int sampleRate)
 {
@@ -52,5 +56,27 @@ unsigned int MaxBitrate(unsigned long sampleRate)
 unsigned int MinBitrate()
 {
     return 8000;
+}
+
+/* Portable CLZ (returns 32 for x==0); lets escape() get a magnitude's bit-length
+ * in O(1) instead of the old shift-until-fits loop. */
+int CountLeadingZeros(unsigned int x)
+{
+    if (x == 0) return 32;
+#ifdef _MSC_VER
+    unsigned long leading_zero;
+    _BitScanReverse(&leading_zero, x);
+    return 31 - leading_zero;
+#elif defined(__GNUC__) || defined(__clang__)
+    return __builtin_clz(x);
+#else
+    int n = 0;
+    if (x <= 0x0000FFFF) { n += 16; x <<= 16; }
+    if (x <= 0x00FFFFFF) { n += 8; x <<= 8; }
+    if (x <= 0x0FFFFFFF) { n += 4; x <<= 4; }
+    if (x <= 0x3FFFFFFF) { n += 2; x <<= 2; }
+    if (x <= 0x7FFFFFFF) { n += 1; x <<= 1; }
+    return n;
+#endif
 }
 

--- a/libfaac/util.h
+++ b/libfaac/util.h
@@ -15,8 +15,6 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- * $Id: util.h,v 1.8 2003/12/20 04:32:48 stux Exp $
  */
 
 #ifndef UTIL_H
@@ -50,6 +48,7 @@ extern "C" {
 int GetSRIndex(unsigned int sampleRate);
 unsigned int MaxBitrate(unsigned long sampleRate);
 unsigned int MinBitrate();
+int CountLeadingZeros(unsigned int x);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- **Named codebook constants** — `HCB_1..HCB_10`/`HCB_DELTA`, `LAV_*` (range-pair reach), `DIM_*` (codeword-index radix) in huff2.h, replacing the magic `27/9/13/17/16` in `huffcode`/`huffbook`.
- **escape() via CountLeadingZeros** — replaces the shift-until-fits loop with an O(1) bit-length (new portable helper in util.c). Byte-identical, marginally faster.
- **ResetCoderSections** — extract the per-frame `book[]=HCB_NONE; sf[]=0` reset out of `AACstereo` into quantize.c, called per present channel from frame.c.
- **why-comments** on escape/huffcode/huffbook/writebooks/writesf; drop the util.h `$Id` line.

## Verification
https://github.com/nschimme/faac/actions/runs/27991621532

<img width="654" height="422" alt="image" src="https://github.com/user-attachments/assets/01301fab-3433-4620-b068-445447edb632" />
