### PR TITLE
build: fix compiler warnings and transition to C11

### DIFF
--- a/frontend/input.c
+++ b/frontend/input.c
@@ -195,7 +195,7 @@ pcmfile_t *wav_open_read(const char *name, int rawinput)
     if (fmtsize < 16)
 	return NULL;
 
-   if (fread(&wave, 1, fmtsize, wave_f) != fmtsize)
+   if (fread(&wave, 1, fmtsize, wave_f) != (size_t)fmtsize)
         return NULL;
 
     seekcur(wave_f, riffsub.len - fmtsize);

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -122,7 +122,7 @@ static help_t help_qual[] = {
     {"-c <freq>\tSet the bandwidth in Hz.\n",
     "\t\tThe actual frequency is adjusted to maximize upper spectral band\n"
     "\t\tusage.\n"},
-    {0}
+    {NULL, NULL}
 };
 
 static help_t help_io[] = {
@@ -136,7 +136,7 @@ static help_t help_io[] = {
     "\t\tthus enabling piping from other applications and utilities. The\n"
     "\t\tsame works for stdout as well, so FAAC can pipe its output to\n"
     "\t\tother apps such as a server.\n"},
-    {"-v <verbose>\t\tverbosity level (-v0 is quiet mode)\n"},
+    {"-v <verbose>\t\tverbosity level (-v0 is quiet mode)\n", NULL},
     {"-r\t\tUse RAW AAC output file.\n",
     "\t\tGenerate raw AAC bitstream (i.e. without any headers).\n"
     "\t\tNot advised!!!, RAW AAC files are practically useless!!!\n"},
@@ -160,47 +160,47 @@ static help_t help_io[] = {
     "\t\thave to specify a different position of these two mono channels\n"
     "\t\tin your multichannel input files if they haven't been reordered\n"
     "\t\talready).\n"},
-    {"--ignorelength\tIgnore wav length from header (useful with files over 4 GB)\n"},
-    {"--overwrite\t\tOverwrite existing output file"},
-    {0}
+    {"--ignorelength\tIgnore wav length from header (useful with files over 4 GB)\n", NULL},
+    {"--overwrite\t\tOverwrite existing output file", NULL},
+    {NULL, NULL}
 };
 
 static help_t help_mp4[] = {
-    {"-w\tWrap AAC data in MP4 container (default for *.mp4, *.m4a and *.m4b)\n"},
-    {"--tag <tagname,tagvalue> Add named tag (iTunes '----')\n"},
-    {"--artist <name>\tSet artist name\n"},
-    {"--artistsort <name>\tSet artist sort order\n"},
-    {"--composer <name>\tSet composer name\n"},
-    {"--composersort <name>\tSet composer sort order\n"},
-    {"--title <name>\tSet title/track name\n"},
-    {"--genre <number>\tSet genre number\n"},
-    {"--album <name>\tSet album/performer\n"},
-    {"--albumartist <name>\tSet album artist\n"},
-    {"--albumartistsort <name>\tSet album artist sort order\n"},
-    {"--albumsort <name>\tSet album sort order\n"},
-    {"--compilation\tMark as compilation\n"},
-    {"--track <number/total>\tSet track number\n"},
-    {"--disc <number/total>\tSet disc number\n"},
-    {"--year <number>\tSet year\n"},
+    {"-w\tWrap AAC data in MP4 container (default for *.mp4, *.m4a and *.m4b)\n", NULL},
+    {"--tag <tagname,tagvalue> Add named tag (iTunes '----')\n", NULL},
+    {"--artist <name>\tSet artist name\n", NULL},
+    {"--artistsort <name>\tSet artist sort order\n", NULL},
+    {"--composer <name>\tSet composer name\n", NULL},
+    {"--composersort <name>\tSet composer sort order\n", NULL},
+    {"--title <name>\tSet title/track name\n", NULL},
+    {"--genre <number>\tSet genre number\n", NULL},
+    {"--album <name>\tSet album/performer\n", NULL},
+    {"--albumartist <name>\tSet album artist\n", NULL},
+    {"--albumartistsort <name>\tSet album artist sort order\n", NULL},
+    {"--albumsort <name>\tSet album sort order\n", NULL},
+    {"--compilation\tMark as compilation\n", NULL},
+    {"--track <number/total>\tSet track number\n", NULL},
+    {"--disc <number/total>\tSet disc number\n", NULL},
+    {"--year <number>\tSet year\n", NULL},
     {"--cover-art <filename>\tRead cover art from file X\n",
     "\t\tSupported image formats are GIF, JPEG, and PNG.\n"},
-    {"--comment <string>\tSet comment\n"},
-    {"--creation-time <value>\tSet creation/modification time (auto, now, or timestamp)\n"},
-    {0}
+    {"--comment <string>\tSet comment\n", NULL},
+    {"--creation-time <value>\tSet creation/modification time (auto, now, or timestamp)\n", NULL},
+    {NULL, NULL}
 };
 
 static help_t help_advanced[] = {
-    {"--tns  \tEnable coding of TNS, temporal noise shaping.\n"},
-    {"--no-tns\tDisable coding of TNS, temporal noise shaping.\n"},
-    {"--joint 0\tDisable joint stereo coding.\n"},
-    {"--joint 1\tUse Mid/Side coding.\n"},
-    {"--joint 2\tUse Intensity Stereo coding.\n"},
-    {"--joint 3\tUse Mixed Mode (dynamic M/S and IS) coding (default).\n"},
-    {"--pns <0 .. 10>\tPNS level; 0=disabled.\n"},
-    {"--mpeg-vers X\tForce AAC MPEG version, X can be 2 or 4\n"},
+    {"--tns  \tEnable coding of TNS, temporal noise shaping.\n", NULL},
+    {"--no-tns\tDisable coding of TNS, temporal noise shaping.\n", NULL},
+    {"--joint 0\tDisable joint stereo coding.\n", NULL},
+    {"--joint 1\tUse Mid/Side coding.\n", NULL},
+    {"--joint 2\tUse Intensity Stereo coding.\n", NULL},
+    {"--joint 3\tUse Mixed Mode (dynamic M/S and IS) coding (default).\n", NULL},
+    {"--pns <0 .. 10>\tPNS level; 0=disabled.\n", NULL},
+    {"--mpeg-vers X\tForce AAC MPEG version, X can be 2 or 4\n", NULL},
     {"--shortctl X\tEnforce block type (0 = both (default); 1 = no short; 2 = no\n"
-    "\t\tlong).\n"},
-    {0}
+    "\t\tlong).\n", NULL},
+    {NULL, NULL}
 };
 
 static struct {
@@ -295,6 +295,7 @@ enum container_format
 #ifndef _WIN32
 void signal_handler(int signal)
 {
+    (void)signal;
     running = 0;
 }
 #endif
@@ -686,11 +687,11 @@ int main(int argc, char *argv[])
             albumsort = optarg;
             break;
         case TRACK_FLAG:
-            if (sscanf(optarg, "%d/%d", &trackno, &ntracks) < 1)
+            if (sscanf(optarg, "%u/%u", &trackno, &ntracks) < 1)
                 dieMessage = "Wrong track number.\n";
             break;
         case DISC_FLAG:
-            if (sscanf(optarg, "%d/%d", &discno, &ndiscs) < 1)
+            if (sscanf(optarg, "%u/%u", &discno, &ndiscs) < 1)
                 dieMessage = "Wrong disc number.\n";
             break;
         case GENRE_FLAG:
@@ -1088,14 +1089,14 @@ int main(int argc, char *argv[])
 
         if (!ignorelen)
         {
-            if (input_samples < infile->samples || infile->samples == 0)
+            if (input_samples < (uint64_t)infile->samples || infile->samples == 0)
                 samplesRead =
                     wav_read_float32(infile, pcmbuf, samplesInput, chanmap);
             else
                 samplesRead = 0;
 
             if (input_samples + (samplesRead / infile->channels) >
-                infile->samples && infile->samples != 0)
+                (uint64_t)infile->samples && infile->samples != 0)
                 samplesRead =
                     (infile->samples - input_samples) * infile->channels;
         }

--- a/libfaac/bitstream.c
+++ b/libfaac/bitstream.c
@@ -46,36 +46,28 @@ static int WriteCPE(CoderInfo *coderInfoL,
                     CoderInfo *coderInfoR,
                     ChannelInfo *channelInfo,
                     BitStream* bitStream,
-                    int objectType,
                     int writeFlag);
 static int WriteSCE(CoderInfo *coderInfo,
                     ChannelInfo *channelInfo,
                     BitStream *bitStream,
-                    int objectType,
                     int writeFlag);
 static int WriteLFE(CoderInfo *coderInfo,
                     ChannelInfo *channelInfo,
                     BitStream *bitStream,
-                    int objectType,
                     int writeFlag);
 static int WriteICSInfo(CoderInfo *coderInfo,
                         BitStream *bitStream,
-                        int objectType,
-                        int common_window,
                         int writeFlag);
 static int WriteICS(CoderInfo *coderInfo,
                     BitStream *bitStream,
                     int commonWindow,
-                    int objectType,
                     int writeFlag);
-static int WritePulseData(CoderInfo *coderInfo,
-                          BitStream *bitStream,
+static int WritePulseData(BitStream *bitStream,
                           int writeFlag);
 static int WriteTNSData(CoderInfo *coderInfo,
                         BitStream *bitStream,
                         int writeFlag);
-static int WriteGainControlData(CoderInfo *coderInfo,
-                                BitStream *bitStream,
+static int WriteGainControlData(BitStream *bitStream,
                                 int writeFlag);
 static int WriteSpectralData(CoderInfo *coderInfo,
                              BitStream *bitStream,
@@ -119,14 +111,12 @@ int WriteBitstream(faacEncStruct* hEncoder,
                     bits += WriteLFE(&coderInfo[channel],
                         &channelInfo[channel],
                         bitStream,
-                        hEncoder->config.aacObjectType,
                         1);
                 } else {
                     /* Write out sce */
                     bits += WriteSCE(&coderInfo[channel],
                         &channelInfo[channel],
                         bitStream,
-                        hEncoder->config.aacObjectType,
                         1);
                 }
 
@@ -138,7 +128,6 @@ int WriteBitstream(faacEncStruct* hEncoder,
                         &coderInfo[channelInfo[channel].paired_ch],
                         &channelInfo[channel],
                         bitStream,
-                        hEncoder->config.aacObjectType,
                         1);
                 }
             }
@@ -202,14 +191,12 @@ static int CountBitstream(faacEncStruct* hEncoder,
                     bits += WriteLFE(&coderInfo[channel],
                         &channelInfo[channel],
                         bitStream,
-                        hEncoder->config.aacObjectType,
                         0);
                 } else {
                     /* Write out sce */
                     bits += WriteSCE(&coderInfo[channel],
                         &channelInfo[channel],
                         bitStream,
-                        hEncoder->config.aacObjectType,
                         0);
                 }
 
@@ -221,7 +208,6 @@ static int CountBitstream(faacEncStruct* hEncoder,
                         &coderInfo[channelInfo[channel].paired_ch],
                         &channelInfo[channel],
                         bitStream,
-                        hEncoder->config.aacObjectType,
                         0);
                 }
             }
@@ -321,7 +307,6 @@ static int WriteCPE(CoderInfo *coderInfoL,
                     CoderInfo *coderInfoR,
                     ChannelInfo *channelInfo,
                     BitStream* bitStream,
-                    int objectType,
                     int writeFlag)
 {
     int bits = 0;
@@ -345,7 +330,7 @@ static int WriteCPE(CoderInfo *coderInfoL,
     if (channelInfo->common_window) {
         int numWindows, maxSfb;
 
-        bits += WriteICSInfo(coderInfoL, bitStream, objectType, channelInfo->common_window, writeFlag);
+        bits += WriteICSInfo(coderInfoL, bitStream, writeFlag);
         numWindows = coderInfoL->groups.n;
         maxSfb = coderInfoL->sfbn;
 
@@ -367,8 +352,8 @@ static int WriteCPE(CoderInfo *coderInfoL,
     }
 
     /* Write individual_channel_stream elements */
-    bits += WriteICS(coderInfoL, bitStream, channelInfo->common_window, objectType, writeFlag);
-    bits += WriteICS(coderInfoR, bitStream, channelInfo->common_window, objectType, writeFlag);
+    bits += WriteICS(coderInfoL, bitStream, channelInfo->common_window, writeFlag);
+    bits += WriteICS(coderInfoR, bitStream, channelInfo->common_window, writeFlag);
 
     return bits;
 }
@@ -376,7 +361,6 @@ static int WriteCPE(CoderInfo *coderInfoL,
 static int WriteSCE(CoderInfo *coderInfo,
                     ChannelInfo *channelInfo,
                     BitStream *bitStream,
-                    int objectType,
                     int writeFlag)
 {
     int bits = 0;
@@ -393,7 +377,7 @@ static int WriteSCE(CoderInfo *coderInfo,
     bits += LEN_TAG;
 
     /* Write an Individual Channel Stream element */
-    bits += WriteICS(coderInfo, bitStream, 0, objectType, writeFlag);
+    bits += WriteICS(coderInfo, bitStream, 0, writeFlag);
 
     return bits;
 }
@@ -401,7 +385,6 @@ static int WriteSCE(CoderInfo *coderInfo,
 static int WriteLFE(CoderInfo *coderInfo,
                     ChannelInfo *channelInfo,
                     BitStream *bitStream,
-                    int objectType,
                     int writeFlag)
 {
     int bits = 0;
@@ -418,15 +401,13 @@ static int WriteLFE(CoderInfo *coderInfo,
     bits += LEN_TAG;
 
     /* Write an individual_channel_stream element */
-    bits += WriteICS(coderInfo, bitStream, 0, objectType, writeFlag);
+    bits += WriteICS(coderInfo, bitStream, 0, writeFlag);
 
     return bits;
 }
 
 static int WriteICSInfo(CoderInfo *coderInfo,
                         BitStream *bitStream,
-                        int objectType,
-                        int common_window,
                         int writeFlag)
 {
     int grouping_bits;
@@ -473,7 +454,6 @@ static int WriteICSInfo(CoderInfo *coderInfo,
 static int WriteICS(CoderInfo *coderInfo,
                     BitStream *bitStream,
                     int commonWindow,
-                    int objectType,
                     int writeFlag)
 {
     /* this function writes out an individual_channel_stream to the bitstream and */
@@ -487,15 +467,15 @@ static int WriteICS(CoderInfo *coderInfo,
 
     /* Write ics information */
     if (!commonWindow) {
-        bits += WriteICSInfo(coderInfo, bitStream, objectType, commonWindow, writeFlag);
+        bits += WriteICSInfo(coderInfo, bitStream, writeFlag);
     }
 
     bits += writebooks(coderInfo, bitStream, writeFlag);
     bits += writesf(coderInfo, bitStream, writeFlag);
 
-    bits += WritePulseData(coderInfo, bitStream, writeFlag);
+    bits += WritePulseData(bitStream, writeFlag);
     bits += WriteTNSData(coderInfo, bitStream, writeFlag);
-    bits += WriteGainControlData(coderInfo, bitStream, writeFlag);
+    bits += WriteGainControlData(bitStream, writeFlag);
 
     bits += WriteSpectralData(coderInfo, bitStream, writeFlag);
 
@@ -503,8 +483,7 @@ static int WriteICS(CoderInfo *coderInfo,
     return bits;
 }
 
-static int WritePulseData(CoderInfo *coderInfo,
-                          BitStream *bitStream,
+static int WritePulseData(BitStream *bitStream,
                           int writeFlag)
 {
     int bits = 0;
@@ -592,7 +571,7 @@ static int WriteTNSData(CoderInfo *coderInfo,
                     if (writeFlag) {
                         int i;
                         for (i=1;i<=order;i++) {
-                            unsignedIndex = (unsigned long) (tnsFilterPtr->index[i])&(~(~0<<bitsToTransmit));
+                            unsignedIndex = (unsigned long) (tnsFilterPtr->index[i])&(~(~0UL<<bitsToTransmit));
                             PutBit(bitStream,unsignedIndex,bitsToTransmit);
                         }
                     }
@@ -603,8 +582,7 @@ static int WriteTNSData(CoderInfo *coderInfo,
     return bits;
 }
 
-static int WriteGainControlData(CoderInfo *coderInfo,
-                                BitStream *bitStream,
+static int WriteGainControlData(BitStream *bitStream,
                                 int writeFlag)
 {
     int bits = 0;

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -49,7 +49,7 @@ static char *libCopyright =
 
 static const psymodellist_t psymodellist[] = {
   {&psymodel2, "knipsycho psychoacoustic"},
-  {NULL}
+  {NULL, NULL}
 };
 
 static SR_INFO srInfo[12+1];
@@ -219,7 +219,7 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
     if (hEncoder->config.bandWidth > (hEncoder->sampleRate / 2))
 		hEncoder->config.bandWidth = hEncoder->sampleRate / 2;
 
-    if (config->quantqual > maxqual)
+    if (config->quantqual > (unsigned long)maxqual)
         config->quantqual = maxqual;
     if (config->quantqual < MINQUAL)
         config->quantqual = MINQUAL;
@@ -254,8 +254,8 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
 
     // reset psymodel
     hEncoder->psymodel->PsyEnd(hEncoder->psyInfo, hEncoder->numChannels);
-    if (config->psymodelidx >= (sizeof(psymodellist) / sizeof(psymodellist[0]) - 1))
-		config->psymodelidx = (sizeof(psymodellist) / sizeof(psymodellist[0])) - 2;
+    if (config->psymodelidx >= (int)(sizeof(psymodellist) / sizeof(psymodellist[0]) - 1))
+		config->psymodelidx = (int)(sizeof(psymodellist) / sizeof(psymodellist[0])) - 2;
 
     hEncoder->config.psymodelidx = config->psymodelidx;
     hEncoder->psymodel = (psymodel_t *)psymodellist[hEncoder->config.psymodelidx].ptr;
@@ -810,5 +810,5 @@ static SR_INFO srInfo[12+1] =
             4, 4, 4, 4, 4, 4, 4, 8, 8, 8, 8, 12, 16, 20, 20
         }
     },
-    { -1 }
+{ -1, 0, 0, {0}, {0} }
 };

--- a/libfaac/util.c
+++ b/libfaac/util.c
@@ -53,7 +53,7 @@ unsigned int MaxBitrate(unsigned long sampleRate)
 }
 
 /* Returns the minimum bitrate per channel for that sampling frequency */
-unsigned int MinBitrate()
+unsigned int MinBitrate(void)
 {
     return 8000;
 }

--- a/libfaac/util.h
+++ b/libfaac/util.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include <stdlib.h>
-#include <memory.h>
+#include <string.h>
 
 #ifndef max
 #define max(a, b) (((a) > (b)) ? (a) : (b))
@@ -39,6 +39,9 @@ extern "C" {
 #ifndef M_PI
 #define M_PI        3.14159265358979323846
 #endif
+#ifndef M_SQRT2
+#define M_SQRT2     1.41421356237309504880
+#endif
 
 /* Memory functions */
 #define AllocMemory(size) malloc(size)
@@ -47,7 +50,7 @@ extern "C" {
 
 int GetSRIndex(unsigned int sampleRate);
 unsigned int MaxBitrate(unsigned long sampleRate);
-unsigned int MinBitrate();
+unsigned int MinBitrate(void);
 int CountLeadingZeros(unsigned int x);
 
 #ifdef __cplusplus

--- a/meson.build
+++ b/meson.build
@@ -3,8 +3,8 @@ project('faac', 'c',
     default_options: [
         'default_library=both',
         'buildtype=release',
-        'warning_level=1',
-        'c_std=gnu99,c99',
+        'warning_level=3',
+        'c_std=gnu11,c11',
     ])
 
 add_global_arguments('-DHAVE_CONFIG_H', language: 'c')


### PR DESCRIPTION
- Remove unused parameters from internal bitstream.c functions and
  suppress unused-parameter warning in signal_handler callback.
- Fix negative bitwise shift in WriteTNSData.
- Resolve sign-comparison and missing-initializer warnings in frame.c,
  main.c, and input.c with casts and explicit initializers.
- Use correct %u format specifiers for unsigned track/disc numbers in
  main.c.
- Use MinBitrate(void) instead of an empty K&R-style prototype to
  satisfy -Wstrict-prototypes.
- Update meson.build to use c_std=gnu11,c11 and warning_level=3.
- Standardize on <string.h> in libfaac/util.h and add fallback
  definitions for M_PI and M_SQRT2 for portability across compilers.

Verified clean build with -Wall -Wextra -Wpedantic at warning_level=3
(zero warnings).