### PR TITLE
huffman: refactor hcode32_t to use bit-fields

### DIFF
--- a/libfaac/huffdata.h
+++ b/libfaac/huffdata.h
@@ -28,8 +28,8 @@ typedef struct {
 } hcode16_t;
 
 typedef struct {
-    const uint32_t len;
-    const uint32_t data;
+    const uint32_t len  : 8;    /* lengths <= 19        */
+    const uint32_t data : 24;   /* codes are <= 19 bits */
 } hcode32_t;
 
 extern hcode16_t book01[81];


### PR DESCRIPTION
Updated hcode32_t structure to pack len and data from 8 B to 4 B. The compiler folds the layout, so every { len, data } literal in huffdata.c is unchanged for book12.

### Motivation
Shrinks the library size slightly

<img width="590" height="452" alt="image" src="https://github.com/user-attachments/assets/8335aa85-7a7c-4926-8190-7f7e0acd007b" />


https://github.com/nschimme/faac/actions/runs/28121036729