### PR TITLE
fix lookahead regression causing pre-echo and stereo issues

### DIFF
--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -337,6 +337,8 @@ faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
         hEncoder->coderInfo[channel].groups.len[0] = 1;
 
         hEncoder->sampleBuff[channel] = NULL;
+        hEncoder->nextSampleBuff[channel] = NULL;
+        hEncoder->next2SampleBuff[channel] = NULL;
     }
 
     /* Initialize coder functions */
@@ -433,6 +435,10 @@ int FAACAPI faacEncClose(faacEncHandle hpEncoder)
 	{
 		if (hEncoder->sampleBuff[channel])
 			FreeMemory(hEncoder->sampleBuff[channel]);
+		if (hEncoder->nextSampleBuff[channel])
+			FreeMemory (hEncoder->nextSampleBuff[channel]);
+		if (hEncoder->next2SampleBuff[channel])
+			FreeMemory (hEncoder->next2SampleBuff[channel]);
 		if (hEncoder->next3SampleBuff[channel])
 			FreeMemory (hEncoder->next3SampleBuff[channel]);
 		if (hEncoder->inputFifo[channel])
@@ -519,7 +525,9 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
 
 		tmp = hEncoder->sampleBuff[channel];
 
-		hEncoder->sampleBuff[channel]	= hEncoder->next3SampleBuff[channel];
+		hEncoder->sampleBuff[channel]		= hEncoder->nextSampleBuff[channel];
+		hEncoder->nextSampleBuff[channel]	= hEncoder->next2SampleBuff[channel];
+		hEncoder->next2SampleBuff[channel]	= hEncoder->next3SampleBuff[channel];
 		hEncoder->next3SampleBuff[channel]	= tmp;
 
         if (realPerCh == 0)

--- a/libfaac/frame.h
+++ b/libfaac/frame.h
@@ -58,6 +58,8 @@ typedef struct {
 
     /* sample buffers of current next and next next frame*/
     faac_real *sampleBuff[MAX_CHANNELS];
+    faac_real *nextSampleBuff[MAX_CHANNELS];
+    faac_real *next2SampleBuff[MAX_CHANNELS];
     faac_real *next3SampleBuff[MAX_CHANNELS];
 
     /* Filterbank buffers */


### PR DESCRIPTION
Commit e9c62ad90d2c10418650e062cf3288a5f072d3d5 accidentally truncated the encoder's lookahead depth to an effective 1-frame delay by bypassing intermediate buffers and assigning next3SampleBuff directly to sampleBuff.

This architectural mismatch decouples the 4-frame energy history in PsyBufferUpdate from the active audio buffers. As a result, the psychoacoustic model misaligns or misses window sequence transitions (LONG_START, EIGHT_SHORT, LONG_STOP), causing audible pre-echo artifacts and breaking stereo coherence.

Restore the proper 4-frame deep FIFO pipeline by reintroducing nextSampleBuff and next2SampleBuff into the pointer rotation logic inside faacEncEncode. This fixes the transient lookahead depth via O(1) pointer swaps, resolving the window sequencing flaws and restoring joint stereo efficiency without altering memory allocation overhead.

## Benchmark
Stereo Coherence Error is now `0.0208` compared to the  previous `0.0953` (and even beating FFmpeg's `0.0285`!!)

https://github.com/nschimme/faac/actions/runs/28303969189

<img width="646" height="932" alt="image" src="https://github.com/user-attachments/assets/f0258f0a-9995-4960-bc2c-58e099acdcbc" />

