### PR TITLE
harden input parsing and guard against allocation failures

### DIFF
--- a/frontend/input.c
+++ b/frontend/input.c
@@ -118,7 +118,7 @@ static void unsuperr(const char *name)
 
 static void seekcur(FILE *f, int ofs)
 {
-    if (ofs <= 0)
+    if (ofs < 0)
         return;
 
     if (fseek(f, ofs, SEEK_CUR) != 0)
@@ -272,8 +272,7 @@ pcmfile_t *wav_open_read(const char *name, int rawinput)
     /* channel/sample-width bounds guard against a corrupt header (e.g. a
        bogus huge channel count) driving an oversized allocation downstream */
     if (sndf->channels < 1 || sndf->channels > 64 ||
-        (sndf->samplebytes != 1 && sndf->samplebytes != 2 &&
-         sndf->samplebytes != 3 && sndf->samplebytes != 4))
+        sndf->samplebytes < 1 || sndf->samplebytes > 4)
     {
       if (wave_f != stdin) fclose(wave_f);
       free(sndf);
@@ -282,6 +281,13 @@ pcmfile_t *wav_open_read(const char *name, int rawinput)
 
     sndf->samples = riffsub.len / (sndf->samplebytes * sndf->channels);
   }
+
+#ifdef WORDS_BIGENDIAN
+  sndf->swap = !sndf->bigendian;
+#else
+  sndf->swap = sndf->bigendian;
+#endif
+
   return sndf;
 }
 
@@ -349,11 +355,7 @@ size_t wav_read_float32(pcmfile_t *sndf, float *buf, size_t num, int *map)
       case 2:
           {
               int16_t *in = (int16_t*)bufi;
-#ifdef WORDS_BIGENDIAN
-              int swap = !sndf->bigendian;
-#else
-              int swap = sndf->bigendian;
-#endif
+              int swap = sndf->swap;
               if (swap)
               {
                   for (size_t i = 0; i < cnt; i++)
@@ -392,11 +394,7 @@ size_t wav_read_float32(pcmfile_t *sndf, float *buf, size_t num, int *map)
       case 4:
           {
               int32_t *in = (int32_t*)bufi;
-#ifdef WORDS_BIGENDIAN
-              int swap = !sndf->bigendian;
-#else
-              int swap = sndf->bigendian;
-#endif
+              int swap = sndf->swap;
               if (swap)
               {
                   for (size_t i = 0; i < cnt; i++)
@@ -444,11 +442,7 @@ size_t wav_read_int24(pcmfile_t *sndf, int32_t *buf, size_t num, int *map)
 
   case 2:
     {
-#ifdef WORDS_BIGENDIAN
-      int swap = !sndf->bigendian;
-#else
-      int swap = sndf->bigendian;
-#endif
+      int swap = sndf->swap;
       int16_t *in = (int16_t *)bufi;
       if (swap)
       {
@@ -486,11 +480,7 @@ size_t wav_read_int24(pcmfile_t *sndf, int32_t *buf, size_t num, int *map)
 
   case 4:
     {
-#ifdef WORDS_BIGENDIAN
-      int swap = !sndf->bigendian;
-#else
-      int swap = sndf->bigendian;
-#endif
+      int swap = sndf->swap;
       if (swap)
       {
         for (i = 0; i < size; i++)

--- a/frontend/input.c
+++ b/frontend/input.c
@@ -118,10 +118,19 @@ static void unsuperr(const char *name)
 
 static void seekcur(FILE *f, int ofs)
 {
-    int cnt;
+    if (ofs <= 0)
+        return;
 
-    for (cnt = 0; cnt < ofs; cnt++)
-        fgetc(f);
+    if (fseek(f, ofs, SEEK_CUR) != 0)
+    {
+        /* fseek fails on non-seekable streams (stdin/pipes); fall back to
+           reading and discarding bytes one at a time */
+        while (ofs--)
+        {
+            if (fgetc(f) == EOF)
+                break;
+        }
+    }
 }
 
 static int seekchunk(FILE *f, riffsub_t *riffsub, char *name)
@@ -228,6 +237,11 @@ pcmfile_t *wav_open_read(const char *name, int rawinput)
   }
 
   sndf = (pcmfile_t*)malloc(sizeof(*sndf));
+  if (!sndf)
+  {
+      if (wave_f != stdin) fclose(wave_f);
+      return NULL;
+  }
   memset(sndf, 0, sizeof(*sndf));
   sndf->f = wave_f;
 
@@ -254,11 +268,18 @@ pcmfile_t *wav_open_read(const char *name, int rawinput)
     sndf->channels = UINT16(wave.Format.nChannels);
     sndf->samplebytes = UINT16(wave.Format.wBitsPerSample) / 8;
     sndf->samplerate = UINT32(wave.Format.nSamplesPerSec);
-    if (!sndf->samplebytes || !sndf->channels)
+
+    /* channel/sample-width bounds guard against a corrupt header (e.g. a
+       bogus huge channel count) driving an oversized allocation downstream */
+    if (sndf->channels < 1 || sndf->channels > 64 ||
+        (sndf->samplebytes != 1 && sndf->samplebytes != 2 &&
+         sndf->samplebytes != 3 && sndf->samplebytes != 4))
     {
+      if (wave_f != stdin) fclose(wave_f);
       free(sndf);
       return NULL;
     }
+
     sndf->samples = riffsub.len / (sndf->samplebytes * sndf->channels);
   }
   return sndf;
@@ -269,6 +290,8 @@ static void chan_remap(int32_t *buf, int channels, int blocks, int *map)
 {
   int i;
   int32_t *tmp = (int32_t*)malloc(channels * sizeof(int32_t));
+
+  if (!tmp) return;
 
   for (i = 0; i < blocks; i++)
   {
@@ -298,77 +321,92 @@ size_t wav_read_float32(pcmfile_t *sndf, float *buf, size_t num, int *map)
   isize /= sndf->samplebytes;
 
   // perform in-place conversion
-  for (cnt = 0; cnt < num; cnt++)
+  cnt = (num < isize) ? num : isize;
+
+  if (sndf->isfloat)
   {
-      if (cnt >= isize)
-          break;
-
-      if (sndf->isfloat)
+      if (sndf->samplebytes == 4)
       {
-          switch (sndf->samplebytes) {
-          case 4:
-              buf[cnt] *= 32768.0;
-              break;
-          default:
-              return 0;
-          }
-          continue;
+          for (size_t i = 0; i < cnt; i++)
+              buf[i] *= 32768.0f;
       }
-
+      else
+      {
+          return 0;
+      }
+  }
+  else
+  {
       switch (sndf->samplebytes)
       {
       case 1:
           {
               uint8_t *in = (uint8_t*)bufi;
-              uint8_t s = in[cnt];
-
-              buf[cnt] = ((float)s - 128.0) * (float)256;
+              for (size_t i = 0; i < cnt; i++)
+                  buf[i] = ((float)in[i] - 128.0f) * 256.0f;
           }
           break;
       case 2:
           {
               int16_t *in = (int16_t*)bufi;
-              int16_t s = in[cnt];
 #ifdef WORDS_BIGENDIAN
-              if (!sndf->bigendian)
+              int swap = !sndf->bigendian;
 #else
-              if (sndf->bigendian)
+              int swap = sndf->bigendian;
 #endif
-                  buf[cnt] = (float)SWAP16(s);
+              if (swap)
+              {
+                  for (size_t i = 0; i < cnt; i++)
+                      buf[i] = (float)SWAP16(in[i]);
+              }
               else
-                  buf[cnt] = (float)s;
+              {
+                  for (size_t i = 0; i < cnt; i++)
+                      buf[i] = (float)in[i];
+              }
           }
           break;
       case 3:
           {
-              int s;
               uint8_t *in = (uint8_t*)bufi;
-              in += 3 * cnt;
-
               if (!sndf->bigendian)
-                  s = in[0] | (in[1] << 8) | (in[2] << 16);
+              {
+                  for (size_t i = 0; i < cnt; i++)
+                  {
+                      int s = in[3*i] | (in[3*i+1] << 8) | (in[3*i+2] << 16);
+                      if (s & 0x800000) s |= 0xff000000;
+                      buf[i] = (float)s / 256.0f;
+                  }
+              }
               else
-                  s = (in[0] << 16) | (in[1] << 8) | in[2];
-
-              // fix sign
-              if (s & 0x800000)
-                  s |= 0xff000000;
-
-              buf[cnt] = (float)s / 256;
+              {
+                  for (size_t i = 0; i < cnt; i++)
+                  {
+                      int s = (in[3*i] << 16) | (in[3*i+1] << 8) | in[3*i+2];
+                      if (s & 0x800000) s |= 0xff000000;
+                      buf[i] = (float)s / 256.0f;
+                  }
+              }
           }
         break;
       case 4:
           {
               int32_t *in = (int32_t*)bufi;
-              int s = in[cnt];
 #ifdef WORDS_BIGENDIAN
-              if (!sndf->bigendian)
+              int swap = !sndf->bigendian;
 #else
-              if (sndf->bigendian)
+              int swap = sndf->bigendian;
 #endif
-                  buf[cnt] = (float)SWAP32(s) / 65536;
+              if (swap)
+              {
+                  for (size_t i = 0; i < cnt; i++)
+                      buf[i] = (float)SWAP32(in[i]) / 65536.0f;
+              }
               else
-                  buf[cnt] = (float)s / 65536;
+              {
+                  for (size_t i = 0; i < cnt; i++)
+                      buf[i] = (float)in[i] / 65536.0f;
+              }
           }
           break;
       default:
@@ -405,30 +443,22 @@ size_t wav_read_int24(pcmfile_t *sndf, int32_t *buf, size_t num, int *map)
     break;
 
   case 2:
+    {
 #ifdef WORDS_BIGENDIAN
-    if (!sndf->bigendian)
+      int swap = !sndf->bigendian;
 #else
-    if (sndf->bigendian)
+      int swap = sndf->bigendian;
 #endif
-    {
-      // swap bytes
-      for (i = 0; i < size; i++)
+      int16_t *in = (int16_t *)bufi;
+      if (swap)
       {
-	int16_t s = ((int16_t *)bufi)[i];
-
-	s = SWAP16(s);
-
-	buf[i] = ((uint32_t)s) << 8;
+        for (i = 0; i < size; i++)
+          buf[i] = ((uint32_t)SWAP16(in[i])) << 8;
       }
-    }
-    else
-    {
-      // no swap
-      for (i = 0; i < size; i++)
+      else
       {
-	int s = ((int16_t *)bufi)[i];
-
-	buf[i] = s << 8;
+        for (i = 0; i < size; i++)
+          buf[i] = ((int32_t)in[i]) << 8;
       }
     }
     break;
@@ -439,11 +469,7 @@ size_t wav_read_int24(pcmfile_t *sndf, int32_t *buf, size_t num, int *map)
       for (i = 0; i < size; i++)
       {
 	int s = bufi[3 * i] | (bufi[3 * i + 1] << 8) | (bufi[3 * i + 2] << 16);
-
-        // fix sign
-	if (s & 0x800000)
-          s |= 0xff000000;
-
+	if (s & 0x800000) s |= 0xff000000;
 	buf[i] = s;
       }
     }
@@ -452,29 +478,23 @@ size_t wav_read_int24(pcmfile_t *sndf, int32_t *buf, size_t num, int *map)
       for (i = 0; i < size; i++)
       {
 	int s = (bufi[3 * i] << 16) | (bufi[3 * i + 1] << 8) | bufi[3 * i + 2];
-
-        // fix sign
-	if (s & 0x800000)
-          s |= 0xff000000;
-
+	if (s & 0x800000) s |= 0xff000000;
 	buf[i] = s;
       }
     }
     break;
 
   case 4:
-#ifdef WORDS_BIGENDIAN
-    if (!sndf->bigendian)
-#else
-    if (sndf->bigendian)
-#endif
     {
-      // swap bytes
-      for (i = 0; i < size; i++)
+#ifdef WORDS_BIGENDIAN
+      int swap = !sndf->bigendian;
+#else
+      int swap = sndf->bigendian;
+#endif
+      if (swap)
       {
-	int s = buf[i];
-
-	buf[i] = SWAP32(s);
+        for (i = 0; i < size; i++)
+          buf[i] = SWAP32(buf[i]);
       }
     }
     break;

--- a/frontend/input.h
+++ b/frontend/input.h
@@ -43,6 +43,7 @@ typedef struct
   int samplerate;
   int samples;
   int bigendian;
+  int swap;
   int isfloat;
 } pcmfile_t;
 

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -394,6 +394,7 @@ static int *mkChanMap(int channels, int center, int lf)
         center = 0;             // default AAC position
 
     map = malloc(channels * sizeof(map[0]));
+    if (!map) return NULL;
     memset(map, 0, channels * sizeof(map[0]));
 
     outpos = 0;
@@ -401,7 +402,7 @@ static int *mkChanMap(int channels, int center, int lf)
         map[outpos++] = center;
 
     inpos = 0;
-    for (; outpos < (channels - 1); inpos++)
+    for (; outpos < (channels - 1) && inpos < channels; inpos++)
     {
         if (inpos == center)
             continue;
@@ -414,7 +415,7 @@ static int *mkChanMap(int channels, int center, int lf)
     {
         if ((lf >= 0) && (lf < channels))
             map[outpos] = lf;
-        else
+        else if (inpos < channels)
             map[outpos] = inpos;
     }
 
@@ -580,6 +581,11 @@ int main(int argc, char *argv[])
             {
                 int l = strlen(optarg);
                 aacFileName = malloc(l + 1);
+                if (!aacFileName)
+                {
+                    fprintf(stderr, "out of memory\n");
+                    return 1;
+                }
                 memcpy(aacFileName, optarg, l);
                 aacFileName[l] = '\0';
                 aacFileNameGiven = 1;
@@ -729,6 +735,12 @@ int main(int argc, char *argv[])
                     artSize = ftell(artFile);
 
                     artData = malloc(artSize);
+                    if (!artData)
+                    {
+                        fprintf(stderr, "out of memory\n");
+                        fclose(artFile);
+                        return 1;
+                    }
 
                     fseek(artFile, 0, SEEK_SET);
                     clearerr(artFile);
@@ -835,6 +847,11 @@ int main(int argc, char *argv[])
         aacFileExt = container == MP4_CONTAINER ? ".m4a" : ".aac";
 
         aacFileName = malloc(l + 1 + 4);
+        if (!aacFileName)
+        {
+            fprintf(stderr, "out of memory\n");
+            return 1;
+        }
         memcpy(aacFileName, audioFileName, l);
         memcpy(aacFileName + l, aacFileExt, 4);
         aacFileName[l + 4] = '\0';
@@ -906,6 +923,11 @@ int main(int argc, char *argv[])
     delay_samples = frameSize;  // encoder delay 1024 samples
     pcmbuf = (float *) malloc(samplesInput * sizeof(float));
     bitbuf = (unsigned char *) malloc(maxBytesOutput * sizeof(unsigned char));
+    if (!pcmbuf || !bitbuf)
+    {
+        fprintf(stderr, "out of memory\n");
+        return 1;
+    }
     chanmap = mkChanMap(infile->channels, chanC, chanLF);
     if (chanmap)
     {
@@ -1171,7 +1193,7 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
                 if (frames != 0)
                 {
-                    sprintf(percent, "%.2f%% encoding %s",
+                    snprintf(percent, sizeof(percent), "%.2f%% encoding %s",
                             100.0 * currentFrame / frames, audioFileName);
                     SetConsoleTitle(percent);
                 }
@@ -1196,7 +1218,11 @@ int main(int argc, char *argv[])
                 frame_samples = delay_samples;
 
             if (container == MP4_CONTAINER) {
-                mp4_write_frame(bitbuf, (uint32_t)bytesWritten, (uint32_t)frame_samples);
+                if (mp4_write_frame(bitbuf, (uint32_t)bytesWritten, (uint32_t)frame_samples))
+                {
+                    fprintf(stderr, "mp4_write_frame() failed\n");
+                    break;
+                }
             } else
                 fwrite(bitbuf, 1, bytesWritten, outfile);
 
@@ -1208,13 +1234,17 @@ int main(int argc, char *argv[])
     if (container == MP4_CONTAINER)
     {
         char *version_string = malloc(strlen(faac_id_string) + 6);
+        if (!version_string)
+        {
+            fprintf(stderr, "out of memory\n");
+            return 1;
+        }
         unsigned char *ascData = NULL;
         unsigned long ascSize = 0;
 
         faacEncGetDecoderSpecificInfo(hEncoder, &ascData, &ascSize);
         mp4_set_decoder_config(ascData, ascSize);
-        strcpy(version_string, "FAAC ");
-        strcpy(version_string + 5, faac_id_string);
+        snprintf(version_string, strlen(faac_id_string) + 6, "FAAC %s", faac_id_string);
 
         mp4_set_encoder(version_string);
 
@@ -1295,7 +1325,8 @@ int main(int argc, char *argv[])
             mp4_set_creation_time(final_creation_time);
         }
 
-        mp4_finish();
+        if (mp4_finish())
+            fprintf(stderr, "mp4_finish() failed: output file may be incomplete\n");
         mp4_close();
 
         free(version_string);

--- a/frontend/mp4write.c
+++ b/frontend/mp4write.c
@@ -145,16 +145,24 @@ static struct {
 static uint8_t *g_membuf = NULL;
 static size_t g_mempos = 0;
 static size_t g_memcap = 0;
+/* Set whenever mem_write() can't grow g_membuf to fit a write and drops
+   it instead; checked by mp4_finish() so a truncated moov atom is never
+   mistaken for a successfully written one. */
+static int g_mem_error = 0;
 
 static inline void mem_write(const void *data, size_t size) {
     if (g_membuf) {
         if (g_mempos + size > g_memcap) {
             size_t new_cap = g_memcap ? g_memcap * 2 : 1024;
-            while (g_mempos + size > new_cap) new_cap *= 2;
+            /* cap growth so a bogus/huge write request can't spin the
+               doubling loop forever or overflow new_cap */
+            while (g_mempos + size > new_cap && new_cap < (1UL << 31)) new_cap *= 2;
+            if (g_mempos + size > new_cap) { g_mem_error = 1; return; }
             void *tmp = realloc(g_membuf, new_cap);
             if (!tmp) {
                 free(g_membuf);
                 g_membuf = NULL;
+                g_mem_error = 1;
                 return;
             }
             g_membuf = (uint8_t *)tmp;
@@ -162,8 +170,9 @@ static inline void mem_write(const void *data, size_t size) {
         }
         memcpy(g_membuf + g_mempos, data, size);
         g_mempos += size;
-    } else if (g_mp4.fout) {
-        fwrite(data, 1, size, g_mp4.fout);
+    } else if (g_mp4.fout && !g_mem_error) {
+        if (fwrite(data, 1, size, g_mp4.fout) != size)
+            g_mem_error = 1;
     }
 }
 
@@ -269,6 +278,7 @@ static void reset_write_state(void) {
 int mp4_open(const char *path, int overwrite) {
     mp4_close(); /* in case of a retry after a failed previous mp4_open() */
     reset_write_state();
+    g_mem_error = 0;
 
     if (!overwrite && access(path, 0) == 0) return 1;
     g_mp4.fout = fopen(path, "wb");
@@ -277,10 +287,17 @@ int mp4_open(const char *path, int overwrite) {
 
     g_mp4.frame.bufsize = 1024;
     g_mp4.frame.data = (uint32_t *)malloc(g_mp4.frame.bufsize * sizeof(uint32_t));
+    if (!g_mp4.frame.data) return 1;
 
     g_mempos = 0;
     g_memcap = 1024;
     g_membuf = (uint8_t *)malloc(g_memcap);
+    if (!g_membuf)
+    {
+        free(g_mp4.frame.data);
+        g_mp4.frame.data = NULL;
+        return 1;
+    }
 
     long ftyp = start_atom("ftyp");
     put_data("M4A \0\0\0\0M4A mp42isom", 20);
@@ -297,7 +314,7 @@ int mp4_open(const char *path, int overwrite) {
     g_mp4.mdatofs = (uint32_t)ftell(g_mp4.fout) + 8;
     put_u32(0);
     put_data("mdat", 4);
-    return 0;
+    return g_mem_error ? 1 : 0;
 }
 
 void mp4_set_format(uint32_t samplerate, uint32_t channels, uint32_t bits) {
@@ -376,6 +393,9 @@ int mp4_write_frame(const uint8_t *data, uint32_t size, uint32_t samples) {
 
     if (g_mp4.frame.ents >= g_mp4.frame.bufsize) {
         uint32_t new_cap = g_mp4.frame.bufsize ? g_mp4.frame.bufsize * 2 : 1024;
+        /* bound the frame table so an unreasonably long encode can't grow
+           this without limit or overflow new_cap * sizeof(uint32_t) */
+        if (new_cap > (1UL << 30)) return -1;
         uint32_t *tmp = (uint32_t *)realloc(g_mp4.frame.data, new_cap * sizeof(uint32_t));
         if (!tmp) return -1;
         g_mp4.frame.data = tmp;
@@ -475,14 +495,18 @@ static const char *tag_atom_names[MP4TAG_COUNT] = {
     [MP4TAG_COMMENT]         = "\xa9" "cmt",
 };
 
+/* Returns 0 on success, 1 on failure (mirroring mp4_open()'s convention). */
 int mp4_finish(void) {
-    if (!g_mp4.fout) return 0;
+    if (!g_mp4.fout) return 1;
+    g_mem_error = 0;
+
     /* now that all frames are written, go back and fill in the mdat
        size placeholder left by mp4_open() */
     long pos = ftell(g_mp4.fout);
     fseek(g_mp4.fout, g_mp4.mdatofs - 8, SEEK_SET);
     put_u32(g_mp4.mdatsize + 8);
     fseek(g_mp4.fout, pos, SEEK_SET);
+    if (g_mem_error) return 1;
 
     g_mp4.bitrate.avg = (uint32_t)((uint64_t)8 * g_mp4.mdatsize * g_mp4.samplerate / (g_mp4.samples ? g_mp4.samples : 1));
     /* a file shorter than one second never crosses the sample-count
@@ -493,6 +517,7 @@ int mp4_finish(void) {
     g_mempos = 0;
     g_memcap = 65536 + (size_t)g_mp4.frame.ents * 4;
     g_membuf = (uint8_t *)malloc(g_memcap);
+    if (!g_membuf) return 1;
 
     long moov = start_atom("moov");
     long mvhd = start_atom("mvhd");
@@ -592,9 +617,13 @@ int mp4_finish(void) {
         size_t stsz_size = (size_t)g_mp4.frame.ents * 4;
         if (g_mempos + stsz_size > g_memcap) {
             size_t new_cap = g_memcap ? g_memcap * 2 : 1024;
-            while (g_mempos + stsz_size > new_cap) new_cap *= 2;
-            void *tmp = realloc(g_membuf, new_cap);
-            if (!tmp) return 0;
+            while (g_mempos + stsz_size > new_cap && new_cap < (1UL << 31)) new_cap *= 2;
+            void *tmp = (g_mempos + stsz_size > new_cap) ? NULL : realloc(g_membuf, new_cap);
+            if (!tmp) {
+                free(g_membuf);
+                g_membuf = NULL;
+                return 1;
+            }
             g_membuf = (uint8_t *)tmp;
             g_memcap = new_cap;
         }
@@ -644,10 +673,10 @@ int mp4_finish(void) {
     end_atom(udta);
     end_atom(moov);
 
-    fwrite(g_membuf, 1, g_mempos, g_mp4.fout);
+    int ok = !g_mem_error && fwrite(g_membuf, 1, g_mempos, g_mp4.fout) == g_mempos;
     free(g_membuf);
     g_membuf = NULL;
-    return 0;
+    return ok ? 0 : 1;
 }
 
 int mp4_close(void) {

--- a/libfaac/bitstream.c
+++ b/libfaac/bitstream.c
@@ -730,7 +730,9 @@ BitStream *OpenBitStream(int size, unsigned char *buffer)
     BitStream *bitStream;
 
     bitStream = AllocMemory(sizeof(BitStream));
+    if (!bitStream) return NULL;
     bitStream->size = size;
+    bitStream->maxBit = (long)size * 8;
     bitStream->numBit = 0;
     bitStream->currentBit = 0;
     bitStream->data = buffer;
@@ -761,6 +763,12 @@ int PutBit(BitStream *bitStream,
 
     if (numBit == 0)
         return 0;
+
+    /* refuse to write past the caller's buffer instead of corrupting
+       adjacent memory; can be hit with pathological configs (e.g. large
+       channel counts) that make the ASC/header overflow its fixed size */
+    if (bitStream->currentBit + numBit > bitStream->maxBit)
+        return -1;
 
     /* Hoist bitstream state for faster access */
     unsigned int currentBit = (unsigned int)bitStream->currentBit;

--- a/libfaac/bitstream.h
+++ b/libfaac/bitstream.h
@@ -96,6 +96,7 @@ typedef struct
   unsigned char *data;      /* data bits */
   long numBit;          /* number of bits in buffer */
   long size;            /* buffer size in bytes */
+  long maxBit;          /* maximum bits in buffer (size * 8) */
   long currentBit;      /* current bit position in bit stream */
   long numByte;         /* number of bytes read/written (only file) */
 } BitStream;

--- a/libfaac/blockswitch.c
+++ b/libfaac/blockswitch.c
@@ -90,6 +90,7 @@ static void PsyInit(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo, unsigned int nu
   for (channel = 0; channel < numChannels; channel++)
   {
     psydata_t *psydata = (psydata_t *)AllocMemory(sizeof(psydata_t));
+    if (!psydata) return;
     memset(psydata, 0, sizeof(psydata_t));
     psyInfo[channel].data = psydata;
   }

--- a/libfaac/fft.c
+++ b/libfaac/fft.c
@@ -36,6 +36,17 @@ void fft_initialize( FFT_Tables *fft_tables )
 	fft_tables->costbl		= AllocMemory( (MAXLOGM+1) * sizeof( fft_tables->costbl[0] ) );
 	fft_tables->negsintbl	= AllocMemory( (MAXLOGM+1) * sizeof( fft_tables->negsintbl[0] ) );
 	fft_tables->reordertbl	= AllocMemory( (MAXLOGM+1) * sizeof( fft_tables->reordertbl[0] ) );
+
+	if (!fft_tables->costbl || !fft_tables->negsintbl || !fft_tables->reordertbl)
+	{
+		if (fft_tables->costbl) FreeMemory(fft_tables->costbl);
+		if (fft_tables->negsintbl) FreeMemory(fft_tables->negsintbl);
+		if (fft_tables->reordertbl) FreeMemory(fft_tables->reordertbl);
+		fft_tables->costbl = NULL;
+		fft_tables->negsintbl = NULL;
+		fft_tables->reordertbl = NULL;
+		return;
+	}
 	
 	for( i = 0; i< MAXLOGM+1; i++ )
 	{
@@ -80,6 +91,7 @@ static void reorder2( FFT_Tables *fft_tables, faac_real *xr, faac_real *xi, int 
 	if ( fft_tables->reordertbl[logm] == NULL ) // create bit reversing table
 	{
 		fft_tables->reordertbl[logm] = AllocMemory(size * sizeof(*(fft_tables->reordertbl[0])));
+		if (!fft_tables->reordertbl[logm]) return;
 
 		for (i = 0; i < size; i++)
 		{
@@ -233,6 +245,14 @@ static void check_tables( FFT_Tables *fft_tables, int logm)
 		int alloc_size = (size < 4) ? 0 : (size - 4);
 		fft_tables->costbl[logm]	= AllocMemory(alloc_size * sizeof(*(fft_tables->costbl[0])));
 		fft_tables->negsintbl[logm]	= AllocMemory(alloc_size * sizeof(*(fft_tables->negsintbl[0])));
+
+		if (!fft_tables->costbl[logm] || !fft_tables->negsintbl[logm])
+		{
+			if (fft_tables->costbl[logm]) FreeMemory(fft_tables->costbl[logm]);
+			if (fft_tables->negsintbl[logm]) FreeMemory(fft_tables->negsintbl[logm]);
+			fft_tables->costbl[logm] = fft_tables->negsintbl[logm] = NULL;
+			return;
+		}
 
 		for (step = 4; step < size; step *= 2)
 		{

--- a/libfaac/filtbank.c
+++ b/libfaac/filtbank.c
@@ -55,12 +55,17 @@ void FilterBankInit(faacEncStruct* hEncoder)
 
     for (channel = 0; channel < hEncoder->numChannels; channel++) {
         hEncoder->freqBuff[channel] = (faac_real*)AllocMemory(2*FRAME_LEN*sizeof(faac_real));
+        if (!hEncoder->freqBuff[channel]) return;
     }
 
     hEncoder->sin_window_long = (faac_real*)AllocMemory(BLOCK_LEN_LONG*sizeof(faac_real));
     hEncoder->sin_window_short = (faac_real*)AllocMemory(BLOCK_LEN_SHORT*sizeof(faac_real));
     hEncoder->kbd_window_long = (faac_real*)AllocMemory(BLOCK_LEN_LONG*sizeof(faac_real));
     hEncoder->kbd_window_short = (faac_real*)AllocMemory(BLOCK_LEN_SHORT*sizeof(faac_real));
+
+    if (!hEncoder->sin_window_long || !hEncoder->sin_window_short ||
+        !hEncoder->kbd_window_long || !hEncoder->kbd_window_short)
+        return;
 
     for( i=0; i<BLOCK_LEN_LONG; i++ )
         hEncoder->sin_window_long[i] = FAAC_SIN((M_PI/(2*BLOCK_LEN_LONG)) * (i + 0.5));

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -116,12 +116,12 @@ int FAACAPI faacEncGetDecoderSpecificInfo(faacEncHandle hpEncoder,unsigned char*
     }
 
     *pSizeOfDecoderSpecificInfo = 2;
-    *ppBuffer = malloc(2);
+    *ppBuffer = (unsigned char *)malloc(2);
 
     if(*ppBuffer != NULL){
-
         memset(*ppBuffer,0,*pSizeOfDecoderSpecificInfo);
-        pBitStream = OpenBitStream(*pSizeOfDecoderSpecificInfo, *ppBuffer);
+        pBitStream = OpenBitStream((int)*pSizeOfDecoderSpecificInfo, *ppBuffer);
+        if (!pBitStream) return -3;
         PutBit(pBitStream, hEncoder->config.aacObjectType, 5);
         PutBit(pBitStream, hEncoder->sampleRateIdx, 4);
         PutBit(pBitStream, hEncoder->numChannels, 4);
@@ -241,8 +241,11 @@ int FAACAPI faacEncSetConfiguration(faacEncHandle hpEncoder,
         unsigned int channel;
         for (channel = 0; channel < hEncoder->numChannels; channel++)
             if (!hEncoder->inputFifo[channel])
+            {
                 hEncoder->inputFifo[channel] =
                     (faac_real *)AllocMemory(2 * FRAME_LEN * sizeof(faac_real));
+                if (!hEncoder->inputFifo[channel]) return 0;
+            }
         hEncoder->inputFifoCap  = 2 * FRAME_LEN;
         hEncoder->inputFifoFill = 0;
     }
@@ -278,13 +281,14 @@ faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
     unsigned int channel;
     faacEncStruct* hEncoder;
 
-    if (numChannels > MAX_CHANNELS)
+    if (numChannels < 1 || numChannels > MAX_CHANNELS)
 	return NULL;
 
     *inputSamples = FRAME_LEN*numChannels;
     *maxOutputBytes = ADTS_FRAMESIZE;
 
     hEncoder = (faacEncStruct*)AllocMemory(sizeof(faacEncStruct));
+    if (!hEncoder) return NULL;
     SetMemory(hEncoder, 0, sizeof(faacEncStruct));
 
     hEncoder->numChannels = numChannels;
@@ -339,6 +343,11 @@ faacEncHandle FAACAPI faacEncOpen(unsigned long sampleRate,
 
         for (buf = 0; buf < 4; buf++) {
             hEncoder->audioFIFO[channel][buf] = (faac_real*)AllocMemory(FRAME_LEN*sizeof(faac_real));
+            if (!hEncoder->audioFIFO[channel][buf])
+            {
+                faacEncClose(hEncoder);
+                return NULL;
+            }
             memset(hEncoder->audioFIFO[channel][buf], 0, FRAME_LEN*sizeof(faac_real));
         }
     }

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -121,7 +121,11 @@ int FAACAPI faacEncGetDecoderSpecificInfo(faacEncHandle hpEncoder,unsigned char*
     if(*ppBuffer != NULL){
         memset(*ppBuffer,0,*pSizeOfDecoderSpecificInfo);
         pBitStream = OpenBitStream((int)*pSizeOfDecoderSpecificInfo, *ppBuffer);
-        if (!pBitStream) return -3;
+        if (!pBitStream) {
+            free(*ppBuffer);
+            *ppBuffer = NULL;
+            return -3;
+        }
         PutBit(pBitStream, hEncoder->config.aacObjectType, 5);
         PutBit(pBitStream, hEncoder->sampleRateIdx, 4);
         PutBit(pBitStream, hEncoder->numChannels, 4);
@@ -679,6 +683,8 @@ int FAACAPI faacEncEncode(faacEncHandle hpEncoder,
     }
     /* Write the AAC bitstream */
     bitStream = OpenBitStream(bufferSize, outputBuffer);
+    if (!bitStream)
+        return -1;
 
     if (WriteBitstream(hEncoder, coderInfo, channelInfo, bitStream, numChannels) < 0)
         return -1;


### PR DESCRIPTION
- check malloc/AllocMemory return values across frontend and libfaac
- validate WAV channel count/sample width against corrupt headers
- bound bitstream writes and mp4 buffer growth to prevent overflow
- fall back to byte-skipping when fseek fails on non-seekable input