### PR TITLE
stereo: optimize IS-gate sqrt and sfcnt increment

### DIFF
--- a/libfaac/stereo.c
+++ b/libfaac/stereo.c
@@ -68,7 +68,7 @@ static inline void apply_ms(faac_real * restrict sl0, faac_real * restrict sr0,
 
 static inline void apply_is(faac_real * restrict sl0, faac_real * restrict sr0,
                             int start, int len, int wstart, int wend,
-                            int in_phase, faac_real vfix, int zero_sr)
+                            int in_phase, faac_real vfix)
 {
     faac_real * restrict sl_out = sl0 + wstart * BLOCK_LEN_SHORT + start;
     faac_real * restrict sr_out = sr0 + wstart * BLOCK_LEN_SHORT + start;
@@ -79,17 +79,19 @@ static inline void apply_is(faac_real * restrict sl0, faac_real * restrict sr0,
         int l;
         if (in_phase)
         {
-            if (zero_sr)
-                for (l = 0; l < len; l++) { sl_out[l] = (sl_out[l] + sr_out[l]) * vfix; sr_out[l] = 0.0; }
-            else
-                for (l = 0; l < len; l++) { sl_out[l] = (sl_out[l] + sr_out[l]) * vfix; }
+            for (l = 0; l < len; l++)
+            {
+                sl_out[l] = (sl_out[l] + sr_out[l]) * vfix;
+                sr_out[l] = 0.0;
+            }
         }
         else
         {
-            if (zero_sr)
-                for (l = 0; l < len; l++) { sl_out[l] = (sl_out[l] - sr_out[l]) * vfix; sr_out[l] = 0.0; }
-            else
-                for (l = 0; l < len; l++) { sl_out[l] = (sl_out[l] - sr_out[l]) * vfix; }
+            for (l = 0; l < len; l++)
+            {
+                sl_out[l] = (sl_out[l] - sr_out[l]) * vfix;
+                sr_out[l] = 0.0;
+            }
         }
         sl_out += BLOCK_LEN_SHORT;
         sr_out += BLOCK_LEN_SHORT;
@@ -120,10 +122,7 @@ static void stereo(CoderInfo * restrict cl, CoderInfo * restrict cr,
     else
         sfmin = 8;
 
-    for (sfb = 0; sfb < sfmin; sfb++)
-    {
-        (*sfcnt)++;
-    }
+    *sfcnt += sfmin;
 
     for (sfb = sfmin; sfb < cl->sfbn; sfb++)
     {
@@ -163,19 +162,19 @@ static void stereo(CoderInfo * restrict cl, CoderInfo * restrict cr,
         if (enrgs < 0.0) enrgs = 0.0;
         if (enrgd < 0.0) enrgd = 0.0;
 
-        /* IS pays off when one phase collapses most energy into a single
-         * channel: gate on (sqrt(L)+sqrt(R))^2 scaled by phthr */
-        ethr = FAAC_SQRT(enrgl) + FAAC_SQRT(enrgr);
-        ethr *= ethr;
-        ethr *= phthr;
+        /* Skip completely silent bands first */
         efix = enrgl + enrgr;
-        /* Skip completely silent bands: efix==0 makes ethr==0 so IS would
-         * trigger spuriously, and vfix=sqrt(0/0) would be NaN. */
         if (efix <= 0.0)
         {
             (*sfcnt)++;
             continue;
         }
+
+        /* IS pays off when one phase collapses most energy into a single
+         * channel: gate on (sqrt(L)+sqrt(R))^2 scaled by phthr */
+        ethr = FAAC_SQRT(enrgl) + FAAC_SQRT(enrgr);
+        ethr *= ethr;
+        ethr *= phthr;
         /* in-phase (l+r) vs out-of-phase (l-r); vfix renormalises the kept
          * channel so its energy matches the original L+R total */
         if (enrgs >= ethr)
@@ -221,10 +220,10 @@ static void stereo(CoderInfo * restrict cl, CoderInfo * restrict cr,
             cr->sf[*sfcnt] = -pan;
             cr->book[*sfcnt] = hcb;
 
-            /* JOINT_IS leaves the right channel intact; the intensity
-             * codebook marks the band, so its spectrum is not coded. */
+            /* the intensity codebook marks the band, so the right channel
+             * spectrum is not coded; apply_is zeroes it to be safe. */
             apply_is(sl0, sr0, start, len, wstart, wend,
-                     hcb == HCB_INTENSITY, vfix, /*zero_sr=*/0);
+                     hcb == HCB_INTENSITY, vfix);
         }
         (*sfcnt)++;
     }
@@ -438,7 +437,7 @@ static int mixed(CoderInfo * restrict cl, CoderInfo * restrict cr, ChannelInfo *
                 /* drop the right channel: the codebook + intensity position
                  * carry the band, so its spectrum is not coded */
                 apply_is(sl0, sr0, start, len, wstart, wend,
-                         hcb == HCB_INTENSITY, vfix, /*zero_sr=*/1);
+                         hcb == HCB_INTENSITY, vfix);
                 continue;
             }
         }


### PR DESCRIPTION
### Overview
This PR optimizes and cleans up the joint-stereo coding implementation in `stereo.c`. It reduces computational waste by skipping expensive square root calculations on silent bands, optimizes loop increments, removes a redundant function parameter, and unifies right-channel zeroing logic to fix an internal inconsistency between `stereo()` and `mixed()`.

### Key Changes

#### 1. Performance: Early Exit for Silent Bands
* **What:** Moved the `efix <= 0.0` check *before* the `ethr` calculation.
* **Why:** The previous layout calculated `FAAC_SQRT(enrgl) + FAAC_SQRT(enrgr)` even for dead silent bands. Moving this up eliminates two expensive square root operations per silent scale-factor band (SFB).

#### 2. Code Cleanup: Direct Pointer Accumulation
* **What:** Replaced the initialization loop `for (sfb = 0; sfb < sfmin; sfb++) { (*sfcnt)++; }` with a direct addition: `*sfcnt += sfmin;`.
* **Why:** Cleaner, more concise code that eliminates basic loop overhead.

#### 3. Refactoring & Bug Fix: Unifying `apply_is` Behavior
* **What:** Removed the `zero_sr` flag from `apply_is()`. The function now *always* zeroes out the right channel (`sr_out[l] = 0.0;`) when Intensity Stereo is applied.
* **Why:** * Previously, pure Intensity Stereo (`stereo()`) passed `zero_sr=0` (leaving the right channel data intact in memory), while `mixed()` passed `zero_sr=1` (zeroing it out). 
  * Leaving the right channel un-zeroed in `stereo()` was misleading and messy. Since the right channel's intensity codebook marks the band, its spectrum isn't coded anyway. Explicitly zeroing it out in both modes ensures memory safety, clears residual data, and simplifies the loop structure inside `apply_is()`.
  * Updated the inline comments to accurately reflect this reality.

---

### Verification & Testing
https://github.com/nschimme/faac/actions/runs/28182069920

<img width="1165" height="1476" alt="image" src="https://github.com/user-attachments/assets/35941c2f-03a1-414c-9dc0-fee60d2704d1" />
