### PR TITLE
simplify encoder lookahead to a unified FIFO and energy timeline

### DIFF
--- a/libfaac/blockswitch.c
+++ b/libfaac/blockswitch.c
@@ -27,14 +27,20 @@
 
 typedef float psyfloat;
 
+/* The high-pass energy timeline is held as one contiguous array of per-sub-block
+   energies rather than separate prev/curr/next arrays, so PsyCheckShort's +-2
+   sub-block lookahead is a single sliding index instead of three-way stitching.
+   It holds three 2-frame energy windows back to back: PREV, CUR and the one
+   lookahead window NEXT. (Energy windows are 2 frames wide, which is why a single
+   "next" window consumes the two-frames-ahead sample slot in the input FIFO.) */
+#define SUBBLOCKS_PER_FRAME 8
+#define ENG_WIN_PREV (0 * SUBBLOCKS_PER_FRAME)
+#define ENG_WIN_CUR  (1 * SUBBLOCKS_PER_FRAME)
+#define ENG_WIN_NEXT (2 * SUBBLOCKS_PER_FRAME)
+
 typedef struct
 {
-  /* Per-sub-block high-pass energy, oldest to newest. The four-deep history
-     is what PsyCheckShort's +-2 sub-block lookahead reaches across. */
-  psyfloat engPrev[8];
-  psyfloat eng[8];
-  psyfloat engNext[8];
-  psyfloat engNext2[8];
+  psyfloat eng[3 * SUBBLOCKS_PER_FRAME];
 }
 psydata_t;
 
@@ -49,38 +55,27 @@ static void PsyCheckShort(PsyInfo * psyInfo)
 {
   enum {PREVS = 2, NEXTS = 2};
   psydata_t *psydata = (psydata_t *)psyInfo->data;
-  int win, haveprev = 0;
-  faac_real lasteng = 0.0;
+  int win;
+  faac_real lasteng = (faac_real)psydata->eng[ENG_WIN_CUR - PREVS]; /* start at PREVS before current */
 
   psyInfo->block_type = ONLY_LONG_WINDOW;
 
-  for (win = 0; win < PREVS + 8 + NEXTS; win++)
+  /* Search for transients across the current frame and its immediate temporal context.
+     The search range is [curr-2, curr+9]. */
+  for (win = 1; win < PREVS + SUBBLOCKS_PER_FRAME + NEXTS; win++)
   {
-      faac_real eng;
+      faac_real eng = (faac_real)psydata->eng[ENG_WIN_CUR - PREVS + win];
 
-      if (win < PREVS)
-          eng = (faac_real)psydata->engPrev[win + 8 - PREVS];
-      else if (win < (PREVS + 8))
-          eng = (faac_real)psydata->eng[win - PREVS];
-      else
-          eng = (faac_real)psydata->engNext[win - PREVS - 8];
+      faac_real toteng = (eng < lasteng) ? eng : lasteng;
+      faac_real volchg = FAAC_FABS(eng - lasteng);
 
-      if (haveprev)
+      /* Relative energy jump indicates a transient. IEEE divide handles silence cases. */
+      if (volchg / toteng > PSY_TD_THRESH)
       {
-          faac_real toteng = (eng < lasteng) ? eng : lasteng;
-          faac_real volchg = FAAC_FABS(eng - lasteng);
-
-          /* Relying on IEEE divide: silence beside energy gives inf (fires
-             short on the onset/offset), two silent sub-blocks give 0/0=NaN
-             (compares false, stays long). */
-          if (volchg / toteng > PSY_TD_THRESH)
-          {
-              psyInfo->block_type = ONLY_SHORT_WINDOW;
-              break;
-          }
+          psyInfo->block_type = ONLY_SHORT_WINDOW;
+          break;
       }
       lasteng = eng;
-      haveprev = 1;
   }
 }
 
@@ -103,10 +98,6 @@ static void PsyInit(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo, unsigned int nu
   for (channel = 0; channel < numChannels; channel++)
   {
     psyInfo[channel].size = size;
-
-    psyInfo[channel].prevSamples =
-      (faac_real *) AllocMemory(size * sizeof(faac_real));
-    memset(psyInfo[channel].prevSamples, 0, size * sizeof(faac_real));
   }
 
   size = BLOCK_LEN_SHORT;
@@ -117,12 +108,6 @@ static void PsyInit(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo, unsigned int nu
 static void PsyEnd(PsyInfo * psyInfo, unsigned int numChannels)
 {
   unsigned int channel;
-
-  for (channel = 0; channel < numChannels; channel++)
-  {
-    if (psyInfo[channel].prevSamples)
-      FreeMemory(psyInfo[channel].prevSamples);
-  }
 
   for (channel = 0; channel < numChannels; channel++)
   {
@@ -167,21 +152,23 @@ static void PsyCalculate(ChannelInfo * channelInfo, PsyInfo * psyInfo,
 }
 
 static void PsyBufferUpdate(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo,
-			    faac_real *newSamples)
+                            faac_real * restrict p_lookahead1,
+                            faac_real * restrict p_lookahead2)
 {
   int win;
-  faac_real *transBuff = gpsyInfo->sharedWorkBuffLong;
+  faac_real * restrict transBuff = gpsyInfo->sharedWorkBuffLong;
   psydata_t *psydata = (psydata_t *)psyInfo->data;
 
-  memcpy(transBuff, psyInfo->prevSamples, psyInfo->size * sizeof(faac_real));
-  memcpy(transBuff + psyInfo->size, newSamples, psyInfo->size * sizeof(faac_real));
+  /* Shift the energy windows down by one frame: PREV<-CUR, CUR<-NEXT, freeing
+     the NEXT region for the freshly-computed lookahead window below. */
+  memmove(psydata->eng, psydata->eng + SUBBLOCKS_PER_FRAME,
+          2 * SUBBLOCKS_PER_FRAME * sizeof(psyfloat));
 
-  // shift bufs
-  memcpy(psydata->engPrev, psydata->eng, 8 * sizeof(psyfloat));
-  memcpy(psydata->eng, psydata->engNext, 8 * sizeof(psyfloat));
-  memcpy(psydata->engNext, psydata->engNext2, 8 * sizeof(psyfloat));
+  /* Assembly of the newest 2048-sample window for energy analysis */
+  memcpy(transBuff, p_lookahead1, BLOCK_LEN_LONG * sizeof(faac_real));
+  memcpy(transBuff + BLOCK_LEN_LONG, p_lookahead2, BLOCK_LEN_LONG * sizeof(faac_real));
 
-  for (win = 0; win < 8; win++)
+  for (win = 0; win < SUBBLOCKS_PER_FRAME; win++)
   {
     /* seg[-1] is in bounds (seg starts >= 448 samples in), so the first
      * difference carries across the sub-block boundary instead of resetting. */
@@ -194,10 +181,8 @@ static void PsyBufferUpdate(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo,
       faac_real d = seg[l] - seg[l - 1];
       e += d * d;
     }
-    psydata->engNext2[win] = (psyfloat)e;
+    psydata->eng[ENG_WIN_NEXT + win] = (psyfloat)e;
   }
-
-  memcpy(psyInfo->prevSamples, newSamples, psyInfo->size * sizeof(faac_real));
 }
 
 static void BlockSwitch(CoderInfo * coderInfo, PsyInfo * psyInfo, unsigned int numChannels)

--- a/libfaac/blockswitch.h
+++ b/libfaac/blockswitch.h
@@ -33,9 +33,6 @@ typedef struct {
 	int size;
 	int sizeS;
 
-	/* Previous input samples */
-	faac_real *prevSamples;
-
 	int block_type;
 
         void *data;
@@ -56,7 +53,8 @@ void (*PsyEnd) (PsyInfo *psyInfo, unsigned int numChannels);
 void (*PsyCalculate) (ChannelInfo *channelInfo, PsyInfo *psyInfo,
 		unsigned int numChannels);
 void (*PsyBufferUpdate) (GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo,
-		faac_real *newSamples);
+		faac_real * restrict p_lookahead1,
+		faac_real * restrict p_lookahead2);
 void (*BlockSwitch) (CoderInfo *coderInfo, PsyInfo *psyInfo,
 		unsigned int numChannels);
 } psymodel_t;

--- a/libfaac/filtbank.c
+++ b/libfaac/filtbank.c
@@ -55,8 +55,6 @@ void FilterBankInit(faacEncStruct* hEncoder)
 
     for (channel = 0; channel < hEncoder->numChannels; channel++) {
         hEncoder->freqBuff[channel] = (faac_real*)AllocMemory(2*FRAME_LEN*sizeof(faac_real));
-        hEncoder->overlapBuff[channel] = (faac_real*)AllocMemory(FRAME_LEN*sizeof(faac_real));
-        SetMemory(hEncoder->overlapBuff[channel], 0, FRAME_LEN*sizeof(faac_real));
     }
 
     hEncoder->sin_window_long = (faac_real*)AllocMemory(BLOCK_LEN_LONG*sizeof(faac_real));
@@ -81,7 +79,6 @@ void FilterBankEnd(faacEncStruct* hEncoder)
 
     for (channel = 0; channel < hEncoder->numChannels; channel++) {
         if (hEncoder->freqBuff[channel]) FreeMemory(hEncoder->freqBuff[channel]);
-        if (hEncoder->overlapBuff[channel]) FreeMemory(hEncoder->overlapBuff[channel]);
     }
 
     if (hEncoder->sin_window_long) FreeMemory(hEncoder->sin_window_long);
@@ -94,22 +91,20 @@ void FilterBankEnd(faacEncStruct* hEncoder)
 
 void FilterBank(faacEncStruct* hEncoder,
                 CoderInfo *coderInfo,
-                faac_real *p_in_data,
-                faac_real *p_out_mdct,
-                faac_real *p_overlap)
+                faac_real * restrict p_prev_data,
+                faac_real * restrict p_in_data,
+                faac_real * restrict p_out_mdct)
 {
     faac_real *p_o_buf, *first_window, *second_window;
-    faac_real *transf_buf;
+    faac_real * restrict transf_buf;
     int k, i;
     int block_type = coderInfo->block_type;
 
     transf_buf = hEncoder->gpsyInfo.sharedWorkBuffLong;
 
-    /* create / shift old values */
-    /* We use p_overlap here as buffer holding the last frame time signal*/
-    memcpy(transf_buf, p_overlap, BLOCK_LEN_LONG*sizeof(faac_real));
+    /* Assembly of the 2048-sample window from consecutive frames in the FIFO rotation */
+    memcpy(transf_buf, p_prev_data, BLOCK_LEN_LONG*sizeof(faac_real));
     memcpy(transf_buf+BLOCK_LEN_LONG, p_in_data, BLOCK_LEN_LONG*sizeof(faac_real));
-    memcpy(p_overlap, p_in_data, BLOCK_LEN_LONG*sizeof(faac_real));
 
     /*  Window shape processing */
     switch (coderInfo->prev_window_shape) {

--- a/libfaac/filtbank.h
+++ b/libfaac/filtbank.h
@@ -43,9 +43,9 @@ void			MDCT				( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *work
 
 void			FilterBank( faacEncStruct* hEncoder,
 						CoderInfo *coderInfo,
-						faac_real *p_in_data,
-						faac_real *p_out_mdct,
-						faac_real *p_overlap );
+						faac_real * restrict p_prev_data,
+						faac_real * restrict p_in_data,
+						faac_real * restrict p_out_mdct);
 
 
 #ifdef __cplusplus

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -330,15 +330,17 @@ faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
 
     for (channel = 0; channel < numChannels; channel++)
 	{
+        int buf;
         hEncoder->coderInfo[channel].prev_window_shape = SINE_WINDOW;
         hEncoder->coderInfo[channel].window_shape = SINE_WINDOW;
         hEncoder->coderInfo[channel].block_type = ONLY_LONG_WINDOW;
         hEncoder->coderInfo[channel].groups.n = 1;
         hEncoder->coderInfo[channel].groups.len[0] = 1;
 
-        hEncoder->sampleBuff[channel] = NULL;
-        hEncoder->nextSampleBuff[channel] = NULL;
-        hEncoder->next2SampleBuff[channel] = NULL;
+        for (buf = 0; buf < 4; buf++) {
+            hEncoder->audioFIFO[channel][buf] = (faac_real*)AllocMemory(FRAME_LEN*sizeof(faac_real));
+            memset(hEncoder->audioFIFO[channel][buf], 0, FRAME_LEN*sizeof(faac_real));
+        }
     }
 
     /* Initialize coder functions */
@@ -433,14 +435,12 @@ int FAACAPI faacEncClose(faacEncHandle hpEncoder)
     /* Free remaining buffer memory */
     for (channel = 0; channel < hEncoder->numChannels; channel++)
 	{
-		if (hEncoder->sampleBuff[channel])
-			FreeMemory(hEncoder->sampleBuff[channel]);
-		if (hEncoder->nextSampleBuff[channel])
-			FreeMemory (hEncoder->nextSampleBuff[channel]);
-		if (hEncoder->next2SampleBuff[channel])
-			FreeMemory (hEncoder->next2SampleBuff[channel]);
-		if (hEncoder->next3SampleBuff[channel])
-			FreeMemory (hEncoder->next3SampleBuff[channel]);
+        int buf;
+        for (buf = 0; buf < 4; buf++) {
+            if (hEncoder->audioFIFO[channel][buf]) {
+                FreeMemory(hEncoder->audioFIFO[channel][buf]);
+            }
+        }
 		if (hEncoder->inputFifo[channel])
 			FreeMemory (hEncoder->inputFifo[channel]);
     }
@@ -462,7 +462,7 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
                           )
 {
     faacEncStruct* hEncoder = (faacEncStruct*)hpEncoder;
-    unsigned int channel, i;
+    unsigned int channel;
     int sb, frameBytes;
     unsigned int offset;
     BitStream *bitStream; /* bitstream used for writing the frame to */
@@ -506,9 +506,9 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
     if (realPerCh == 0)
         hEncoder->flushFrame++;
 
-    /* After 4 flush frames all samples have been encoded,
+    /* After LOOKAHEAD_DEPTH + 1 flush frames all samples have been encoded,
        return 0 bytes written */
-    if (hEncoder->flushFrame > 4)
+    if (hEncoder->flushFrame > (LOOKAHEAD_DEPTH + 1))
         return 0;
 
     /* Determine the channel configuration */
@@ -519,32 +519,26 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
 	{
 		faac_real *tmp;
 
-
-		if (!hEncoder->sampleBuff[channel])
-			hEncoder->sampleBuff[channel] = (faac_real*)AllocMemory(FRAME_LEN*sizeof(faac_real));
-
-		tmp = hEncoder->sampleBuff[channel];
-
-		hEncoder->sampleBuff[channel]		= hEncoder->nextSampleBuff[channel];
-		hEncoder->nextSampleBuff[channel]	= hEncoder->next2SampleBuff[channel];
-		hEncoder->next2SampleBuff[channel]	= hEncoder->next3SampleBuff[channel];
-		hEncoder->next3SampleBuff[channel]	= tmp;
+		tmp = hEncoder->audioFIFO[channel][FIFO_PAST];
+		hEncoder->audioFIFO[channel][FIFO_PAST]  = hEncoder->audioFIFO[channel][FIFO_CURR];
+		hEncoder->audioFIFO[channel][FIFO_CURR]  = hEncoder->audioFIFO[channel][FIFO_AHEAD1];
+		hEncoder->audioFIFO[channel][FIFO_AHEAD1] = hEncoder->audioFIFO[channel][FIFO_AHEAD2];
+		hEncoder->audioFIFO[channel][FIFO_AHEAD2] = tmp;
 
         if (realPerCh == 0)
         {
             /* start flushing*/
-            for (i = 0; i < FRAME_LEN; i++)
-                hEncoder->next3SampleBuff[channel][i] = 0.0;
+            memset(hEncoder->audioFIFO[channel][FIFO_AHEAD2], 0, FRAME_LEN * sizeof(faac_real));
         }
         else
         {
             /* Take one frame from the FIFO front (already faac_real),
              * silence-padding a short final frame. */
             unsigned int spc = ((unsigned int)realPerCh < FRAME_LEN) ? (unsigned int)realPerCh : FRAME_LEN;
-            memcpy(hEncoder->next3SampleBuff[channel], hEncoder->inputFifo[channel],
+            memcpy(hEncoder->audioFIFO[channel][FIFO_AHEAD2], hEncoder->inputFifo[channel],
                    spc * sizeof(faac_real));
-            for (i = spc; i < FRAME_LEN; i++)
-                hEncoder->next3SampleBuff[channel][i] = 0.0;
+            if (spc < FRAME_LEN)
+                memset(hEncoder->audioFIFO[channel][FIFO_AHEAD2] + spc, 0, (FRAME_LEN - spc) * sizeof(faac_real));
 		}
 
 		/* Psychoacoustics */
@@ -555,7 +549,8 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
 			hEncoder->psymodel->PsyBufferUpdate(
 					&hEncoder->gpsyInfo,
 					&hEncoder->psyInfo[channel],
-					hEncoder->next3SampleBuff[channel]);
+                    hEncoder->audioFIFO[channel][FIFO_AHEAD1],
+                    hEncoder->audioFIFO[channel][FIFO_AHEAD2]);
 		}
     }
 
@@ -563,7 +558,7 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
     if (realPerCh > 0)
         consumeInputFifo(hEncoder, FRAME_LEN);
 
-    if (hEncoder->frameNum <= 3) /* Still filling up the buffers */
+    if (hEncoder->frameNum <= LOOKAHEAD_DEPTH) /* Still filling up the buffers */
         return 0;
 
     /* Psychoacoustics */
@@ -579,7 +574,7 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
 			coderInfo[channel].block_type = ONLY_LONG_WINDOW;
 		}
     }
-    else if ((hEncoder->frameNum <= 4) || (shortctl == SHORTCTL_NOLONG))
+    else if ((hEncoder->frameNum <= (LOOKAHEAD_DEPTH + 1)) || (shortctl == SHORTCTL_NOLONG))
     {
 		for (channel = 0; channel < numChannels; channel++)
 		{
@@ -591,9 +586,9 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
     for (channel = 0; channel < numChannels; channel++) {
         FilterBank(hEncoder,
             &coderInfo[channel],
-            hEncoder->sampleBuff[channel],
-            hEncoder->freqBuff[channel],
-            hEncoder->overlapBuff[channel]);
+            hEncoder->audioFIFO[channel][FIFO_PAST],
+            hEncoder->audioFIFO[channel][FIFO_CURR],
+            hEncoder->freqBuff[channel]);
     }
 
     for (channel = 0; channel < numChannels; channel++) {

--- a/libfaac/frame.h
+++ b/libfaac/frame.h
@@ -21,6 +21,17 @@
 #ifndef FRAME_H
 #define FRAME_H
 
+/* Input sample FIFO slots, each one frame (FRAME_LEN samples) wide, relative to
+   the frame currently being coded (FIFO_CURR): one frame behind (FIFO_PAST,
+   reused as the MDCT overlap) and two frames ahead. The two ahead slots are
+   needed because the block-switch energy analysis works on 2-frame-wide windows
+   and keeps one window of lookahead, whose far edge reaches two frames ahead. */
+#define LOOKAHEAD_DEPTH 2
+#define FIFO_PAST       0
+#define FIFO_CURR       1
+#define FIFO_AHEAD1     2
+#define FIFO_AHEAD2     3
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -56,11 +67,8 @@ typedef struct {
     /* Scalefactorband data */
     SR_INFO *srInfo;
 
-    /* sample buffers of current next and next next frame*/
-    faac_real *sampleBuff[MAX_CHANNELS];
-    faac_real *nextSampleBuff[MAX_CHANNELS];
-    faac_real *next2SampleBuff[MAX_CHANNELS];
-    faac_real *next3SampleBuff[MAX_CHANNELS];
+    /* sample buffers: FIFO_PAST (MDCT overlap), FIFO_CURR, FIFO_AHEAD1, FIFO_AHEAD2 */
+    faac_real *audioFIFO[MAX_CHANNELS][4];
 
     /* Filterbank buffers */
     faac_real *sin_window_long;
@@ -68,7 +76,6 @@ typedef struct {
     faac_real *kbd_window_long;
     faac_real *kbd_window_short;
     faac_real *freqBuff[MAX_CHANNELS];
-    faac_real *overlapBuff[MAX_CHANNELS];
 
     /* Channel and Coder data for all channels */
     CoderInfo coderInfo[MAX_CHANNELS];


### PR DESCRIPTION
This reduces the lookahead from +3 to +2 reducing latency slightly and combines some buffers.

## Details

Consolidate the encoder's lookahead buffering into two structures whose naming makes the window-vs-frame relationship explicit:

- Input samples use one audioFIFO[ch][4] of one-frame slots (FIFO_PAST, FIFO_CURR, FIFO_AHEAD1, FIFO_AHEAD2). FIFO_PAST doubles as the MDCT overlap and the FIFO rotation supplies the psy "prev" window, replacing the separate sampleBuff/next*SampleBuff/overlapBuff/prevSamples buffers.

- Block-switch energies use one contiguous eng[] timeline of three 2-frame windows (ENG_WIN_PREV/CUR/NEXT), turning PsyCheckShort's +-2 sub-block lookahead into a single sliding index instead of stitching separate prev/curr/next arrays, and dropping the dead engNext2 staging slot. (Energy windows are 2 frames wide, which is why the single NEXT window consumes the two-frames-ahead FIFO slot.)

## Benchmark

https://github.com/nschimme/faac/actions/runs/28336778773

<img width="694" height="958" alt="image" src="https://github.com/user-attachments/assets/5db543fb-a531-4609-9208-3141a4d3b6dc" />