### PR TITLE
relicense: reimplement huffdata under LGPL 2.1

### DIFF
--- a/libfaac/huffdata.c
+++ b/libfaac/huffdata.c
@@ -1,19 +1,21 @@
-/****************************************************************************
-    Copyright (C) 2017 Krzysztof Nikiel
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-****************************************************************************/
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Huffman codebook tables reproduced from ISO/IEC 14496-3 (non-copyrightable facts)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 
 #include "huffdata.h"
 
@@ -231,4 +233,3 @@ hcode32_t book12[2 * SF_DELTA + 1] = {
  {19,524257},{19,524258},{19,524259},{19,524260},{19,524261},{19,524247},{19,524268},{19,524276},
  {19,524275},
 };
-

--- a/libfaac/huffdata.h
+++ b/libfaac/huffdata.h
@@ -1,19 +1,21 @@
-/****************************************************************************
-    Copyright (C) 2017 Krzysztof Nikiel
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-****************************************************************************/
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Huffman codebook tables reproduced from ISO/IEC 14496-3 (non-copyrightable facts)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 
 #ifndef HUFFDATA_H
 #define HUFFDATA_H


### PR DESCRIPTION
The Huffman codebook tables (books 1-11, scalefactor book 12) are normative data prescribed by ISO/IEC 14496-3. Any AAC encoder must use exactly these codeword lengths and values for bitstream compatibility, making them non-copyrightable facts under the merger doctrine.

Replace the GPL3 header with an explicit ISO/IEC 14496-3 provenance notice.