### PR TITLE
fft: switch to radix-4 DIF, precomputed MDCT twiddles

### DIFF
--- a/libfaac/fft.c
+++ b/libfaac/fft.c
@@ -21,289 +21,300 @@
 
 #include <math.h>
 #include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 
 #include "fft.h"
 #include "util.h"
 
-#define MAXLOGM 9
-#define MAXLOGR 8
+#define LOGM_SHORT 6      /* logm for the 256-sample short block MDCT */
+#define LOGM_LONG  FFT_MAXLOGM /* logm for the 2048-sample long block MDCT */
 
-void fft_initialize( FFT_Tables *fft_tables )
+void fft_initialize(FFT_Tables *fft_tables)
 {
-	int i;
-	fft_tables->costbl		= AllocMemory( (MAXLOGM+1) * sizeof( fft_tables->costbl[0] ) );
-	fft_tables->negsintbl	= AllocMemory( (MAXLOGM+1) * sizeof( fft_tables->negsintbl[0] ) );
-	fft_tables->reordertbl	= AllocMemory( (MAXLOGM+1) * sizeof( fft_tables->reordertbl[0] ) );
+    int i;
+    fft_tables->costbl = AllocMemory((FFT_MAXLOGM + 1) * sizeof(fft_tables->costbl[0]));
+    fft_tables->negsintbl = AllocMemory((FFT_MAXLOGM + 1) * sizeof(fft_tables->negsintbl[0]));
+    fft_tables->reordertbl = AllocMemory((FFT_MAXLOGM + 1) * sizeof(fft_tables->reordertbl[0]));
 
-	if (!fft_tables->costbl || !fft_tables->negsintbl || !fft_tables->reordertbl)
-	{
-		if (fft_tables->costbl) FreeMemory(fft_tables->costbl);
-		if (fft_tables->negsintbl) FreeMemory(fft_tables->negsintbl);
-		if (fft_tables->reordertbl) FreeMemory(fft_tables->reordertbl);
-		fft_tables->costbl = NULL;
-		fft_tables->negsintbl = NULL;
-		fft_tables->reordertbl = NULL;
-		return;
-	}
-	
-	for( i = 0; i< MAXLOGM+1; i++ )
-	{
-		fft_tables->costbl[i]		= NULL;
-		fft_tables->negsintbl[i]	= NULL;
-		fft_tables->reordertbl[i]	= NULL;
-	}
+    if (!fft_tables->costbl || !fft_tables->negsintbl || !fft_tables->reordertbl)
+    {
+        if (fft_tables->costbl) FreeMemory(fft_tables->costbl);
+        if (fft_tables->negsintbl) FreeMemory(fft_tables->negsintbl);
+        if (fft_tables->reordertbl) FreeMemory(fft_tables->reordertbl);
+        fft_tables->costbl = NULL;
+        fft_tables->negsintbl = NULL;
+        fft_tables->reordertbl = NULL;
+        return;
+    }
+
+    for (i = 0; i < FFT_MAXLOGM + 1; i++)
+    {
+        fft_tables->costbl[i] = NULL;
+        fft_tables->negsintbl[i] = NULL;
+        fft_tables->reordertbl[i] = NULL;
+    }
+
+    for (i = 0; i < FFT_MAXLOGM + 1; i++)
+    {
+        fft_tables->mdct_cos[i] = NULL;
+        fft_tables->mdct_sin[i] = NULL;
+    }
+
+    /* Precompute MDCT pre/post-twiddles for both block sizes now, so the
+       per-frame twiddle loop is a table lookup instead of a cos/sin recurrence. */
+    {
+        static const int logms[2] = { LOGM_SHORT, LOGM_LONG };
+        int t;
+        for (t = 0; t < 2; t++)
+        {
+            int logm = logms[t];
+            int size = 1 << logm;
+            faac_real freq = (faac_real)(2.0 * M_PI) / (faac_real)(4 << logm);
+            fftfloat *c = AllocMemory(size * sizeof(fftfloat));
+            fftfloat *s = AllocMemory(size * sizeof(fftfloat));
+
+            if (!c || !s)
+            {
+                if (c) FreeMemory(c);
+                if (s) FreeMemory(s);
+                continue;
+            }
+
+            for (i = 0; i < size; i++)
+            {
+                faac_real theta = freq * ((faac_real)i + (faac_real)0.125);
+                c[i] = (fftfloat)FAAC_COS(theta);
+                s[i] = (fftfloat)FAAC_SIN(theta);
+            }
+            fft_tables->mdct_cos[logm] = c;
+            fft_tables->mdct_sin[logm] = s;
+        }
+    }
 }
 
-void fft_terminate( FFT_Tables *fft_tables )
+void fft_terminate(FFT_Tables *fft_tables)
 {
-	int i;
+    int i;
 
-	for( i = 0; i< MAXLOGM+1; i++ )
-	{
-		if( fft_tables->costbl[i] != NULL )
-			FreeMemory( fft_tables->costbl[i] );
-		
-		if( fft_tables->negsintbl[i] != NULL )
-			FreeMemory( fft_tables->negsintbl[i] );
-			
-		if( fft_tables->reordertbl[i] != NULL )
-			FreeMemory( fft_tables->reordertbl[i] );
-	}
+    for (i = 0; i < FFT_MAXLOGM + 1; i++)
+    {
+        if (fft_tables->costbl[i] != NULL)
+            FreeMemory(fft_tables->costbl[i]);
 
-	FreeMemory( fft_tables->costbl );
-	FreeMemory( fft_tables->negsintbl );
-	FreeMemory( fft_tables->reordertbl );
+        if (fft_tables->negsintbl[i] != NULL)
+            FreeMemory(fft_tables->negsintbl[i]);
 
-	fft_tables->costbl		= NULL;
-	fft_tables->negsintbl	= NULL;
-	fft_tables->reordertbl	= NULL;
+        if (fft_tables->reordertbl[i] != NULL)
+            FreeMemory(fft_tables->reordertbl[i]);
+    }
+
+    for (i = 0; i < FFT_MAXLOGM + 1; i++)
+    {
+        if (fft_tables->mdct_cos[i] != NULL)
+            FreeMemory(fft_tables->mdct_cos[i]);
+        if (fft_tables->mdct_sin[i] != NULL)
+            FreeMemory(fft_tables->mdct_sin[i]);
+        fft_tables->mdct_cos[i] = NULL;
+        fft_tables->mdct_sin[i] = NULL;
+    }
+
+    FreeMemory(fft_tables->costbl);
+    FreeMemory(fft_tables->negsintbl);
+    FreeMemory(fft_tables->reordertbl);
+
+    fft_tables->costbl = NULL;
+    fft_tables->negsintbl = NULL;
+    fft_tables->reordertbl = NULL;
 }
 
-static void reorder2( FFT_Tables *fft_tables, faac_real *xr, faac_real *xi, int logm)
+
+/* Radix-4 DIF. Swapping the 2nd/3rd butterfly outputs yields plain
+ * bit-reversed order at the end, avoiding a digit-reversal permutation.
+ * logm=9 (512) isn't a power of 4, so it ends with one radix-2 stage.
+ */
+
+static void check_tables_radix4(FFT_Tables *fft_tables, int logm)
 {
-	int i;
-	int size = 1 << logm;
-	const unsigned short *r;
+    if (fft_tables->costbl[logm] == NULL)
+    {
+        int size = 1 << logm;
+        int i;
+        /* one table serves all stages: stage k needs W_N^{k<<2k'} via tw_idx below */
+        fft_tables->costbl[logm] = AllocMemory(size * sizeof(*(fft_tables->costbl[0])));
+        fft_tables->negsintbl[logm] = AllocMemory(size * sizeof(*(fft_tables->negsintbl[0])));
 
+        if (!fft_tables->costbl[logm] || !fft_tables->negsintbl[logm])
+        {
+            if (fft_tables->costbl[logm]) FreeMemory(fft_tables->costbl[logm]);
+            if (fft_tables->negsintbl[logm]) FreeMemory(fft_tables->negsintbl[logm]);
+            fft_tables->costbl[logm] = fft_tables->negsintbl[logm] = NULL;
+            return;
+        }
 
-	if ( fft_tables->reordertbl[logm] == NULL ) // create bit reversing table
-	{
-		fft_tables->reordertbl[logm] = AllocMemory(size * sizeof(*(fft_tables->reordertbl[0])));
-		if (!fft_tables->reordertbl[logm]) return;
-
-		for (i = 0; i < size; i++)
-		{
-			int reversed = 0;
-			int b0;
-			int tmp = i;
-
-			for (b0 = 0; b0 < logm; b0++)
-			{
-				reversed = (reversed << 1) | (tmp & 1);
-				tmp >>= 1;
-			}
-			fft_tables->reordertbl[logm][i] = reversed;
-		}
-	}
-
-	r = fft_tables->reordertbl[logm];
-
-	for (i = 0; i < size; i++)
-	{
-		int j = r[i];
-		faac_real tmp;
-
-		if (j <= i)
-			continue;
-
-		tmp = xr[i];
-		xr[i] = xr[j];
-		xr[j] = tmp;
-
-		tmp = xi[i];
-		xi[i] = xi[j];
-		xi[j] = tmp;
-	}
+        for (i = 0; i < size; i++)
+        {
+            faac_real theta = 2.0 * M_PI * (faac_real)i / (faac_real)size;
+            fft_tables->costbl[logm][i] = (fftfloat)FAAC_COS(theta);
+            fft_tables->negsintbl[logm][i] = (fftfloat)-FAAC_SIN(theta);
+        }
+    }
 }
 
-static void fft_proc(
-		faac_real * __restrict xr,
-		faac_real * __restrict xi,
-		const fftfloat * __restrict refac,
-		const fftfloat * __restrict imfac,
-		int size)
+static void radix4_dif_proc(
+    faac_real * restrict xr,
+    faac_real * restrict xi,
+    int logm,
+    const fftfloat * restrict costbl,
+    const fftfloat * restrict sintbl)
 {
-	int step, shift, pos;
-	int exp, estep;
+    int n = 1 << logm;
+    int n2 = n;
+    int n1;
+    int i, j, k;
 
-	estep = size >> 1;
-	/* First stage: step = 1
-	   Twiddle factor W_N^0 is always (1, 0).
-	   Eliminate all multiplications and table lookups.
-	*/
-	for (pos = 0; pos < size; pos += 2)
-	{
-		faac_real v2r, v2i;
-		int x1 = pos;
-		int x2 = pos + 1;
+    for (k = 0; k < (logm >> 1); k++)
+    {
+        n1 = n2;
+        n2 >>= 2;
+        for (i = 0; i < n; i += n1)
+        {
+            faac_real * restrict r1p = xr + i;
+            faac_real * restrict r2p = xr + i + n2;
+            faac_real * restrict r3p = xr + i + 2*n2;
+            faac_real * restrict r4p = xr + i + 3*n2;
+            faac_real * restrict i1p = xi + i;
+            faac_real * restrict i2p = xi + i + n2;
+            faac_real * restrict i3p = xi + i + 2*n2;
+            faac_real * restrict i4p = xi + i + 3*n2;
 
-		v2r = xr[x2];
-		v2i = xi[x2];
+            /* j=0 unrolled: skip the twiddle multiply, it's the identity here */
+            {
+                faac_real r1 = *r1p, i1 = *i1p;
+                faac_real r2 = *r2p, i2 = *i2p;
+                faac_real r3 = *r3p, i3 = *i3p;
+                faac_real r4 = *r4p, i4 = *i4p;
 
-		xr[x2] = xr[x1] - v2r;
-		xr[x1] += v2r;
+                faac_real t1 = r1 + r3, t2 = i1 + i3;
+                faac_real t3 = r2 + r4, t4 = i2 + i4;
+                faac_real t5 = r1 - r3, t6 = i1 - i3;
+                faac_real t7 = r2 - r4, t8 = i2 - i4;
 
-		xi[x2] = xi[x1] - v2i;
-		xi[x1] += v2i;
-	}
+                *r1p = t1 + t3; *i1p = t2 + t4;
+                *r3p = t5 + t8; *i3p = t6 - t7;
+                *r2p = t1 - t3; *i2p = t2 - t4;
+                *r4p = t5 - t8; *i4p = t6 + t7;
 
-	/* Second stage: step = 2
-	   shift = 0: Twiddle is (1, 0).
-	   shift = 1: Twiddle is (0, -1).
-	   Eliminate multiplications and avoid trig/table calls entirely.
-	*/
-	if (size >= 4) {
-		for (pos = 0; pos < size; pos += 4)
-		{
-			faac_real v2r, v2i;
-			int x1 = pos;
-			int x2 = pos + 2;
+                r1p++; r2p++; r3p++; r4p++;
+                i1p++; i2p++; i3p++; i4p++;
+            }
 
-			/* shift = 0: Rotation by 0 degrees */
-			v2r = xr[x2];
-			v2i = xi[x2];
+            /* unit-stride pointers, not xr[i+j+...], so the compiler can vectorize this */
+            for (j = 1; j < n2; j++)
+            {
+                int tw_idx = j << (2 * k);
+                const faac_real c1 = (faac_real)costbl[tw_idx];
+                const faac_real s1 = (faac_real)sintbl[tw_idx];
+                const faac_real c2 = (faac_real)costbl[2 * tw_idx];
+                const faac_real s2 = (faac_real)sintbl[2 * tw_idx];
+                const faac_real c3 = (faac_real)costbl[3 * tw_idx];
+                const faac_real s3 = (faac_real)sintbl[3 * tw_idx];
 
-			xr[x2] = xr[x1] - v2r;
-			xr[x1] += v2r;
+                faac_real r1 = *r1p, i1 = *i1p;
+                faac_real r2 = *r2p, i2 = *i2p;
+                faac_real r3 = *r3p, i3 = *i3p;
+                faac_real r4 = *r4p, i4 = *i4p;
 
-			xi[x2] = xi[x1] - v2i;
-			xi[x1] += v2i;
+                faac_real t1 = r1 + r3, t2 = i1 + i3;
+                faac_real t3 = r2 + r4, t4 = i2 + i4;
+                faac_real t5 = r1 - r3, t6 = i1 - i3;
+                faac_real t7 = r2 - r4, t8 = i2 - i4;
 
-			/* shift = 1: Rotation by -90 degrees */
-			x1++;
-			x2++;
+                *r1p = t1 + t3;
+                *i1p = t2 + t4;
 
-			v2r = xi[x2];
-			v2i = -xr[x2];
+                r1 = t1 - t3; i1 = t2 - t4;
+                r2 = t5 + t8; i2 = t6 - t7;
+                r3 = t5 - t8; i3 = t6 + t7;
 
-			xr[x2] = xr[x1] - v2r;
-			xr[x1] += v2r;
+                *r3p = r2 * c1 - i2 * s1;
+                *i3p = r2 * s1 + i2 * c1;
+                *r2p = r1 * c2 - i1 * s2;
+                *i2p = r1 * s2 + i1 * c2;
+                *r4p = r3 * c3 - i3 * s3;
+                *i4p = r3 * s3 + i3 * c3;
 
-			xi[x2] = xi[x1] - v2i;
-			xi[x1] += v2i;
-		}
-	}
+                r1p++; r2p++; r3p++; r4p++;
+                i1p++; i2p++; i3p++; i4p++;
+            }
+        }
+    }
 
-	/* Resume standard Radix-2 loop from stage 3 (step = 4) */
-	estep = 0;
-	for (step = 4; step < size; step *= 2)
-	{
-		for (pos = 0; pos < size; pos += (2 * step))
-		{
-			int x1 = pos;
-			int x2 = pos + step;
-			exp = estep;
-			for (shift = 0; shift < step; shift++)
-			{
-				faac_real v2r, v2i;
-
-				v2r = xr[x2] * refac[exp] - xi[x2] * imfac[exp];
-				v2i = xr[x2] * imfac[exp] + xi[x2] * refac[exp];
-
-				xr[x2] = xr[x1] - v2r;
-				xr[x1] += v2r;
-
-				xi[x2] = xi[x1] - v2i;
-				xi[x1] += v2i;
-
-				exp++;
-				x1++;
-				x2++;
-			}
-		}
-		estep += step;
-	}
+    /* odd logm: 4^k can't fill it, one radix-2 stage mops up the remainder */
+    if (logm & 1)
+    {
+        faac_real * restrict r1p = xr;
+        faac_real * restrict r2p = xr + 1;
+        faac_real * restrict i1p = xi;
+        faac_real * restrict i2p = xi + 1;
+        for (i = 0; i < n; i += 2)
+        {
+            faac_real r1 = *r1p, i1 = *i1p;
+            faac_real r2 = *r2p, i2 = *i2p;
+            *r1p = r1 + r2; *i1p = i1 + i2;
+            *r2p = r1 - r2; *i2p = i1 - i2;
+            r1p += 2; r2p += 2; i1p += 2; i2p += 2;
+        }
+    }
 }
 
-static void check_tables( FFT_Tables *fft_tables, int logm)
+static void bit_reverse(
+    faac_real * restrict xr,
+    faac_real * restrict xi,
+    int logm,
+    const unsigned short * restrict r)
 {
-	if( fft_tables->costbl[logm] == NULL )
-	{
-		int step;
-		int size = 1 << logm;
-		int offset = 0;
+    int i;
+    int size = 1 << logm;
 
-		if( fft_tables->negsintbl[logm] != NULL )
-			FreeMemory( fft_tables->negsintbl[logm] );
-
-		/* Total elements: 4 + 8 + ... + size/2 = size - 4.
-		   We allocate exactly the required size for stage-contiguous twiddles.
-		   Guard against size < 4 (logm < 2) which would result in negative allocation.
-		*/
-		int alloc_size = (size < 4) ? 0 : (size - 4);
-		fft_tables->costbl[logm]	= AllocMemory(alloc_size * sizeof(*(fft_tables->costbl[0])));
-		fft_tables->negsintbl[logm]	= AllocMemory(alloc_size * sizeof(*(fft_tables->negsintbl[0])));
-
-		if (!fft_tables->costbl[logm] || !fft_tables->negsintbl[logm])
-		{
-			if (fft_tables->costbl[logm]) FreeMemory(fft_tables->costbl[logm]);
-			if (fft_tables->negsintbl[logm]) FreeMemory(fft_tables->negsintbl[logm]);
-			fft_tables->costbl[logm] = fft_tables->negsintbl[logm] = NULL;
-			return;
-		}
-
-		for (step = 4; step < size; step *= 2)
-		{
-			int shift;
-			for (shift = 0; shift < step; shift++)
-			{
-				faac_real theta = M_PI * (faac_real)shift / (faac_real)step;
-				fft_tables->costbl[logm][offset] = (fftfloat)FAAC_COS(theta);
-				fft_tables->negsintbl[logm][offset] = (fftfloat)-FAAC_SIN(theta);
-				offset++;
-			}
-		}
-	}
+    for (i = 0; i < size; i++)
+    {
+        int j = (int)r[i];
+        if (j > i)
+        {
+            faac_real tr = xr[i]; xr[i] = xr[j]; xr[j] = tr;
+            faac_real ti = xi[i]; xi[i] = xi[j]; xi[j] = ti;
+        }
+    }
 }
 
-void fft( FFT_Tables *fft_tables, faac_real *xr, faac_real *xi, int logm)
+void fft(FFT_Tables *fft_tables, faac_real *xr, faac_real *xi, int logm)
 {
-	if (logm > MAXLOGM)
-	{
-		fprintf(stderr, "%s:%d: fft size too big (%d)\n",
-		        __FILE__, __LINE__, logm);
-		return;
-	}
+    if (logm > FFT_MAXLOGM) return;
+    if (logm < 1) return;
 
-	if (logm < 1)
-	{
-		//printf("logm < 1\n");
-		return;
-	}
+    check_tables_radix4(fft_tables, logm);
 
-	check_tables( fft_tables, logm);
+    if (fft_tables->reordertbl[logm] == NULL)
+    {
+        int size = 1 << logm;
+        int i;
+        fft_tables->reordertbl[logm] = AllocMemory(size * sizeof(*(fft_tables->reordertbl[0])));
+        if (!fft_tables->reordertbl[logm]) return;
 
-	reorder2( fft_tables, xr, xi, logm);
+        for (i = 0; i < size; i++)
+        {
+            int reversed = 0;
+            int b;
+            int tmp = i;
+            for (b = 0; b < logm; b++)
+            {
+                reversed = (reversed << 1) | (tmp & 1);
+                tmp >>= 1;
+            }
+            fft_tables->reordertbl[logm][i] = (unsigned short)reversed;
+        }
+    }
 
-	fft_proc( xr, xi, fft_tables->costbl[logm], fft_tables->negsintbl[logm], 1 << logm );
+    radix4_dif_proc(xr, xi, logm, fft_tables->costbl[logm], fft_tables->negsintbl[logm]);
+    bit_reverse(xr, xi, logm, fft_tables->reordertbl[logm]);
 }
 
-void rfft( FFT_Tables *fft_tables, faac_real *x, int logm)
-{
-	faac_real xi[1 << MAXLOGR];
-
-	if (logm > MAXLOGR)
-	{
-		fprintf(stderr, "%s:%d: rfft size too big (%d)\n",
-		        __FILE__, __LINE__, logm);
-		return;
-	}
-
-	memset(xi, 0, (1 << logm) * sizeof(xi[0]));
-
-	fft( fft_tables, x, xi, logm);
-
-	memcpy(x + (1 << (logm - 1)), xi, (1 << (logm - 1)) * sizeof(*x));
-}

--- a/libfaac/fft.h
+++ b/libfaac/fft.h
@@ -24,6 +24,8 @@
 
 #include "faac_real.h"
 
+#define FFT_MAXLOGM 9
+
 typedef faac_real fftfloat;
 
 typedef struct
@@ -31,12 +33,17 @@ typedef struct
     fftfloat **costbl;
     fftfloat **negsintbl;
     unsigned short **reordertbl;
+    /* MDCT pre/post-twiddle factors cos/sin(freq*(i+1/8)), one table pair per
+     * transform size (indexed by the size's fft logm). Precomputing them
+     * breaks the serial cos/sin recurrence that kept the MDCT twiddle loops
+     * from vectorizing, and is more accurate than the recurrence. */
+    fftfloat *mdct_cos[FFT_MAXLOGM + 1];
+    fftfloat *mdct_sin[FFT_MAXLOGM + 1];
 } FFT_Tables;
 
 void fft_initialize		( FFT_Tables *fft_tables );
 void fft_terminate	( FFT_Tables *fft_tables );
 
-void rfft			( FFT_Tables *fft_tables, faac_real *x, int logm );
 void fft			( FFT_Tables *fft_tables, faac_real *xr, faac_real *xi, int logm );
 
 #endif

--- a/libfaac/filtbank.c
+++ b/libfaac/filtbank.c
@@ -240,32 +240,31 @@ static void CalculateKBDWindow(faac_real* win, faac_real alpha, int length)
     }
 }
 
-void MDCT( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *work )
+void MDCT( FFT_Tables *fft_tables, faac_real * restrict data, int N, faac_real * restrict work )
 {
-    faac_real tempr, tempi, c, s, cold, cfreq, sfreq; /* temps for pre and post twiddle */
-    faac_real freq = TWOPI / N;
+    faac_real tempr, tempi;
     int i;
 
     /* Hoisted constants */
     const int N2 = N >> 1;
     const int N4 = N >> 2;
     const int N8 = N >> 3;
+    const int logm = (N == 2 * BLOCK_LEN_LONG) ? 9 : 6;
+
+    /* Twiddle factors cos/sin(freq*(i+1/8)), precomputed once in fft_initialize.
+       Indexing them (instead of the old serial cos/sin recurrence) lets the
+       twiddle loops below vectorize. */
+    const fftfloat * restrict tc = fft_tables->mdct_cos[logm];
+    const fftfloat * restrict ts = fft_tables->mdct_sin[logm];
 
     /* Pre/post-twiddle FFT buffers carved from the shared work buffer */
-    faac_real *xr = work;
-    faac_real *xi = work + N4;
+    faac_real * restrict xr = work;
+    faac_real * restrict xi = work + N4;
 
     /* Base pointers for address simplification */
     faac_real *base0 = data + N4;
     faac_real *base1 = data + (N4 - 1);
     faac_real *base2 = data + (N + N4 - 1);
-
-    /* prepare for recurrence relation in pre-twiddle */
-    cfreq = FAAC_COS(freq);
-    sfreq = FAAC_SIN(freq);
-
-    c = FAAC_COS(freq * 0.125);
-    s = FAAC_SIN(freq * 0.125);
 
     /* Induction variables */
     int n1 = N2 - 1;  /* descending: N/2 - 1 - 2i */
@@ -283,13 +282,8 @@ void MDCT( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *work )
         tempi = base0[n2] - base1[-n2];
 
         /* calculate pre-twiddled FFT input */
-        xr[i] = tempr * c + tempi * s;
-        xi[i] = tempi * c - tempr * s;
-
-        /* use recurrence to prepare cosine and sine for next value of i */
-        cold = c;
-        c = c * cfreq - s * sfreq;
-        s = s * cfreq + cold * sfreq;
+        xr[i] = tempr * tc[i] + tempi * ts[i];
+        xi[i] = tempi * tc[i] - tempr * ts[i];
 
         n1 -= 2;
         n2 += 2;
@@ -307,31 +301,15 @@ void MDCT( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *work )
         tempi = base0[n2] + base2[-n2];
 
         /* calculate pre-twiddled FFT input */
-        xr[i] = tempr * c + tempi * s;
-        xi[i] = tempi * c - tempr * s;
-
-        /* use recurrence to prepare cosine and sine for next value of i */
-        cold = c;
-        c = c * cfreq - s * sfreq;
-        s = s * cfreq + cold * sfreq;
+        xr[i] = tempr * tc[i] + tempi * ts[i];
+        xi[i] = tempi * tc[i] - tempr * ts[i];
 
         n1 -= 2;
         n2 += 2;
     }
 
     /* Perform in-place complex FFT of length N/4 */
-    switch (N) {
-    case BLOCK_LEN_SHORT * 2:
-        fft( fft_tables, xr, xi, 6);
-        break;
-    case BLOCK_LEN_LONG * 2:
-        fft( fft_tables, xr, xi, 9);
-        break;
-    }
-
-    /* prepare for recurrence relations in post-twiddle */
-    c = FAAC_COS(freq * 0.125);
-    s = FAAC_SIN(freq * 0.125);
+    fft( fft_tables, xr, xi, logm);
 
     /* Base pointers for output mapping */
     faac_real *base_even0 = data;
@@ -345,19 +323,14 @@ void MDCT( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *work )
     for (i = 0; i < N4; i++) {
 
         /* get post-twiddled FFT output */
-        tempr = 2. * (xr[i] * c + xi[i] * s);
-        tempi = 2. * (xi[i] * c - xr[i] * s);
+        tempr = (faac_real)2.0 * (xr[i] * tc[i] + xi[i] * ts[i]);
+        tempi = (faac_real)2.0 * (xi[i] * tc[i] - xr[i] * ts[i]);
 
         /* fill in output values */
         base_even0[n2] = -tempr;  /* first half even */
         base_odd0[-n2] =  tempi;  /* first half odd */
         base_even1[n2] = -tempi;  /* second half even */
         base_odd1[-n2] =  tempr;  /* second half odd */
-
-        /* use recurrence to prepare cosine and sine for next value of i */
-        cold = c;
-        c = c * cfreq - s * sfreq;
-        s = s * cfreq + cold * sfreq;
 
         n2 += 2;
     }

--- a/libfaac/filtbank.h
+++ b/libfaac/filtbank.h
@@ -39,7 +39,7 @@ void			FilterBankInit		( faacEncStruct* hEncoder );
 
 void			FilterBankEnd		( faacEncStruct* hEncoder );
 
-void			MDCT				( FFT_Tables *fft_tables, faac_real *data, int N, faac_real *work );
+void			MDCT				( FFT_Tables *fft_tables, faac_real * restrict data, int N, faac_real * restrict work );
 
 void			FilterBank( faacEncStruct* hEncoder,
 						CoderInfo *coderInfo,


### PR DESCRIPTION
Replace the radix-2 FFT with a radix-4 decimation-in-frequency transform and make it the only implementation. Radix-4 halves the number of butterfly stages at the sizes AAC uses (logm 6 and 9), giving ~18% faster encode versus the radix-2 baseline with the only cost of minor imperceptible changes at single-precision.

MDCT: precompute the pre/post-twiddle factors cos/sin(freq*(i+1/8)) once in fft_initialize for both transform sizes, indexed directly in the twiddle loops instead of the serial cos/sin recurrence that defeated vectorization.

## Benchmark

https://github.com/nschimme/faac/actions/runs/28694190279

<img width="566" height="749" alt="image" src="https://github.com/user-attachments/assets/4e21f6b3-3507-411a-bb98-69e99aa8a8bf" />
