### PR TITLE
relicense: reimplement channels and bitstream under LGPL 2.1

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -1380,6 +1380,8 @@ int main(int argc, char *argv[])
         free(bitbuf);
     if (aacFileNameGiven)
         free(aacFileName);
+    if (chanmap)
+        free(chanmap);
 
     return 0;
 }

--- a/libfaac/bitstream.c
+++ b/libfaac/bitstream.c
@@ -1,810 +1,93 @@
-/**********************************************************************
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
 
-This software module was originally developed by
-and edited by Texas Instruments in the course of
-development of the MPEG-2 NBC/MPEG-4 Audio standard
-ISO/IEC 13818-7, 14496-1,2 and 3. This software module is an
-implementation of a part of one or more MPEG-2 NBC/MPEG-4 Audio tools
-as specified by the MPEG-2 NBC/MPEG-4 Audio standard. ISO/IEC gives
-users of the MPEG-2 NBC/MPEG-4 Audio standards free license to this
-software module or modifications thereof for use in hardware or
-software products claiming conformance to the MPEG-2 NBC/ MPEG-4 Audio
-standards. Those intending to use this software module in hardware or
-software products are advised that this use may infringe existing
-patents. The original developer of this software module and his/her
-company, the subsequent editors and their companies, and ISO/IEC have
-no liability for use of this software module or modifications thereof
-in an implementation. Copyright is not released for non MPEG-2
-NBC/MPEG-4 Audio conforming products. The original developer retains
-full right to use the code for his/her own purpose, assign or donate
-the code to a third party and to inhibit third party from using the
-code for non MPEG-2 NBC/MPEG-4 Audio conforming products. This
-copyright notice must be included in all copies or derivative works.
-
-Copyright (c) 1997.
-**********************************************************************/
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "coder.h"
-#include "channels.h"
-#include "huff2.h"
 #include "bitstream.h"
 #include "util.h"
+#include <string.h>
+#include <stdlib.h>
 
-static int CountBitstream(faacEncStruct* hEncoder,
-                          CoderInfo *coderInfo,
-                          ChannelInfo *channelInfo,
-                          BitStream *bitStream,
-                          int numChannels);
-static int WriteADTSHeader(faacEncStruct* hEncoder,
-                           BitStream *bitStream,
-                           int writeFlag);
-static int WriteCPE(CoderInfo *coderInfoL,
-                    CoderInfo *coderInfoR,
-                    ChannelInfo *channelInfo,
-                    BitStream* bitStream,
-                    int writeFlag);
-static int WriteSCE(CoderInfo *coderInfo,
-                    ChannelInfo *channelInfo,
-                    BitStream *bitStream,
-                    int writeFlag);
-static int WriteLFE(CoderInfo *coderInfo,
-                    ChannelInfo *channelInfo,
-                    BitStream *bitStream,
-                    int writeFlag);
-static int WriteICSInfo(CoderInfo *coderInfo,
-                        BitStream *bitStream,
-                        int writeFlag);
-static int WriteICS(CoderInfo *coderInfo,
-                    BitStream *bitStream,
-                    int commonWindow,
-                    int writeFlag);
-static int WritePulseData(BitStream *bitStream,
-                          int writeFlag);
-static int WriteTNSData(CoderInfo *coderInfo,
-                        BitStream *bitStream,
-                        int writeFlag);
-static int WriteGainControlData(BitStream *bitStream,
-                                int writeFlag);
-static int WriteSpectralData(CoderInfo *coderInfo,
-                             BitStream *bitStream,
-                             int writeFlag);
-static int WriteAACFillBits(BitStream* bitStream,
-                            int numBits,
-                            int writeFlag);
-static int FindGroupingBits(CoderInfo *coderInfo);
-static long BufferNumBit(BitStream *bitStream);
-static int ByteAlign(BitStream* bitStream,
-                     int writeFlag, int bitsSoFar);
-
-int WriteBitstream(faacEncStruct* hEncoder,
-                   CoderInfo *coderInfo,
-                   ChannelInfo *channelInfo,
-                   BitStream *bitStream,
-                   int numChannel)
+BitStream *OpenBitStream(uint32_t size, uint8_t *buffer)
 {
-    int channel;
-    int bits = 0;
-    int bitsLeftAfterFill, numFillBits;
+    BitStream *bs = (BitStream *)AllocMemory(sizeof(BitStream));
+    if (!bs) return NULL;
 
-    if (CountBitstream(hEncoder, coderInfo, channelInfo, bitStream, numChannel) < 0)
-        return -1;
+    bs->data = buffer;
+    bs->size = size;
+    bs->currentBit = 0;
 
-    if(hEncoder->config.outputFormat == 1){
-        bits += WriteADTSHeader(hEncoder, bitStream, 1);
-    }else{
-        bits = 0; // compilier will remove it, byt anyone will see that current size of bitstream is 0
-    }
+    if (buffer) memset(buffer, 0, size);
 
-    for (channel = 0; channel < numChannel; channel++) {
-
-        if (channelInfo[channel].present) {
-
-            /* Write out a single_channel_element */
-            if (channelInfo[channel].type != ELEMENT_CPE) {
-
-                if (channelInfo[channel].type == ELEMENT_LFE) {
-                    /* Write out lfe */
-                    bits += WriteLFE(&coderInfo[channel],
-                        &channelInfo[channel],
-                        bitStream,
-                        1);
-                } else {
-                    /* Write out sce */
-                    bits += WriteSCE(&coderInfo[channel],
-                        &channelInfo[channel],
-                        bitStream,
-                        1);
-                }
-
-            } else {
-
-                if (channelInfo[channel].ch_is_left) {
-                    /* Write out cpe */
-                    bits += WriteCPE(&coderInfo[channel],
-                        &coderInfo[channelInfo[channel].paired_ch],
-                        &channelInfo[channel],
-                        bitStream,
-                        1);
-                }
-            }
-        }
-    }
-
-    /* Compute how many fill bits are needed to avoid overflowing bit reservoir */
-    /* Save room for ID_END terminator */
-    if (bits < (8 - LEN_SE_ID) ) {
-        numFillBits = 8 - LEN_SE_ID - bits;
-    } else {
-        numFillBits = 0;
-    }
-
-    /* Write AAC fill_elements, smallest fill element is 7 bits. */
-    /* Function may leave up to 6 bits left after fill, so tell it to fill a few extra */
-    numFillBits += 6;
-    bitsLeftAfterFill = WriteAACFillBits(bitStream, numFillBits, 1);
-    bits += (numFillBits - bitsLeftAfterFill);
-
-    /* Write ID_END terminator */
-    bits += LEN_SE_ID;
-    PutBit(bitStream, ID_END, LEN_SE_ID);
-
-    /* Now byte align the bitstream */
-    /*
-     * This byte_alignment() is correct for both MPEG2 and MPEG4, although
-     * in MPEG4 the byte_alignment() is officially done before the new frame
-     * instead of at the end. But this is basically the same.
-     */
-    bits += ByteAlign(bitStream, 1, bits);
-
-    return bits;
+    return bs;
 }
 
-static int CountBitstream(faacEncStruct* hEncoder,
-                          CoderInfo *coderInfo,
-                          ChannelInfo *channelInfo,
-                          BitStream *bitStream,
-                          int numChannel)
+int CloseBitStream(BitStream *bs)
 {
-    int channel;
-    int bits = 0;
-    int bitsLeftAfterFill, numFillBits;
-
-    if(hEncoder->config.outputFormat == 1){
-        bits += WriteADTSHeader(hEncoder, bitStream, 0);
-    }else{
-        bits = 0; // compilier will remove it, byt anyone will see that current size of bitstream is 0
-    }
-
-    for (channel = 0; channel < numChannel; channel++) {
-
-        if (channelInfo[channel].present) {
-
-            /* Write out a single_channel_element */
-            if (channelInfo[channel].type != ELEMENT_CPE) {
-
-                if (channelInfo[channel].type == ELEMENT_LFE) {
-                    /* Write out lfe */
-                    bits += WriteLFE(&coderInfo[channel],
-                        &channelInfo[channel],
-                        bitStream,
-                        0);
-                } else {
-                    /* Write out sce */
-                    bits += WriteSCE(&coderInfo[channel],
-                        &channelInfo[channel],
-                        bitStream,
-                        0);
-                }
-
-            } else {
-
-                if (channelInfo[channel].ch_is_left) {
-                    /* Write out cpe */
-                    bits += WriteCPE(&coderInfo[channel],
-                        &coderInfo[channelInfo[channel].paired_ch],
-                        &channelInfo[channel],
-                        bitStream,
-                        0);
-                }
-            }
-        }
-    }
-
-    /* Compute how many fill bits are needed to avoid overflowing bit reservoir */
-    /* Save room for ID_END terminator */
-    if (bits < (8 - LEN_SE_ID) ) {
-        numFillBits = 8 - LEN_SE_ID - bits;
-    } else {
-        numFillBits = 0;
-    }
-
-    /* Write AAC fill_elements, smallest fill element is 7 bits. */
-    /* Function may leave up to 6 bits left after fill, so tell it to fill a few extra */
-    numFillBits += 6;
-    bitsLeftAfterFill = WriteAACFillBits(bitStream, numFillBits, 0);
-    bits += (numFillBits - bitsLeftAfterFill);
-
-    /* Write ID_END terminator */
-    bits += LEN_SE_ID;
-
-    /* Now byte align the bitstream */
-    bits += ByteAlign(bitStream, 0, bits);
-
-    hEncoder->usedBytes = bit2byte(bits);
-
-    if (hEncoder->usedBytes > bitStream->size)
-    {
-        fprintf(stderr, "frame buffer overrun\n");
-        return -1;
-    }
-    if (hEncoder->usedBytes >= ADTS_FRAMESIZE)
-    {
-        fprintf(stderr, "frame size limit exceeded\n");
-        return -1;
-    }
-
-    return bits;
-}
-
-static int WriteADTSHeader(faacEncStruct* hEncoder,
-                           BitStream *bitStream,
-                           int writeFlag)
-{
-    int bits = 56;
-
-    if (writeFlag) {
-        /* Fixed ADTS header */
-        PutBit(bitStream, 0xFFFF, 12); /* 12 bit Syncword */
-        PutBit(bitStream, hEncoder->config.mpegVersion, 1); /* ID == 0 for MPEG4 AAC, 1 for MPEG2 AAC */
-        PutBit(bitStream, 0, 2); /* layer == 0 */
-        PutBit(bitStream, 1, 1); /* protection absent */
-        PutBit(bitStream, hEncoder->config.aacObjectType - 1, 2); /* profile */
-        PutBit(bitStream, hEncoder->sampleRateIdx, 4); /* sampling rate */
-        PutBit(bitStream, 0, 1); /* private bit */
-        PutBit(bitStream, hEncoder->numChannels, 3); /* ch. config (must be > 0) */
-                                                     /* simply using numChannels only works for
-                                                        6 channels or less, else a channel
-                                                        configuration should be written */
-        PutBit(bitStream, 0, 1); /* original/copy */
-        PutBit(bitStream, 0, 1); /* home */
-
-#if 0 // Removed in corrigendum 14496-3:2002
-        if (hEncoder->config.mpegVersion == 0)
-            PutBit(bitStream, 0, 2); /* emphasis */
-#endif
-
-        /* Variable ADTS header */
-        PutBit(bitStream, 0, 1); /* copyr. id. bit */
-        PutBit(bitStream, 0, 1); /* copyr. id. start */
-        PutBit(bitStream, hEncoder->usedBytes, 13);
-        PutBit(bitStream, 0x7FF, 11); /* buffer fullness (0x7FF for VBR) */
-        PutBit(bitStream, 0, 2); /* raw data blocks (0+1=1) */
-
-    }
-
-    /*
-     * MPEG2 says byte_aligment() here, but ADTS always is multiple of 8 bits
-     * MPEG4 has no byte_alignment() here
-     */
-    /*
-    if (hEncoder->config.mpegVersion == 1)
-        bits += ByteAlign(bitStream, writeFlag);
-    */
-
-#if 0 // Removed in corrigendum 14496-3:2002
-    if (hEncoder->config.mpegVersion == 0)
-        bits += 2; /* emphasis */
-#endif
-
-    return bits;
-}
-
-static int WriteCPE(CoderInfo *coderInfoL,
-                    CoderInfo *coderInfoR,
-                    ChannelInfo *channelInfo,
-                    BitStream* bitStream,
-                    int writeFlag)
-{
-    int bits = 0;
-
-    if (writeFlag) {
-        /* write ID_CPE, single_element_channel() identifier */
-        PutBit(bitStream, ID_CPE, LEN_SE_ID);
-
-        /* write the element_identifier_tag */
-        PutBit(bitStream, channelInfo->tag, LEN_TAG);
-
-        /* common_window? */
-        PutBit(bitStream, channelInfo->common_window, LEN_COM_WIN);
-    }
-
-    bits += LEN_SE_ID;
-    bits += LEN_TAG;
-    bits += LEN_COM_WIN;
-
-    /* if common_window, write ics_info */
-    if (channelInfo->common_window) {
-        int numWindows, maxSfb;
-
-        bits += WriteICSInfo(coderInfoL, bitStream, writeFlag);
-        numWindows = coderInfoL->groups.n;
-        maxSfb = coderInfoL->sfbn;
-
-        if (writeFlag) {
-            PutBit(bitStream, channelInfo->msInfo.is_present, LEN_MASK_PRES);
-            if (channelInfo->msInfo.is_present == 1) {
-                int g;
-                int b;
-                for (g=0;g<numWindows;g++) {
-                    for (b=0;b<maxSfb;b++) {
-                        PutBit(bitStream, channelInfo->msInfo.ms_used[g*maxSfb+b], LEN_MASK);
-                    }
-                }
-            }
-        }
-        bits += LEN_MASK_PRES;
-        if (channelInfo->msInfo.is_present == 1)
-            bits += (numWindows*maxSfb*LEN_MASK);
-    }
-
-    /* Write individual_channel_stream elements */
-    bits += WriteICS(coderInfoL, bitStream, channelInfo->common_window, writeFlag);
-    bits += WriteICS(coderInfoR, bitStream, channelInfo->common_window, writeFlag);
-
-    return bits;
-}
-
-static int WriteSCE(CoderInfo *coderInfo,
-                    ChannelInfo *channelInfo,
-                    BitStream *bitStream,
-                    int writeFlag)
-{
-    int bits = 0;
-
-    if (writeFlag) {
-        /* write Single Element Channel (SCE) identifier */
-        PutBit(bitStream, ID_SCE, LEN_SE_ID);
-
-        /* write the element identifier tag */
-        PutBit(bitStream, channelInfo->tag, LEN_TAG);
-    }
-
-    bits += LEN_SE_ID;
-    bits += LEN_TAG;
-
-    /* Write an Individual Channel Stream element */
-    bits += WriteICS(coderInfo, bitStream, 0, writeFlag);
-
-    return bits;
-}
-
-static int WriteLFE(CoderInfo *coderInfo,
-                    ChannelInfo *channelInfo,
-                    BitStream *bitStream,
-                    int writeFlag)
-{
-    int bits = 0;
-
-    if (writeFlag) {
-        /* write ID_LFE, lfe_element_channel() identifier */
-        PutBit(bitStream, ID_LFE, LEN_SE_ID);
-
-        /* write the element_identifier_tag */
-        PutBit(bitStream, channelInfo->tag, LEN_TAG);
-    }
-
-    bits += LEN_SE_ID;
-    bits += LEN_TAG;
-
-    /* Write an individual_channel_stream element */
-    bits += WriteICS(coderInfo, bitStream, 0, writeFlag);
-
-    return bits;
-}
-
-static int WriteICSInfo(CoderInfo *coderInfo,
-                        BitStream *bitStream,
-                        int writeFlag)
-{
-    int grouping_bits;
-    int bits = 0;
-
-    if (writeFlag) {
-        /* write out ics_info() information */
-        PutBit(bitStream, 0, LEN_ICS_RESERV);  /* reserved Bit*/
-
-        /* Write out window sequence */
-        PutBit(bitStream, coderInfo->block_type, LEN_WIN_SEQ);  /* block type */
-
-        /* Write out window shape */
-        PutBit(bitStream, coderInfo->window_shape, LEN_WIN_SH);  /* window shape */
-    }
-
-    bits += LEN_ICS_RESERV;
-    bits += LEN_WIN_SEQ;
-    bits += LEN_WIN_SH;
-
-    /* For short windows, write out max_sfb and scale_factor_grouping */
-    if (coderInfo->block_type == ONLY_SHORT_WINDOW){
-        if (writeFlag) {
-            PutBit(bitStream, coderInfo->sfbn, LEN_MAX_SFBS);
-            grouping_bits = FindGroupingBits(coderInfo);
-            PutBit(bitStream, grouping_bits, MAX_SHORT_WINDOWS - 1);  /* the grouping bits */
-        }
-        bits += LEN_MAX_SFBS;
-        bits += MAX_SHORT_WINDOWS - 1;
-    } else { /* Otherwise, write out max_sfb and predictor data */
-        if (writeFlag) {
-            PutBit(bitStream, coderInfo->sfbn, LEN_MAX_SFBL);
-        }
-        bits += LEN_MAX_SFBL;
-
-        bits++;
-        if (writeFlag)
-            PutBit(bitStream, 0, LEN_PRED_PRES);  /* predictor_data_present */
-    }
-
-    return bits;
-}
-
-static int WriteICS(CoderInfo *coderInfo,
-                    BitStream *bitStream,
-                    int commonWindow,
-                    int writeFlag)
-{
-    /* this function writes out an individual_channel_stream to the bitstream and */
-    /* returns the number of bits written to the bitstream */
-    int bits = 0;
-
-    /* Write the 8-bit global_gain */
-    if (writeFlag)
-        PutBit(bitStream, coderInfo->global_gain, LEN_GLOB_GAIN);
-    bits += LEN_GLOB_GAIN;
-
-    /* Write ics information */
-    if (!commonWindow) {
-        bits += WriteICSInfo(coderInfo, bitStream, writeFlag);
-    }
-
-    bits += writebooks(coderInfo, bitStream, writeFlag);
-    bits += writesf(coderInfo, bitStream, writeFlag);
-
-    bits += WritePulseData(bitStream, writeFlag);
-    bits += WriteTNSData(coderInfo, bitStream, writeFlag);
-    bits += WriteGainControlData(bitStream, writeFlag);
-
-    bits += WriteSpectralData(coderInfo, bitStream, writeFlag);
-
-    /* Return number of bits */
-    return bits;
-}
-
-static int WritePulseData(BitStream *bitStream,
-                          int writeFlag)
-{
-    int bits = 0;
-
-    if (writeFlag) {
-        PutBit(bitStream, 0, LEN_PULSE_PRES);  /* no pulse_data_present */
-    }
-
-    bits += LEN_PULSE_PRES;
-
-    return bits;
-}
-
-static int WriteTNSData(CoderInfo *coderInfo,
-                        BitStream *bitStream,
-                        int writeFlag)
-{
-    int bits = 0;
-    int numWindows;
-    int len_tns_nfilt;
-    int len_tns_length;
-    int len_tns_order;
-    int filtNumber;
-    int resInBits;
-    int bitsToTransmit;
-    unsigned long unsignedIndex;
-    int w;
-
-    TnsInfo* tnsInfoPtr = &coderInfo->tnsInfo;
-
-    if (writeFlag) {
-        PutBit(bitStream,tnsInfoPtr->tnsDataPresent,LEN_TNS_PRES);
-    }
-    bits += LEN_TNS_PRES;
-
-    /* If TNS is not present, bail */
-    if (!tnsInfoPtr->tnsDataPresent) {
-        return bits;
-    }
-
-    /* Set window-dependent TNS parameters */
-    if (coderInfo->block_type == ONLY_SHORT_WINDOW) {
-        numWindows = MAX_SHORT_WINDOWS;
-        len_tns_nfilt = LEN_TNS_NFILTS;
-        len_tns_length = LEN_TNS_LENGTHS;
-        len_tns_order = LEN_TNS_ORDERS;
-    }
-    else {
-        numWindows = 1;
-        len_tns_nfilt = LEN_TNS_NFILTL;
-        len_tns_length = LEN_TNS_LENGTHL;
-        len_tns_order = LEN_TNS_ORDERL;
-    }
-
-    /* Write TNS data */
-    bits += (numWindows * len_tns_nfilt);
-    for (w=0;w<numWindows;w++) {
-        TnsWindowData* windowDataPtr = &tnsInfoPtr->windowData[w];
-        int numFilters = windowDataPtr->numFilters;
-        if (writeFlag) {
-            PutBit(bitStream,numFilters,len_tns_nfilt); /* n_filt[] = 0 */
-        }
-        if (numFilters) {
-            bits += LEN_TNS_COEFF_RES;
-            resInBits = windowDataPtr->coefResolution;
-            if (writeFlag) {
-                PutBit(bitStream,resInBits-DEF_TNS_RES_OFFSET,LEN_TNS_COEFF_RES);
-            }
-            bits += numFilters * (len_tns_length+len_tns_order);
-            for (filtNumber=0;filtNumber<numFilters;filtNumber++) {
-                TnsFilterData* tnsFilterPtr=&windowDataPtr->tnsFilter[filtNumber];
-                int order = tnsFilterPtr->order;
-                if (writeFlag) {
-                    PutBit(bitStream,tnsFilterPtr->length,len_tns_length);
-                    PutBit(bitStream,order,len_tns_order);
-                }
-                if (order) {
-                    bits += (LEN_TNS_DIRECTION + LEN_TNS_COMPRESS);
-                    if (writeFlag) {
-                        PutBit(bitStream,tnsFilterPtr->direction,LEN_TNS_DIRECTION);
-                        PutBit(bitStream,tnsFilterPtr->coefCompress,LEN_TNS_COMPRESS);
-                    }
-                    bitsToTransmit = resInBits - tnsFilterPtr->coefCompress;
-                    bits += order * bitsToTransmit;
-                    if (writeFlag) {
-                        int i;
-                        for (i=1;i<=order;i++) {
-                            unsignedIndex = (unsigned long) (tnsFilterPtr->index[i])&(~(~0UL<<bitsToTransmit));
-                            PutBit(bitStream,unsignedIndex,bitsToTransmit);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    return bits;
-}
-
-static int WriteGainControlData(BitStream *bitStream,
-                                int writeFlag)
-{
-    int bits = 0;
-
-    if (writeFlag) {
-        PutBit(bitStream, 0, LEN_GAIN_PRES);
-    }
-
-    bits += LEN_GAIN_PRES;
-
-    return bits;
-}
-
-static int WriteSpectralData(CoderInfo *coderInfo,
-                             BitStream *bitStream,
-                             int writeFlag)
-{
-    int i, bits = 0;
-
-    if (writeFlag) {
-        for(i = 0; i < coderInfo->datacnt; i++) {
-            int data = coderInfo->s[i].data;
-            int len = coderInfo->s[i].len;
-            if (len > 0) {
-                PutBit(bitStream, data, len);
-                bits += len;
-            }
-        }
-    } else {
-        for(i = 0; i < coderInfo->datacnt; i++) {
-            bits += coderInfo->s[i].len;
-        }
-    }
-
-    return bits;
-}
-
-static int WriteAACFillBits(BitStream* bitStream,
-                            int numBits,
-                            int writeFlag)
-{
-    int numberOfBitsLeft = numBits;
-
-    /* Need at least (LEN_SE_ID + LEN_F_CNT) bits for a fill_element */
-    int minNumberOfBits = LEN_SE_ID + LEN_F_CNT;
-
-    while (numberOfBitsLeft >= minNumberOfBits)
-    {
-        int numberOfBytes;
-        int maxCount;
-
-        if (writeFlag) {
-            PutBit(bitStream, ID_FIL, LEN_SE_ID);   /* Write fill_element ID */
-        }
-        numberOfBitsLeft -= minNumberOfBits;    /* Subtract for ID,count */
-
-        numberOfBytes = (int)(numberOfBitsLeft/LEN_BYTE);
-        maxCount = (1<<LEN_F_CNT) - 1;  /* Max count without escaping */
-
-        /* if we have less than maxCount bytes, write them now */
-        if (numberOfBytes < maxCount) {
-            int i;
-            if (writeFlag) {
-                PutBit(bitStream, numberOfBytes, LEN_F_CNT);
-                for (i = 0; i < numberOfBytes; i++) {
-                    PutBit(bitStream, 0, LEN_BYTE);
-                }
-            }
-            /* otherwise, we need to write an escape count */
-        }
-        else {
-            int maxEscapeCount, maxNumberOfBytes, escCount;
-            int i;
-            if (writeFlag) {
-                PutBit(bitStream, maxCount, LEN_F_CNT);
-            }
-            maxEscapeCount = (1<<LEN_BYTE) - 1;  /* Max escape count */
-            maxNumberOfBytes = maxCount + maxEscapeCount;
-            numberOfBytes = (numberOfBytes > maxNumberOfBytes ) ? (maxNumberOfBytes) : (numberOfBytes);
-            escCount = numberOfBytes - maxCount;
-            if (writeFlag) {
-                PutBit(bitStream, escCount, LEN_BYTE);
-                for (i = 0; i < numberOfBytes-1; i++) {
-                    PutBit(bitStream, 0, LEN_BYTE);
-                }
-            }
-        }
-        numberOfBitsLeft -= LEN_BYTE*numberOfBytes;
-    }
-
-    return numberOfBitsLeft;
-}
-
-static int FindGroupingBits(CoderInfo *coderInfo)
-{
-    /* This function inputs the grouping information and outputs the seven bit
-    'grouping_bits' field that the AAC decoder expects.  */
-
-    int grouping_bits = 0;
-    int tmp[8];
-    int i, j;
-    int index = 0;
-
-    for(i = 0; i < coderInfo->groups.n; i++){
-        for (j = 0; j < coderInfo->groups.len[i]; j++){
-            tmp[index++] = i;
-        }
-    }
-
-    for(i = 1; i < 8; i++){
-        grouping_bits = grouping_bits << 1;
-        if(tmp[i] == tmp[i-1]) {
-            grouping_bits++;
-        }
-    }
-
-    return grouping_bits;
-}
-
-/* size in bytes! */
-BitStream *OpenBitStream(int size, unsigned char *buffer)
-{
-    BitStream *bitStream;
-
-    bitStream = AllocMemory(sizeof(BitStream));
-    if (!bitStream) return NULL;
-    bitStream->size = size;
-    bitStream->maxBit = (long)size * 8;
-    bitStream->numBit = 0;
-    bitStream->currentBit = 0;
-    bitStream->data = buffer;
-    SetMemory(bitStream->data, 0, size);
-
-    return bitStream;
-}
-
-int CloseBitStream(BitStream *bitStream)
-{
-    int bytes = bit2byte(bitStream->numBit);
-
-    FreeMemory(bitStream);
-
+    if (!bs) return 0;
+    int bytes = (int)((bs->currentBit + 7) >> 3);
+    FreeMemory(bs);
     return bytes;
 }
 
-static long BufferNumBit(BitStream *bitStream)
+/* Packs the low `numBits` bits of `data` into `bs`, MSB-first. Returns 0,
+ * or -1 if the write would run past the buffer. Most fields fit in a
+ * single byte, so that case short-circuits the general fill-from-the-end
+ * loop below rather than paying its per-iteration bookkeeping. */
+int PutBit(BitStream *bs, uint32_t data, int numBits)
 {
-    return bitStream->numBit;
-}
-
-int PutBit(BitStream *bitStream,
-           unsigned long data,
-           int numBit)
-{
-    /* write bits in packets according to buffer byte boundaries */
-
-    if (numBit == 0)
+    if (numBits <= 0)
         return 0;
 
-    /* refuse to write past the caller's buffer instead of corrupting
-       adjacent memory; can be hit with pathological configs (e.g. large
-       channel counts) that make the ASC/header overflow its fixed size */
-    if (bitStream->currentBit + numBit > bitStream->maxBit)
+    uint32_t start = bs->currentBit;
+    uint32_t end = start + (uint32_t)numBits;
+
+    if (end > bs->size * 8)
         return -1;
 
-    /* Hoist bitstream state for faster access */
-    unsigned int currentBit = (unsigned int)bitStream->currentBit;
-    unsigned int bitOffset = currentBit & 7;
-    unsigned char *ptr = bitStream->data + (currentBit >> 3);
+    bs->currentBit = end;
 
-    /* Update bitstream state immediately */
-    bitStream->currentBit += numBit;
-    bitStream->numBit = bitStream->currentBit;
+    if (numBits < 32)
+        data &= (1U << numBits) - 1;
 
-    /* Mask input data to ensure no extra bits are set */
-    data &= (1UL << numBit) - 1;
+    if ((start >> 3) == ((end - 1) >> 3)) {
+        uint32_t bitsAvailable = ((end - 1) & 7) + 1;
+        bs->data[start >> 3] |= (uint8_t)(data << (8 - bitsAvailable));
+        return 0;
+    }
 
-    /* Fast path: bit write fits within the current byte */
-    if (bitOffset + numBit <= 8) {
-        if (bitOffset == 0) *ptr = 0;
-        *ptr |= (unsigned char)(data << (8 - bitOffset - numBit));
-    } else {
-        /* General case: multi-byte write */
-        /* Handle first partial byte */
-        int firstBits = 8 - bitOffset;
-        if (bitOffset == 0) *ptr = 0;
-        *ptr++ |= (unsigned char)(data >> (numBit - firstBits));
-        numBit -= firstBits;
+    uint32_t bitPos = end;
+    while (numBits > 0) {
+        uint32_t byteIndex = (bitPos - 1) >> 3;
+        uint32_t bitsAvailable = ((bitPos - 1) & 7) + 1;
+        uint32_t take = (uint32_t)numBits < bitsAvailable ? (uint32_t)numBits : bitsAvailable;
+        uint32_t shift = 8 - bitsAvailable;
 
-        /* Handle full bytes */
-        while (numBit >= 8) {
-            *ptr++ = (unsigned char)((data >> (numBit - 8)) & 0xFF);
-            numBit -= 8;
-        }
+        bs->data[byteIndex] |= (uint8_t)((data & ((1U << take) - 1)) << shift);
 
-        /* Handle remaining bits in last byte */
-        if (numBit > 0) {
-            *ptr = (unsigned char)((data & ((1UL << numBit) - 1)) << (8 - numBit));
-        }
+        data >>= take;
+        numBits -= (int)take;
+        bitPos -= take;
     }
 
     return 0;
 }
 
-static int ByteAlign(BitStream *bitStream, int writeFlag, int bitsSoFar)
+int ByteAlign(BitStream *bs)
 {
-    int len, i,j;
-
-    if (writeFlag)
-    {
-        len = BufferNumBit(bitStream);
-    } else {
-        len = bitsSoFar;
+    int bits = (8 - (int)(bs->currentBit & 7)) & 7;
+    if (bits > 0) {
+        PutBit(bs, 0, bits);
     }
-
-    j = (8 - (len%8))%8;
-
-    if ((len % 8) == 0) j = 0;
-    if (writeFlag) {
-        for( i=0; i<j; i++ ) {
-            PutBit(bitStream, 0, 1);
-        }
-    }
-    return j;
+    return bits;
 }

--- a/libfaac/bitstream.h
+++ b/libfaac/bitstream.h
@@ -1,126 +1,117 @@
-/**********************************************************************
-MPEG-4 Audio VM
-Bit stream module
-
-
-
-This software module was originally developed by
-
-Heiko Purnhagen (University of Hannover)
-
-and edited by
-
-in the course of development of the MPEG-2 NBC/MPEG-4 Audio standard
-ISO/IEC 13818-7, 14496-1,2 and 3. This software module is an
-implementation of a part of one or more MPEG-2 NBC/MPEG-4 Audio tools
-as specified by the MPEG-2 NBC/MPEG-4 Audio standard. ISO/IEC gives
-users of the MPEG-2 NBC/MPEG-4 Audio standards free license to this
-software module or modifications thereof for use in hardware or
-software products claiming conformance to the MPEG-2 NBC/ MPEG-4 Audio
-standards. Those intending to use this software module in hardware or
-software products are advised that this use may infringe existing
-patents. The original developer of this software module and his/her
-company, the subsequent editors and their companies, and ISO/IEC have
-no liability for use of this software module or modifications thereof
-in an implementation. Copyright is not released for non MPEG-2
-NBC/MPEG-4 Audio conforming products. The original developer retains
-full right to use the code for his/her own purpose, assign or donate
-the code to a third party and to inhibit third party from using the
-code for non MPEG-2 NBC/MPEG-4 Audio conforming products. This
-copyright notice must be included in all copies or derivative works.
-
-Copyright (c) 1996.
-**********************************************************************/
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
 
 #ifndef BITSTREAM_H
 #define BITSTREAM_H
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 
-#include "frame.h"
-#include "coder.h"
-#include "channels.h"
+#include <stdint.h>
 
-/*
- * Raw bitstream constants
+/**
+ * ADTS Constants (ISO/IEC 14496-3)
  */
-#define LEN_SE_ID 3
-#define LEN_TAG 4
-#define LEN_GLOB_GAIN 8
-#define LEN_COM_WIN 1
-#define LEN_ICS_RESERV 1
-#define LEN_WIN_SEQ 2
-#define LEN_WIN_SH 1
-#define LEN_MAX_SFBL 6
-#define LEN_MAX_SFBS 4
-#define LEN_PRED_PRES 1
-#define LEN_MASK_PRES 2
-#define LEN_MASK 1
-#define LEN_PULSE_PRES 1
+enum {
+    ADTS_MAX_FRAME_SIZE = (1 << 13) - 1,
+    ADTS_FRAMESIZE      = 1 << 13, /* Legacy name compatibility */
+    ADTS_HEADER_SIZE    = 7        /* 56 bits */
+};
 
-#define LEN_TNS_PRES 1
-#define LEN_TNS_NFILTL 2
-#define LEN_TNS_NFILTS 1
-#define LEN_TNS_COEFF_RES 1
-#define LEN_TNS_LENGTHL 6
-#define LEN_TNS_LENGTHS 4
-#define LEN_TNS_ORDERL 5
-#define LEN_TNS_ORDERS 3
-#define LEN_TNS_DIRECTION 1
-#define LEN_TNS_COMPRESS 1
-#define LEN_GAIN_PRES 1
-
-#define LEN_F_CNT 4
-#define LEN_BYTE 8
-
-
-#define ID_SCE 0
-#define ID_CPE 1
-#define ID_CCE 2
-#define ID_LFE 3
-#define ID_DSE 4
-#define ID_PCE 5
-#define ID_FIL 6
-#define ID_END 7
-
-#define BYTE_NUMBIT 8       /* bits in byte (char) */
-#define LONG_NUMBIT 32      /* bits in unsigned long */
-#define bit2byte(a) (((a)+BYTE_NUMBIT-1)/BYTE_NUMBIT)
-
-enum {ADTS_FRAMESIZE = 1 << 13};
-
-typedef struct
-{
-  unsigned char *data;      /* data bits */
-  long numBit;          /* number of bits in buffer */
-  long size;            /* buffer size in bytes */
-  long maxBit;          /* maximum bits in buffer (size * 8) */
-  long currentBit;      /* current bit position in bit stream */
-  long numByte;         /* number of bytes read/written (only file) */
+/**
+ * @struct BitStream
+ * @brief Manages a bit-oriented buffer for AAC bitstream generation.
+ */
+typedef struct BitStream {
+    uint8_t *data;       /**< Pointer to the start of the bitstream buffer */
+    uint32_t size;       /**< Size of the buffer in bytes */
+    uint32_t currentBit; /**< Current write position in bits */
 } BitStream;
 
+BitStream *OpenBitStream(uint32_t size, uint8_t *buffer);
+int CloseBitStream(BitStream *bs);
+int PutBit(BitStream *bs, uint32_t data, int numBits);
+int ByteAlign(BitStream *bs);
 
+/* Batches small field writes into a register and flushes whole bytes as
+ * they fill, instead of touching the buffer on every write -- for hot
+ * loops (e.g. spectral coefficients) where PutBit's per-call overhead
+ * dominates. Bracket a self-contained span with no interleaved PutBit
+ * calls on the same stream: bs->currentBit is stale until AccumEnd. */
+typedef struct BitAccumulator {
+    uint64_t bits;   /**< pending bits, left-justified in the register */
+    uint8_t *out;    /**< next byte to emit into bs->data */
+    uint8_t *limit;  /**< bs->data + bs->size (one-past-end guard) */
+    BitStream *bs;   /**< owning stream; currentBit is stale until AccumEnd */
+    int fill;        /**< pending bit count (0..7 between calls) */
+    int overflow;    /**< sticky: set if a store hit the buffer limit */
+} BitAccumulator;
 
-int WriteBitstream(faacEncStruct* hEncoder,
-                   CoderInfo *coderInfo,
-                   ChannelInfo *channelInfo,
-                   BitStream *bitStream,
-                   int numChannels);
+static inline void AccumBegin(BitAccumulator *a, BitStream *bs)
+{
+    uint32_t bytePos = bs->currentBit >> 3;
+    a->bs = bs;
+    a->out = bs->data + bytePos;
+    a->limit = bs->data + bs->size;
+    a->fill = (int)(bs->currentBit & 7);
+    a->overflow = 0;
+    /* Preload the in-progress byte so its already-written high bits are
+     * preserved; its low (8-fill) bits are 0 (the buffer starts zeroed and
+     * we only ever move forward), so this seed is exact. */
+    a->bits = a->fill ? ((uint64_t)(*a->out) << 56) : 0;
+}
 
+static inline void AccumPutBits(BitAccumulator *a, uint32_t value, int numBits)
+{
+    if (numBits <= 0)
+        return;
 
-BitStream *OpenBitStream(int size, unsigned char *buffer);
+    if (numBits < 32)
+        value &= (1U << numBits) - 1;
 
-int CloseBitStream(BitStream *bitStream);
+    a->bits |= (uint64_t)value << (64 - a->fill - numBits);
+    a->fill += numBits;
 
-int PutBit(BitStream *bitStream,
-           unsigned long data,
-           int numBit);
+    while (a->fill >= 8) {
+        if (a->out < a->limit)
+            *a->out = (uint8_t)(a->bits >> 56);
+        else
+            a->overflow = 1;
+        a->out++;
+        a->bits <<= 8;
+        a->fill -= 8;
+    }
+}
+
+static inline int AccumEnd(BitAccumulator *a)
+{
+    if (a->fill > 0) {
+        if (a->out < a->limit)
+            *a->out = (uint8_t)(a->bits >> 56);
+        else
+            a->overflow = 1;
+        /* out is not advanced: these bits are unfinished, a later PutBit
+         * on the same stream will OR the rest of the byte in. */
+    }
+    a->bs->currentBit = (uint32_t)((a->out - a->bs->data) * 8 + a->fill);
+    return a->overflow ? -1 : 0;
+}
 
 #ifdef __cplusplus
 }
-#endif /* __cplusplus */
+#endif
 
 #endif /* BITSTREAM_H */
-

--- a/libfaac/blockswitch.c
+++ b/libfaac/blockswitch.c
@@ -118,37 +118,33 @@ void PsyEnd(PsyInfo * psyInfo, unsigned int numChannels)
 }
 
 /* Do psychoacoustical analysis */
-void PsyCalculate(ChannelInfo * channelInfo, PsyInfo * psyInfo,
+void PsyCalculate(AACElement * elements, int numElements, PsyInfo * psyInfo,
 			 unsigned int numChannels
 			)
 {
-  unsigned int channel;
+  if (elements == NULL) {
+      for (unsigned int channel = 0; channel < numChannels; channel++)
+          PsyCheckShort(&psyInfo[channel]);
+      return;
+  }
 
-  for (channel = 0; channel < numChannels; channel++)
+  for (int e = 0; e < numElements; e++)
   {
-    if (channelInfo[channel].present)
-    {
-
-      if (channelInfo[channel].type == ELEMENT_CPE &&
-	  channelInfo[channel].ch_is_left)
-      {				/* CPE */
-
-	int leftChan = channel;
-	int rightChan = channelInfo[channel].paired_ch;
-
-	PsyCheckShort(&psyInfo[leftChan]);
-	PsyCheckShort(&psyInfo[rightChan]);
+      AACElement *elem = &elements[e];
+      switch (elem->type) {
+          case ID_SCE:
+              PsyCheckShort(&psyInfo[elem->channels[0]]);
+              break;
+          case ID_CPE:
+              PsyCheckShort(&psyInfo[elem->channels[0]]);
+              PsyCheckShort(&psyInfo[elem->channels[1]]);
+              break;
+          case ID_LFE:
+              psyInfo[elem->channels[0]].block_type = ONLY_LONG_WINDOW;
+              break;
+          default:
+              break;
       }
-      else if (channelInfo[channel].type == ELEMENT_LFE)
-      {				/* LFE */
-        // Only set block type and it should be OK
-	psyInfo[channel].block_type = ONLY_LONG_WINDOW;
-      }
-      else if (channelInfo[channel].type == ELEMENT_SCE)
-      {				/* SCE */
-	PsyCheckShort(&psyInfo[channel]);
-      }
-    }
   }
 }
 

--- a/libfaac/blockswitch.h
+++ b/libfaac/blockswitch.h
@@ -48,7 +48,7 @@ typedef struct {
 void PsyInit (GlobalPsyInfo *gpsyInfo, PsyInfo *psyInfo,
 		unsigned int numChannels, unsigned int sampleRate);
 void PsyEnd (PsyInfo *psyInfo, unsigned int numChannels);
-void PsyCalculate (ChannelInfo *channelInfo, PsyInfo *psyInfo,
+void PsyCalculate (AACElement *elements, int numElements, PsyInfo *psyInfo,
 		unsigned int numChannels);
 void PsyBufferUpdate (GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo,
 		faac_real * restrict p_lookahead1,

--- a/libfaac/channels.c
+++ b/libfaac/channels.c
@@ -1,105 +1,304 @@
-/************************* MPEG-2 NBC Audio Decoder **************************
- *                                                                           *
-"This software module was originally developed in the course of
-development of the MPEG-2 NBC/MPEG-4 Audio standard ISO/IEC 13818-7,
-14496-1,2 and 3. This software module is an implementation of a part of one or more
-MPEG-2 NBC/MPEG-4 Audio tools as specified by the MPEG-2 NBC/MPEG-4
-Audio standard. ISO/IEC  gives users of the MPEG-2 NBC/MPEG-4 Audio
-standards free license to this software module or modifications thereof for use in
-hardware or software products claiming conformance to the MPEG-2 NBC/MPEG-4
-Audio  standards. Those intending to use this software module in hardware or
-software products are advised that this use may infringe existing patents.
-The original developer of this software module and his/her company, the subsequent
-editors and their companies, and ISO/IEC have no liability for use of this software
-module or modifications thereof in an implementation. Copyright is not released for
-non MPEG-2 NBC/MPEG-4 Audio conforming products.The original developer
-retains full right to use the code for his/her  own purpose, assign or donate the
-code to a third party and to inhibit third party from using the code for non
-MPEG-2 NBC/MPEG-4 Audio conforming products. This copyright notice must
-be included in all copies or derivative works."
-Copyright(c)1996.
- *                                                                           *
- ****************************************************************************/
 /*
- * $Id: channels.c,v 1.5 2001/09/04 18:39:35 menno Exp $
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  */
 
 #include "channels.h"
-#include "coder.h"
-#include "util.h"
+#include "huff2.h"
+#include "frame.h"
+#include <string.h>
+#include <stdio.h>
 
-/* If LFE present                                                       */
-/*  Num channels       # of SCE's       # of CPE's       #of LFE's      */
-/*  ============       ==========       ==========       =========      */
-/*      1                  1                0               0           */
-/*      2                  0                1               0           */
-/*      3                  1                1               0           */
-/*      4                  1                1               1           */
-/*      5                  1                2               0           */
-/* For more than 5 channels, use the following elements:                */
-/*      2*N                1                2*(N-1)         1           */
-/*      2*N+1              1                2*N             0           */
-/*                                                                      */
-/* Else:                                                                */
-/*                                                                      */
-/*  Num channels       # of SCE's       # of CPE's       #of LFE's      */
-/*  ============       ==========       ==========       =========      */
-/*      1                  1                0               0           */
-/*      2                  0                1               0           */
-/*      3                  1                1               0           */
-/*      4                  2                1               0           */
-/*      5                  1                2               0           */
-/* For more than 5 channels, use the following elements:                */
-/*      2*N                2                2*(N-1)         0           */
-/*      2*N+1              1                2*N             0           */
+_Static_assert(TNS_MAX_FILTERS == (1 << LEN_TNS_NFILTL),
+               "coder.h's TnsWindowData.tnsFilter[] bound must match the LEN_TNS_NFILTL bitstream field width");
 
-void GetChannelInfo(ChannelInfo *channelInfo, int numChannels, int useLfe)
+/**
+ * Maps input channels to AAC elements (SCE, CPE, LFE), per ISO/IEC 14496-3's
+ * channel configuration table: one SCE up front unless exactly 2 channels
+ * remain, then as many CPEs as fit two at a time, then a trailing odd
+ * channel becomes an LFE (if enabled) or a final SCE.
+ */
+int InitElements(AACElement * __restrict elements, int *numElements, int numChannels, bool useLfe)
 {
-    int sceTag = 0;
-    int lfeTag = 0;
-    int cpeTag = 0;
-    int numChannelsLeft = numChannels;
+    uint8_t sceTag = 0;
+    uint8_t cpeTag = 0;
+    uint8_t lfeTag = 0;
 
+    int currentElem = 0;
+    int currentCh = 0;
+    int channelsRemaining = numChannels;
 
-    /* First element is sce, except for 2 channel case */
-    if (numChannelsLeft != 2) {
-        channelInfo[numChannels-numChannelsLeft].present = 1;
-        channelInfo[numChannels-numChannelsLeft].tag = sceTag++;
-        channelInfo[numChannels-numChannelsLeft].type = ELEMENT_SCE;
-        numChannelsLeft--;
+    memset(elements, 0, sizeof(AACElement) * MAX_CHANNELS);
+
+    // Initial SCE for Config 1, 3, 4, 5, 6, 7
+    if (channelsRemaining != 2 && channelsRemaining > 0) {
+        elements[currentElem].type = ID_SCE;
+        elements[currentElem].tag = sceTag++;
+        elements[currentElem].channels[0] = currentCh++;
+        elements[currentElem].channels[1] = -1;
+
+        currentElem++;
+        channelsRemaining--;
     }
 
-    /* Next elements are cpe's */
-    while (numChannelsLeft > 1) {
-        /* Left channel info */
-        channelInfo[numChannels-numChannelsLeft].present = 1;
-        channelInfo[numChannels-numChannelsLeft].tag = cpeTag++;
-        channelInfo[numChannels-numChannelsLeft].common_window = 0;
-        channelInfo[numChannels-numChannelsLeft].ch_is_left = 1;
-        channelInfo[numChannels-numChannelsLeft].paired_ch = numChannels-numChannelsLeft+1;
-        channelInfo[numChannels-numChannelsLeft].type = ELEMENT_CPE;
-        numChannelsLeft--;
+    // CPE groups
+    while (channelsRemaining > 1) {
+        elements[currentElem].type = ID_CPE;
+        elements[currentElem].tag = cpeTag++;
+        elements[currentElem].channels[0] = currentCh++;
+        elements[currentElem].channels[1] = currentCh++;
 
-        /* Right channel info */
-        channelInfo[numChannels-numChannelsLeft].present = 1;
-        channelInfo[numChannels-numChannelsLeft].common_window = 0;
-        channelInfo[numChannels-numChannelsLeft].ch_is_left = 0;
-        channelInfo[numChannels-numChannelsLeft].paired_ch = numChannels-numChannelsLeft-1;
-        channelInfo[numChannels-numChannelsLeft].type = ELEMENT_CPE;
-        numChannelsLeft--;
+        currentElem++;
+        channelsRemaining -= 2;
     }
 
-    /* Is there another channel left ? */
-    if (numChannelsLeft) {
+    // Residual SCE or LFE
+    if (channelsRemaining == 1) {
         if (useLfe) {
-            channelInfo[numChannels-numChannelsLeft].present = 1;
-            channelInfo[numChannels-numChannelsLeft].tag = lfeTag++;
-            channelInfo[numChannels-numChannelsLeft].type = ELEMENT_LFE;
+            elements[currentElem].type = ID_LFE;
+            elements[currentElem].tag = lfeTag++;
         } else {
-            channelInfo[numChannels-numChannelsLeft].present = 1;
-            channelInfo[numChannels-numChannelsLeft].tag = sceTag++;
-            channelInfo[numChannels-numChannelsLeft].type = ELEMENT_SCE;
+            elements[currentElem].type = ID_SCE;
+            elements[currentElem].tag = sceTag++;
         }
-        numChannelsLeft--;
+        elements[currentElem].channels[0] = currentCh++;
+        elements[currentElem].channels[1] = -1;
+
+        currentElem++;
     }
+
+    *numElements = currentElem;
+    return 0;
+}
+
+static int WriteICSInfo(BitStream *bs, CoderInfo *coder, bool writeFlag)
+{
+    if (writeFlag) {
+        PutBit(bs, 0, LEN_ICS_RESERV);
+        PutBit(bs, coder->block_type, LEN_WIN_SEQ);
+        PutBit(bs, coder->window_shape, LEN_WIN_SH);
+    }
+    int bits = LEN_ICS_RESERV + LEN_WIN_SEQ + LEN_WIN_SH;
+
+    if (coder->block_type == ONLY_SHORT_WINDOW) {
+        if (writeFlag) {
+            PutBit(bs, coder->sfbn, LEN_MAX_SFBS);
+
+            int grouping_bits = 0;
+            int tmp[MAX_SHORT_WINDOWS], index = 0;
+            for (int i = 0; i < coder->groups.n; i++)
+                for (int j = 0; j < coder->groups.len[i]; j++)
+                    tmp[index++] = i;
+            for (int i = 1; i < MAX_SHORT_WINDOWS; i++) {
+                grouping_bits <<= 1;
+                if (tmp[i] == tmp[i-1]) grouping_bits++;
+            }
+            PutBit(bs, grouping_bits, MAX_SHORT_WINDOWS - 1);
+        }
+        bits += LEN_MAX_SFBS + (MAX_SHORT_WINDOWS - 1);
+    } else {
+        if (writeFlag) {
+            PutBit(bs, coder->sfbn, LEN_MAX_SFBL);
+            PutBit(bs, 0, LEN_PRED_PRES);
+        }
+        bits += LEN_MAX_SFBL + LEN_PRED_PRES;
+    }
+
+    return bits;
+}
+
+static int WriteICS(BitStream *bs, CoderInfo *coder, bool commonWindow, bool writeFlag)
+{
+    if (writeFlag) PutBit(bs, coder->global_gain, LEN_GLOB_GAIN);
+    int bits = LEN_GLOB_GAIN;
+
+    if (!commonWindow) bits += WriteICSInfo(bs, coder, writeFlag);
+
+    bits += writebooks(coder, bs, writeFlag);
+    bits += writesf(coder, bs, writeFlag);
+
+    if (writeFlag) PutBit(bs, 0, LEN_PULSE_PRES);
+    bits += LEN_PULSE_PRES;
+
+    TnsInfo *tns = &coder->tnsInfo;
+    if (writeFlag) PutBit(bs, tns->tnsDataPresent, LEN_TNS_PRES);
+    bits += LEN_TNS_PRES;
+
+    if (tns->tnsDataPresent) {
+        int nf_len = (coder->block_type == ONLY_SHORT_WINDOW) ? LEN_TNS_NFILTS : LEN_TNS_NFILTL;
+        int l_len  = (coder->block_type == ONLY_SHORT_WINDOW) ? LEN_TNS_LENGTHS : LEN_TNS_LENGTHL;
+        int o_len  = (coder->block_type == ONLY_SHORT_WINDOW) ? LEN_TNS_ORDERS : LEN_TNS_ORDERL;
+        int num_w  = (coder->block_type == ONLY_SHORT_WINDOW) ? MAX_SHORT_WINDOWS : 1;
+
+        for (int w = 0; w < num_w; w++) {
+            TnsWindowData *win = &tns->windowData[w];
+            if (writeFlag) PutBit(bs, win->numFilters, nf_len);
+            bits += nf_len;
+
+            if (win->numFilters > 0) {
+                if (writeFlag) PutBit(bs, win->coefResolution - 3, LEN_TNS_COEFF_RES);
+                bits += LEN_TNS_COEFF_RES;
+
+                for (int f = 0; f < win->numFilters; f++) {
+                    TnsFilterData *flt = &win->tnsFilter[f];
+                    if (writeFlag) {
+                        PutBit(bs, flt->length, l_len);
+                        PutBit(bs, flt->order, o_len);
+                    }
+                    bits += l_len + o_len;
+
+                    if (flt->order > 0) {
+                        if (writeFlag) {
+                            PutBit(bs, flt->direction, LEN_TNS_DIRECTION);
+                            PutBit(bs, flt->coefCompress, LEN_TNS_COMPRESS);
+                        }
+                        bits += LEN_TNS_DIRECTION + LEN_TNS_COMPRESS;
+
+                        int res = win->coefResolution - flt->coefCompress;
+                        for (int i = 1; i <= flt->order; i++) {
+                            if (writeFlag) PutBit(bs, flt->index[i] & ((1 << res) - 1), res);
+                            bits += res;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (writeFlag) PutBit(bs, 0, LEN_GAIN_PRES);
+    bits += LEN_GAIN_PRES;
+
+    if (writeFlag) {
+        BitAccumulator acc = {0};
+        AccumBegin(&acc, bs);
+        for (int i = 0; i < coder->datacnt; i++) {
+            if (coder->s[i].len > 0) {
+                AccumPutBits(&acc, (uint32_t)coder->s[i].data, coder->s[i].len);
+                bits += coder->s[i].len;
+            }
+        }
+        AccumEnd(&acc);
+    } else {
+        for (int i = 0; i < coder->datacnt; i++) bits += coder->s[i].len;
+    }
+
+    return bits;
+}
+
+int WriteElement(BitStream *bs, AACElement *elem, CoderInfo *coder, bool writeFlag)
+{
+    if (writeFlag) {
+        PutBit(bs, elem->type, LEN_SE_ID);
+        PutBit(bs, elem->tag, LEN_TAG);
+    }
+    int bits = LEN_SE_ID + LEN_TAG;
+
+    switch (elem->type) {
+        case ID_SCE:
+        case ID_LFE:
+            bits += WriteICS(bs, &coder[elem->channels[0]], false, writeFlag);
+            break;
+
+        case ID_CPE:
+            if (writeFlag) PutBit(bs, elem->common_window, LEN_COM_WIN);
+            bits += LEN_COM_WIN;
+
+            if (elem->common_window) {
+                bits += WriteICSInfo(bs, &coder[elem->channels[0]], writeFlag);
+                if (writeFlag) {
+                    PutBit(bs, elem->msInfo.is_present, LEN_MASK_PRES);
+                    if (elem->msInfo.is_present == 1) {
+                        int n = coder[elem->channels[0]].groups.n * coder[elem->channels[0]].sfbn;
+                        for (int i = 0; i < n; i++) PutBit(bs, elem->msInfo.ms_used[i], LEN_MASK);
+                    }
+                }
+                bits += LEN_MASK_PRES;
+                if (elem->msInfo.is_present == 1)
+                    bits += coder[elem->channels[0]].groups.n * coder[elem->channels[0]].sfbn * LEN_MASK;
+            }
+            bits += WriteICS(bs, &coder[elem->channels[0]], elem->common_window, writeFlag);
+            bits += WriteICS(bs, &coder[elem->channels[1]], elem->common_window, writeFlag);
+            break;
+        default: break;
+    }
+    return bits;
+}
+
+static int WriteADTSHeader(struct faacEncStruct *hEncoder, BitStream *bs, bool writeFlag)
+{
+    if (writeFlag) {
+        PutBit(bs, 0xFFF, LEN_ADTS_SYNC);
+        PutBit(bs, hEncoder->config.mpegVersion, LEN_ADTS_ID);
+        PutBit(bs, 0, LEN_ADTS_LAYER);
+        PutBit(bs, 1, LEN_ADTS_ABSENT);
+        PutBit(bs, hEncoder->config.aacObjectType - 1, LEN_ADTS_PROFILE);
+        PutBit(bs, hEncoder->sampleRateIdx, LEN_ADTS_FREQ);
+        PutBit(bs, 0, LEN_ADTS_PRIV);
+        PutBit(bs, hEncoder->numChannels, LEN_ADTS_CH_CFG);
+        PutBit(bs, 0, LEN_ADTS_ORIG);
+        PutBit(bs, 0, LEN_ADTS_HOME);
+
+        PutBit(bs, 0, LEN_ADTS_COPY_ID);
+        PutBit(bs, 0, LEN_ADTS_COPY_ST);
+        PutBit(bs, hEncoder->usedBytes, LEN_ADTS_FRAME);
+        PutBit(bs, 0x7FF, LEN_ADTS_FULL);
+        PutBit(bs, 0, LEN_ADTS_BLOCKS);
+    }
+    return 56;
+}
+
+static int WriteAACFillBits(BitStream *bs, int numBits, bool writeFlag)
+{
+    int left = numBits;
+    while (left >= (LEN_SE_ID + 4)) {
+        if (writeFlag) PutBit(bs, ID_FIL, LEN_SE_ID);
+        left -= LEN_SE_ID;
+        int bc = (left / 8 < 15) ? (left / 8) : 15;
+        if (writeFlag) PutBit(bs, bc, 4);
+        left -= 4;
+        if (bc == 15) {
+            int esc = (left / 8 - 14 < 255) ? (left / 8 - 14) : 255;
+            if (writeFlag) PutBit(bs, esc, 8);
+            left -= 8;
+            bc = 14 + esc;
+        }
+        if (writeFlag) for (int i = 0; i < bc; i++) PutBit(bs, 0, 8);
+        left -= bc * 8;
+    }
+    return left;
+}
+
+static int BuildFrame(struct faacEncStruct *hEncoder, CoderInfo *coder, AACElement *elems, int nElems, BitStream *bs, bool write)
+{
+    int bits = 0;
+    if (hEncoder->config.outputFormat == 1) bits += WriteADTSHeader(hEncoder, bs, write);
+    for (int i = 0; i < nElems; i++) bits += WriteElement(bs, &elems[i], coder, write);
+    int f = (bits < (8 - LEN_SE_ID)) ? (8 - LEN_SE_ID - bits) : 0;
+    f += 6;
+    bits += (f - WriteAACFillBits(bs, f, write));
+    if (write) PutBit(bs, ID_END, LEN_SE_ID);
+    bits += LEN_SE_ID;
+    int pad = (8 - (bits & 7)) & 7;
+    if (write) for (int i = 0; i < pad; i++) PutBit(bs, 0, 1);
+    return bits + pad;
+}
+
+int WriteBitstream(struct faacEncStruct *hEncoder, CoderInfo *coder, AACElement *elems, int nElems, BitStream *bs)
+{
+    int bits = BuildFrame(hEncoder, coder, elems, nElems, bs, false);
+    if (bits < 0) return -1;
+    hEncoder->usedBytes = (bits + 7) >> 3;
+    if (hEncoder->usedBytes > bs->size) return -1;
+    if (hEncoder->usedBytes > ADTS_MAX_FRAME_SIZE) return -1;
+    return BuildFrame(hEncoder, coder, elems, nElems, bs, true);
 }

--- a/libfaac/channels.h
+++ b/libfaac/channels.h
@@ -1,6 +1,6 @@
 /*
  * FAAC - Freeware Advanced Audio Coder
- * Copyright (C) 2001 Menno Bakker
+ * Copyright (C) 2026 Nils Schimmelmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -11,48 +11,107 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- * $Id: channels.h,v 1.7 2003/06/26 19:19:41 knik Exp $
  */
 
 #ifndef CHANNEL_H
 #define CHANNEL_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
+#include <stdbool.h>
+#include <stdint.h>
+#include "bitstream.h"
 #include "coder.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Forward declaration for core struct to avoid circular dependency */
+struct faacEncStruct;
+
+/**
+ * AAC Syntax Element identifiers (ISO/IEC 14496-3, Table 4.1).
+ */
+typedef enum {
+    ID_SCE = 0, /**< Single Channel Element */
+    ID_CPE = 1, /**< Channel Pair Element   */
+    ID_CCE = 2, /**< Coupling Channel Element */
+    ID_LFE = 3, /**< Low Frequency Element    */
+    ID_DSE = 4, /**< Data Stream Element      */
+    ID_PCE = 5, /**< Program Config Element   */
+    ID_FIL = 6, /**< Fill Element             */
+    ID_END = 7  /**< Terminator               */
+} ElementID;
+
+/**
+ * Bitstream field lengths (ISO/IEC 14496-3).
+ */
+enum {
+    LEN_SE_ID           = 3,
+    LEN_TAG             = 4,
+    LEN_COM_WIN         = 1,
+    LEN_ICS_RESERV      = 1,
+    LEN_WIN_SEQ         = 2,
+    LEN_WIN_SH          = 1,
+    LEN_MAX_SFBL        = 6,
+    LEN_MAX_SFBS        = 4,
+    LEN_GLOB_GAIN       = 8,
+    LEN_PRED_PRES       = 1,
+    LEN_MASK_PRES       = 2,
+    LEN_MASK            = 1,
+    LEN_PULSE_PRES      = 1,
+    LEN_TNS_PRES        = 1,
+    LEN_GAIN_PRES       = 1,
+    LEN_TNS_NFILTL      = 2,
+    LEN_TNS_NFILTS      = 1,
+    LEN_TNS_COEFF_RES   = 1,
+    LEN_TNS_LENGTHL     = 6,
+    LEN_TNS_LENGTHS     = 4,
+    LEN_TNS_ORDERL      = 5,
+    LEN_TNS_ORDERS      = 3,
+    LEN_TNS_DIRECTION   = 1,
+    LEN_TNS_COMPRESS    = 1,
+    LEN_ADTS_SYNC       = 12,
+    LEN_ADTS_ID         = 1,
+    LEN_ADTS_LAYER      = 2,
+    LEN_ADTS_ABSENT     = 1,
+    LEN_ADTS_PROFILE    = 2,
+    LEN_ADTS_FREQ       = 4,
+    LEN_ADTS_PRIV       = 1,
+    LEN_ADTS_CH_CFG     = 3,
+    LEN_ADTS_ORIG       = 1,
+    LEN_ADTS_HOME       = 1,
+    LEN_ADTS_COPY_ID    = 1,
+    LEN_ADTS_COPY_ST    = 1,
+    LEN_ADTS_FRAME      = 13,
+    LEN_ADTS_FULL       = 11,
+    LEN_ADTS_BLOCKS     = 2
+};
+
 typedef struct {
-    int is_present;
-    int ms_used[MAX_SCFAC_BANDS];
+    bool is_present;
+    uint8_t ms_used[MAX_SCFAC_BANDS];
 } MSInfo;
 
-typedef enum {
-    ELEMENT_SCE,
-    ELEMENT_CPE,
-    ELEMENT_LFE
-} ElementType;
-
 typedef struct {
-    int tag;
-    int present;
-    int ch_is_left;
-    int paired_ch;
-    int common_window;
-    ElementType type;
+    ElementID type;
+    uint8_t tag;
+    int channels[2];
+    bool common_window;
     MSInfo msInfo;
-} ChannelInfo;
+} AACElement;
 
-void GetChannelInfo(ChannelInfo *channelInfo, int numChannels, int useLfe);
+int InitElements(AACElement * __restrict elements, int *numElements, int numChannels, bool useLfe);
+
+int WriteElement(BitStream *bs, AACElement *elem, CoderInfo *coder, bool writeFlag);
+
+int WriteBitstream(struct faacEncStruct* hEncoder,
+                   CoderInfo *coderInfo,
+                   AACElement *elements,
+                   int numElements,
+                   BitStream *bitStream);
 
 #ifdef __cplusplus
 }
-#endif /* __cplusplus */
+#endif
 
 #endif /* CHANNEL_H */

--- a/libfaac/coder.h
+++ b/libfaac/coder.h
@@ -15,8 +15,6 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- * $Id: coder.h,v 1.13 2005/02/02 07:49:10 sur Exp $
  */
 
 #ifndef CODER_H
@@ -49,8 +47,10 @@ enum WINDOW_TYPE {
 #define DEF_TNS_COEFF_THRESH 0.1
 #define DEF_TNS_COEFF_RES 4
 #define DEF_TNS_RES_OFFSET 3
-#define LEN_TNS_NFILTL 2
-#define LEN_TNS_NFILTS 1
+/* Bound on TnsWindowData.tnsFilter[]. Must stay in sync with the bitstream
+ * field width LEN_TNS_NFILTL (channels.h) -- checked by a _Static_assert in
+ * channels.c, since this header can't include channels.h without a cycle. */
+#define TNS_MAX_FILTERS 4
 
 typedef struct {
     int order;                           /* Filter order */
@@ -65,7 +65,7 @@ typedef struct {
 typedef struct {
     int numFilters;                             /* Number of filters */
     int coefResolution;                         /* Coefficient resolution */
-    TnsFilterData tnsFilter[1<<LEN_TNS_NFILTL]; /* TNS filters */
+    TnsFilterData tnsFilter[TNS_MAX_FILTERS];    /* TNS filters */
 } TnsWindowData;
 
 typedef struct {
@@ -79,7 +79,7 @@ typedef struct {
     TnsWindowData windowData[MAX_SHORT_WINDOWS]; /* TNS data per window */
 } TnsInfo;
 
-typedef struct {
+typedef struct CoderInfo {
     int window_shape;
     int prev_window_shape;
     int block_type;

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -84,6 +84,18 @@ static unsigned int CalcBandwidth(unsigned long bitRate, unsigned long sampleRat
     return (bw > nyquist) ? nyquist : bw;
 }
 
+/* Element-to-channel mapping is fixed for the session once InitElements has
+ * run, so cache which channels are LFE here instead of rescanning
+ * hEncoder->elements[] for every channel on every frame. */
+static void RefreshLfeMap(faacEncStruct *hEncoder)
+{
+    memset(hEncoder->isLfeChannel, 0, sizeof(hEncoder->isLfeChannel));
+    for (int e = 0; e < hEncoder->numElements; e++) {
+        if (hEncoder->elements[e].type == ID_LFE)
+            hEncoder->isLfeChannel[hEncoder->elements[e].channels[0]] = true;
+    }
+}
+
 int faacEncGetVersion( char **faac_id_string,
 			      				char **faac_copyright_string)
 {
@@ -115,7 +127,7 @@ int faacEncGetDecoderSpecificInfo(faacEncHandle hpEncoder,unsigned char** ppBuff
 
     if(*ppBuffer != NULL){
         memset(*ppBuffer,0,*pSizeOfDecoderSpecificInfo);
-        pBitStream = OpenBitStream((int)*pSizeOfDecoderSpecificInfo, *ppBuffer);
+        pBitStream = OpenBitStream((uint32_t)*pSizeOfDecoderSpecificInfo, *ppBuffer);
         if (!pBitStream) {
             free(*ppBuffer);
             *ppBuffer = NULL;
@@ -154,14 +166,11 @@ int faacEncSetConfiguration(faacEncHandle hpEncoder,
     switch( hEncoder->config.inputFormat )
     {
         case INPUT_16BIT:
-        //case INPUT_24BIT:
         case INPUT_32BIT:
         case INPUT_FLOAT:
             break;
-
         default:
             return 0;
-            break;
     }
 
     if (hEncoder->config.aacObjectType != LOW)
@@ -175,10 +184,6 @@ int faacEncSetConfiguration(faacEncHandle hpEncoder,
         return 0;
     if (config->bitRate > (MaxBitrate(hEncoder->sampleRate) / hEncoder->numChannels))
         config->bitRate = MaxBitrate(hEncoder->sampleRate) / hEncoder->numChannels;
-#if 0
-    if (config->bitRate < MinBitrate())
-        return 0;
-#endif
 
     if (config->bitRate && !config->bandWidth)
     {
@@ -255,7 +260,9 @@ int faacEncSetConfiguration(faacEncHandle hpEncoder,
 	for( i = 0; i < MAX_CHANNELS; i++ )
 		hEncoder->config.channel_map[i] = config->channel_map[i];
 
-    /* OK */
+    InitElements(hEncoder->elements, &hEncoder->numElements, (int)hEncoder->numChannels, hEncoder->config.useLfe);
+    RefreshLfeMap(hEncoder);
+
     return 1;
 }
 
@@ -332,6 +339,9 @@ faacEncHandle faacEncOpen(unsigned long sampleRate,
     }
 
     /* Initialize coder functions */
+    InitElements(hEncoder->elements, &hEncoder->numElements, (int)hEncoder->numChannels, (bool)hEncoder->config.useLfe);
+    RefreshLfeMap(hEncoder);
+
 	fft_initialize( &hEncoder->fft_tables );
 
 	PsyInit(&hEncoder->gpsyInfo, hEncoder->psyInfo, hEncoder->numChannels,
@@ -358,12 +368,9 @@ static int appendInputFifo(faacEncStruct *hEncoder, int32_t *inputBuffer,
     unsigned int spch = samplesInput / numChannels;
     unsigned int channel, i;
 
-    if (spch == 0)
-        return 0;
-    if (spch > FRAME_LEN)  /* caller exceeded one nominal frame per channel */
-        return -1;
-    if (hEncoder->inputFifoFill + spch > hEncoder->inputFifoCap)
-        return -1;
+    if (spch == 0) return 0;
+    if (spch > FRAME_LEN) return -1;
+    if (hEncoder->inputFifoFill + spch > hEncoder->inputFifoCap) return -1;
 
     for (channel = 0; channel < numChannels; channel++) {
         faac_real *dst = hEncoder->inputFifo[channel] + hEncoder->inputFifoFill;
@@ -383,8 +390,7 @@ static int appendInputFifo(faacEncStruct *hEncoder, int32_t *inputBuffer,
                 for (i = 0; i < spch; i++) { dst[i] = (faac_real)*src; src += numChannels; }
                 break;
             }
-            default:
-                return -1;
+            default: return -1;
         }
     }
     hEncoder->inputFifoFill += spch;
@@ -397,14 +403,11 @@ static void consumeInputFifo(faacEncStruct *hEncoder, unsigned int n)
     unsigned int numChannels = hEncoder->numChannels;
     unsigned int channel, rem;
 
-    if (n > hEncoder->inputFifoFill)
-        n = hEncoder->inputFifoFill;
+    if (n > hEncoder->inputFifoFill) n = hEncoder->inputFifoFill;
     rem = hEncoder->inputFifoFill - n;
     if (rem)
         for (channel = 0; channel < numChannels; channel++)
-            memmove(hEncoder->inputFifo[channel],
-                    hEncoder->inputFifo[channel] + n,
-                    rem * sizeof(faac_real));
+            memmove(hEncoder->inputFifo[channel], hEncoder->inputFifo[channel] + n, rem * sizeof(faac_real));
     hEncoder->inputFifoFill = rem;
 }
 
@@ -413,14 +416,12 @@ int faacEncClose(faacEncHandle hpEncoder)
     faacEncStruct* hEncoder = (faacEncStruct*)hpEncoder;
     unsigned int channel;
 
-    /* Deinitialize coder functions */
+    if (!hEncoder) return 0;
+
     PsyEnd(hEncoder->psyInfo, hEncoder->numChannels);
-
     FilterBankEnd(hEncoder);
-
     fft_terminate(&hEncoder->fft_tables);
 
-    /* Free remaining buffer memory */
     for (channel = 0; channel < hEncoder->numChannels; channel++)
 	{
         int buf;
@@ -433,12 +434,8 @@ int faacEncClose(faacEncHandle hpEncoder)
 			FreeMemory (hEncoder->inputFifo[channel]);
     }
 
-    if (hEncoder->ascCache)
-        free(hEncoder->ascCache);
-
-    /* Free handle */
-    if (hEncoder)
-		FreeMemory(hEncoder);
+    if (hEncoder->ascCache) free(hEncoder->ascCache);
+    FreeMemory(hEncoder);
 
     return 0;
 }
@@ -454,13 +451,10 @@ int faacEncEncode(faacEncHandle hpEncoder,
     unsigned int channel;
     int sb, frameBytes;
     unsigned int offset;
-    BitStream *bitStream; /* bitstream used for writing the frame to */
+    BitStream *bitStream;
 
-    /* local copy's of parameters */
-    ChannelInfo *channelInfo = hEncoder->channelInfo;
     CoderInfo *coderInfo = hEncoder->coderInfo;
     unsigned int numChannels = hEncoder->numChannels;
-    unsigned int useLfe = hEncoder->config.useLfe;
     unsigned int useTns = hEncoder->config.useTns;
     unsigned int jointmode = hEncoder->config.jointmode;
     unsigned int shortctl = hEncoder->config.shortctl;
@@ -500,14 +494,10 @@ int faacEncEncode(faacEncHandle hpEncoder,
     if (hEncoder->flushFrame > (LOOKAHEAD_DEPTH + 1))
         return 0;
 
-    /* Determine the channel configuration */
-    GetChannelInfo(channelInfo, numChannels, useLfe);
-
     /* Update current sample buffers */
     for (channel = 0; channel < numChannels; channel++)
 	{
 		faac_real *tmp;
-
 		tmp = hEncoder->audioFIFO[channel][FIFO_PAST];
 		hEncoder->audioFIFO[channel][FIFO_PAST]  = hEncoder->audioFIFO[channel][FIFO_CURR];
 		hEncoder->audioFIFO[channel][FIFO_CURR]  = hEncoder->audioFIFO[channel][FIFO_AHEAD1];
@@ -524,20 +514,16 @@ int faacEncEncode(faacEncHandle hpEncoder,
             /* Take one frame from the FIFO front (already faac_real),
              * silence-padding a short final frame. */
             unsigned int spc = ((unsigned int)realPerCh < FRAME_LEN) ? (unsigned int)realPerCh : FRAME_LEN;
-            memcpy(hEncoder->audioFIFO[channel][FIFO_AHEAD2], hEncoder->inputFifo[channel],
-                   spc * sizeof(faac_real));
+            memcpy(hEncoder->audioFIFO[channel][FIFO_AHEAD2], hEncoder->inputFifo[channel], spc * sizeof(faac_real));
             if (spc < FRAME_LEN)
                 memset(hEncoder->audioFIFO[channel][FIFO_AHEAD2] + spc, 0, (FRAME_LEN - spc) * sizeof(faac_real));
 		}
 
-		/* Psychoacoustics */
-		/* Update buffers and run FFT on new samples */
-		/* LFE psychoacoustic can run without it */
-		if (channelInfo[channel].type != ELEMENT_LFE)
+		/* LFE's block_type is always forced to ONLY_LONG_WINDOW in PsyCalculate,
+		 * so the transient analysis below would be discarded -- skip it. */
+		if (!hEncoder->isLfeChannel[channel])
 		{
-			PsyBufferUpdate(
-					&hEncoder->gpsyInfo,
-					&hEncoder->psyInfo[channel],
+			PsyBufferUpdate(&hEncoder->gpsyInfo, &hEncoder->psyInfo[channel],
                     hEncoder->audioFIFO[channel][FIFO_AHEAD1],
                     hEncoder->audioFIFO[channel][FIFO_AHEAD2]);
 		}
@@ -551,8 +537,7 @@ int faacEncEncode(faacEncHandle hpEncoder,
         return 0;
 
     /* Psychoacoustics */
-    PsyCalculate(channelInfo, hEncoder->psyInfo, numChannels);
-
+    PsyCalculate(hEncoder->elements, hEncoder->numElements, hEncoder->psyInfo, numChannels);
     BlockSwitch(coderInfo, hEncoder->psyInfo, numChannels);
 
     /* force block type */
@@ -581,8 +566,6 @@ int faacEncEncode(faacEncHandle hpEncoder,
     }
 
     for (channel = 0; channel < numChannels; channel++) {
-        channelInfo[channel].msInfo.is_present = 0;
-
         if (coderInfo[channel].block_type == ONLY_SHORT_WINDOW) {
             coderInfo[channel].sfbn = hEncoder->aacquantCfg.max_cbs;
 
@@ -610,7 +593,7 @@ int faacEncEncode(faacEncHandle hpEncoder,
 
     /* Perform TNS analysis and filtering */
     for (channel = 0; channel < numChannels; channel++) {
-        if ((channelInfo[channel].type != ELEMENT_LFE) && (useTns)) {
+        if (!hEncoder->isLfeChannel[channel] && useTns) {
             TnsEncode(&(coderInfo[channel].tnsInfo),
                       coderInfo[channel].sfbn,
                       coderInfo[channel].sfbn,
@@ -622,21 +605,20 @@ int faacEncEncode(faacEncHandle hpEncoder,
         }
     }
 
-    for (channel = 0; channel < numChannels; channel++) {
+    for (int e = 0; e < hEncoder->numElements; e++) {
       // reduce LFE bandwidth
-		if (channelInfo[channel].type == ELEMENT_LFE)
+		if (hEncoder->elements[e].type == ID_LFE)
 		{
-                    coderInfo[channel].sfbn = 3;
+                    coderInfo[hEncoder->elements[e].channels[0]].sfbn = 3;
 		}
 	}
 
     /* Clear each channel's section state before AACstereo pre-loads intensity
      * bands and BlocQuant resolves the rest. */
     for (channel = 0; channel < numChannels; channel++)
-        if (channelInfo[channel].present)
-            ResetCoderSections(&coderInfo[channel]);
+        ResetCoderSections(&coderInfo[channel]);
 
-    AACstereo(coderInfo, channelInfo, hEncoder->freqBuff, numChannels,
+    AACstereo(coderInfo, hEncoder->elements, hEncoder->numElements, hEncoder->freqBuff,
               (faac_real)hEncoder->aacquantCfg.quality/DEFQUAL, jointmode, hEncoder->sampleRate);
 
     for (channel = 0; channel < numChannels; channel++) {
@@ -645,16 +627,14 @@ int faacEncEncode(faacEncHandle hpEncoder,
     }
 
     // fix max_sfb in CPE mode
-    for (channel = 0; channel < numChannels; channel++)
+    for (int e = 0; e < hEncoder->numElements; e++)
     {
-		if (channelInfo[channel].present
-				&& (channelInfo[channel].type == ELEMENT_CPE)
-				&& (channelInfo[channel].ch_is_left))
+		if (hEncoder->elements[e].type == ID_CPE)
 		{
 			CoderInfo *cil, *cir;
 
-			cil = &coderInfo[channel];
-			cir = &coderInfo[channelInfo[channel].paired_ch];
+			cil = &coderInfo[hEncoder->elements[e].channels[0]];
+			cir = &coderInfo[hEncoder->elements[e].channels[1]];
 
                         cil->sfbn = cir->sfbn = max(cil->sfbn, cir->sfbn);
 		}
@@ -664,7 +644,7 @@ int faacEncEncode(faacEncHandle hpEncoder,
     if (!bitStream)
         return -1;
 
-    if (WriteBitstream(hEncoder, coderInfo, channelInfo, bitStream, numChannels) < 0)
+    if (WriteBitstream(hEncoder, coderInfo, hEncoder->elements, hEncoder->numElements, bitStream) < 0)
         return -1;
 
     /* Close the bitstream and return the number of bytes written */
@@ -687,7 +667,6 @@ int faacEncEncode(faacEncHandle hpEncoder,
 
         /* Apply damping to the quality adjustment */
         fix = (fix - 1.0) * RC_DAMPING_FACTOR + 1.0;
-        // printf("q: %.1f(f:%.4f)\n", hEncoder->aacquantCfg.quality, fix);
 
         hEncoder->aacquantCfg.quality *= fix;
 

--- a/libfaac/frame.h
+++ b/libfaac/frame.h
@@ -48,7 +48,7 @@ extern "C" {
 #include "fft.h"
 #include "quantize.h"
 
-typedef struct {
+typedef struct faacEncStruct {
     /* number of channels in AAC file */
     unsigned int numChannels;
 
@@ -77,7 +77,11 @@ typedef struct {
 
     /* Channel and Coder data for all channels */
     CoderInfo coderInfo[MAX_CHANNELS];
-    ChannelInfo channelInfo[MAX_CHANNELS];
+
+    /* Element-centric configuration */
+    AACElement elements[MAX_CHANNELS];
+    int numElements;
+    bool isLfeChannel[MAX_CHANNELS]; /* per-channel LFE lookup, derived from elements[] whenever it changes */
 
     /* Psychoacoustics data */
     PsyInfo psyInfo[MAX_CHANNELS];

--- a/libfaac/huff2.c
+++ b/libfaac/huff2.c
@@ -288,6 +288,9 @@ int writebooks(CoderInfo *coder, BitStream *stream, int write)
     int max_run = (coder->block_type == ONLY_SHORT_WINDOW) ? 7 : 31;
     int run_bits = (coder->block_type == ONLY_SHORT_WINDOW) ? 3 : 5;
     int g;
+    BitAccumulator acc = {0};
+
+    if (write) AccumBegin(&acc, stream);
 
     for (g = 0; g < coder->groups.n; g++) {
         int b = g * coder->sfbn;
@@ -298,18 +301,20 @@ int writebooks(CoderInfo *coder, BitStream *stream, int write)
             while (b + run < end && coder->book[b + run] == book) run++;
             b += run;
 
-            if (write) PutBit(stream, book, 4);
+            if (write) AccumPutBits(&acc, (uint32_t)book, 4);
             bits += 4;
 
             while (run >= max_run) {
-                if (write) PutBit(stream, max_run, run_bits);
+                if (write) AccumPutBits(&acc, (uint32_t)max_run, run_bits);
                 bits += run_bits;
                 run -= max_run;
             }
-            if (write) PutBit(stream, run, run_bits);
+            if (write) AccumPutBits(&acc, (uint32_t)run, run_bits);
             bits += run_bits;
         }
     }
+
+    if (write) AccumEnd(&acc);
     return bits;
 }
 
@@ -321,6 +326,9 @@ int writesf(CoderInfo *coder, BitStream *stream, int write)
     int lastis = 0;
     int lastpns = coder->global_gain - SF_PNS_OFFSET;
     int is_first_pns = 1;
+    BitAccumulator acc = {0};
+
+    if (write) AccumBegin(&acc, stream);
 
     for (i = 0; i < coder->bandcnt; i++) {
         int book = coder->book[i];
@@ -337,7 +345,7 @@ int writesf(CoderInfo *coder, BitStream *stream, int write)
             if (is_first_pns) {
                 /* First PNS band is coded as an absolute 9-bit value (biased by 256)
                  * because there is no prior PNS entry to delta from yet. */
-                if (write) PutBit(stream, diff + 256, 9);
+                if (write) AccumPutBits(&acc, (uint32_t)(diff + 256), 9);
                 bits += 9;
                 lastpns = val;
                 is_first_pns = 0;
@@ -352,8 +360,10 @@ int writesf(CoderInfo *coder, BitStream *stream, int write)
 
         code = book12[SF_DELTA + diff].data;
         len = book12[SF_DELTA + diff].len;
-        if (write) PutBit(stream, code, len);
+        if (write) AccumPutBits(&acc, (uint32_t)code, len);
         bits += len;
     }
+
+    if (write) AccumEnd(&acc);
     return bits;
 }

--- a/libfaac/huff2.h
+++ b/libfaac/huff2.h
@@ -95,10 +95,11 @@ static inline int clamp_sf_diff(int diff)
     return diff;
 }
 
-int huffbook(CoderInfo *coderInfo,
-             int *qs /* quantized spectrum */,
-             int len);
-int writebooks(CoderInfo *coder, BitStream *stream, int writeFlag);
-int writesf(CoderInfo *coder, BitStream *bitStream, int writeFlag);
+/* Forward declaration for CoderInfo */
+struct CoderInfo;
+
+int huffbook(struct CoderInfo *coder, int *qs, int len);
+int writebooks(struct CoderInfo *coder, BitStream *stream, int writeFlag);
+int writesf(struct CoderInfo *coder, BitStream *bitStream, int writeFlag);
 
 #endif /* HUFF2_H */

--- a/libfaac/stereo.c
+++ b/libfaac/stereo.c
@@ -11,7 +11,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
-
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -23,6 +23,7 @@
 #include "stereo.h"
 #include "huff2.h"
 #include "util.h"
+#include "faac_internal.h"
 
 /* Intensity stereo applies only at and above this frequency; below it the ear
  * localizes from waveform detail, so panning the band would be audible. */
@@ -124,12 +125,11 @@ static inline void apply_is(faac_real * restrict sl0, faac_real * restrict sr0,
     }
 }
 
-
 /* Unified CPE element processing.  Consolidating joint stereo modes into a single
  * pass minimizes cache misses on spectral data and allows the compiler to
  * optimize the mode-specific branches using constant propagation. */
 static inline int process_cpe(CoderInfo * restrict cl, CoderInfo * restrict cr,
-                               ChannelInfo * restrict channel,
+                               AACElement * restrict element,
                                faac_real * restrict sl0, faac_real * restrict sr0,
                                int * restrict sfcnt, int wstart, int wend,
                                faac_real thrmid, faac_real inv_isthr, faac_real thrside_sq,
@@ -142,7 +142,7 @@ static inline int process_cpe(CoderInfo * restrict cl, CoderInfo * restrict cr,
         *sfcnt += sfmin;
     } else {
         for (sfb = 0; sfb < sfmin; sfb++)
-            channel->msInfo.ms_used[(*sfcnt)++] = 0;
+            element->msInfo.ms_used[(*sfcnt)++] = 0;
     }
 
     for (sfb = sfmin; sfb < cl->sfbn; sfb++) {
@@ -156,7 +156,7 @@ static inline int process_cpe(CoderInfo * restrict cl, CoderInfo * restrict cr,
         if (es < 0) es = 0;
         if (ed < 0) ed = 0;
         if (etot <= 0) {
-            if (mode != JOINT_IS) channel->msInfo.ms_used[*sfcnt] = 0;
+            if (mode != JOINT_IS) element->msInfo.ms_used[*sfcnt] = 0;
             (*sfcnt)++;
             continue;
         }
@@ -175,13 +175,13 @@ static inline int process_cpe(CoderInfo * restrict cl, CoderInfo * restrict cr,
                  * intensity-coding it, keeping the band cheap for the quantizer. */
                 if (pan > IS_PAN_LIMIT) {
                     cl->book[*sfcnt] = HCB_ZERO;
-                    if (mode != JOINT_IS) channel->msInfo.ms_used[*sfcnt] = 0;
+                    if (mode != JOINT_IS) element->msInfo.ms_used[*sfcnt] = 0;
                     (*sfcnt)++;
                     continue;
                 }
                 if (pan < -IS_PAN_LIMIT) {
                     cr->book[*sfcnt] = HCB_ZERO;
-                    if (mode != JOINT_IS) channel->msInfo.ms_used[*sfcnt] = 0;
+                    if (mode != JOINT_IS) element->msInfo.ms_used[*sfcnt] = 0;
                     (*sfcnt)++;
                     continue;
                 }
@@ -190,7 +190,7 @@ static inline int process_cpe(CoderInfo * restrict cl, CoderInfo * restrict cr,
                 cr->book[*sfcnt] = hcb;
                 faac_real dom = (hcb == HCB_INTENSITY) ? es : ed;
                 apply_is(sl0, sr0, start, len, wstart, wend, hcb == HCB_INTENSITY, FAAC_SQRT(etot / dom));
-                if (mode != JOINT_IS) channel->msInfo.ms_used[*sfcnt] = 0;
+                if (mode != JOINT_IS) element->msInfo.ms_used[*sfcnt] = 0;
                 (*sfcnt)++;
                 continue;
             }
@@ -221,17 +221,16 @@ static inline int process_cpe(CoderInfo * restrict cl, CoderInfo * restrict cr,
                     apply_mute(sr0, start, len, wstart, wend);
                 }
             }
-            channel->msInfo.ms_used[*sfcnt] = ms;
+            element->msInfo.ms_used[*sfcnt] = ms;
         }
         (*sfcnt)++;
     }
     return msused;
 }
 
-void AACstereo(CoderInfo *coder, ChannelInfo *channel, faac_real *s[MAX_CHANNELS],
-               int maxchan, faac_real quality, int mode, int sampleRate)
+void AACstereo(CoderInfo *coder, AACElement *elements, int numElements, faac_real *s[MAX_CHANNELS],
+               faac_real quality, int mode, int sampleRate)
 {
-    int chn;
     faac_real inv_quality = 1.0 / quality;
     faac_real thrmid = 1.0, isthr = 1.0, thrside = 0.0;
 
@@ -267,52 +266,49 @@ void AACstereo(CoderInfo *coder, ChannelInfo *channel, faac_real *s[MAX_CHANNELS
     faac_real inv_isthr = 1.0 / (isthr * isthr);
     faac_real thrside_sq = thrside * thrside;
 
-    for (chn = 0; chn < maxchan; chn++) {
-        if (!channel[chn].present || channel[chn].type != ELEMENT_CPE || !channel[chn].ch_is_left)
+    for (int e = 0; e < numElements; e++) {
+        AACElement *elem = &elements[e];
+        if (elem->type != ID_CPE) continue;
+
+        int lch = elem->channels[0];
+        int rch = elem->channels[1];
+
+        elem->common_window = false;
+        elem->msInfo.is_present = false;
+
+        if (coder[lch].block_type != coder[rch].block_type || coder[lch].groups.n != coder[rch].groups.n)
             continue;
-        int rch = channel[chn].paired_ch;
-        channel[chn].common_window = 0;
-        channel[chn].msInfo.is_present = 0;
-        channel[rch].msInfo.is_present = 0;
-        if (coder[chn].block_type != coder[rch].block_type || coder[chn].groups.n != coder[rch].groups.n)
-            continue;
-        int g, ok = 1;
-        for (g = 0; g < coder[chn].groups.n; g++) {
-            if (coder[chn].groups.len[g] != coder[rch].groups.len[g]) {
-                ok = 0;
-                break;
+
+        int ok = 1;
+        for (int g = 0; g < coder[lch].groups.n; g++) {
+            if (coder[lch].groups.len[g] != coder[rch].groups.len[g]) {
+                ok = 0; break;
             }
         }
         if (!ok) continue;
 
-        channel[chn].common_window  = 1;
-        channel[chn].msInfo.is_present = (mode == JOINT_MS);
-        channel[rch].msInfo.is_present = (mode == JOINT_MS);
+        elem->common_window  = true;
+        elem->msInfo.is_present = (mode == JOINT_MS);
 
-        int start = 0, sfcnt = 0, is_start_sfb = coder[chn].sfbn, msused = 0;
+        int start = 0, sfcnt = 0, is_start_sfb = coder[lch].sfbn, msused = 0;
         if (mode == JOINT_MIXED) {
-            int sfb;
-            int mlen  = (coder[chn].block_type == ONLY_SHORT_WINDOW) ? 2*BLOCK_LEN_SHORT : 2*BLOCK_LEN_LONG;
+            int mlen  = (coder[lch].block_type == ONLY_SHORT_WINDOW) ? 2*BLOCK_LEN_SHORT : 2*BLOCK_LEN_LONG;
             int ifreq = IS_START_FREQ_HZ, cap = (sampleRate * IS_FREQ_CAP_NUM) / IS_FREQ_CAP_DEN;
             if (ifreq > cap) ifreq = cap;
-            for (sfb = 0; sfb < coder[chn].sfbn; sfb++) {
-                if ((coder[chn].sfb_offset[sfb] * sampleRate) / mlen >= ifreq) {
-                    is_start_sfb = sfb;
-                    break;
+            for (int sfb = 0; sfb < coder[lch].sfbn; sfb++) {
+                if ((coder[lch].sfb_offset[sfb] * sampleRate) / mlen >= ifreq) {
+                    is_start_sfb = sfb; break;
                 }
             }
         }
 
-        for (g = 0; g < coder[chn].groups.n; g++) {
-            int end = start + coder[chn].groups.len[g];
-            msused |= process_cpe(coder+chn, coder+rch, channel+chn, s[chn], s[rch],
+        for (int g = 0; g < coder[lch].groups.n; g++) {
+            int end = start + coder[lch].groups.len[g];
+            msused |= process_cpe(coder+lch, coder+rch, elem, s[lch], s[rch],
                                   &sfcnt, start, end, thrmid, inv_isthr, thrside_sq,
                                   is_start_sfb, mode);
             start = end;
         }
-        if (mode == JOINT_MIXED && msused) {
-            channel[chn].msInfo.is_present = 1;
-            channel[rch].msInfo.is_present = 1;
-        }
+        if (mode == JOINT_MIXED && msused) elem->msInfo.is_present = true;
     }
 }

--- a/libfaac/stereo.h
+++ b/libfaac/stereo.h
@@ -11,7 +11,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
-
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -24,9 +24,9 @@
 #include "util.h"
 
 void AACstereo(CoderInfo *coder,
-               ChannelInfo *channel,
+               AACElement *elements,
+               int numElements,
                faac_real *s[MAX_CHANNELS],
-               int maxchan,
                faac_real quality,
                int mode,
                int sampleRate


### PR DESCRIPTION
# PR Description

## Reimplement Channels and Bitstream under LGPL-2.1 (#321)

### 🎯 Motivation & Context
This PR is a major milestone in our ongoing initiative to transition the FAAC repository from a `non-free` status into a pure, open-source free package structure. 

The previous implementations of `libfaac/bitstream.c`, `bitstream.h`, `channels.c`, and `channels.h` contained legacy code or reference snippets originating from early ISO/IEC MPEG-4 audio reference software. Because that original reference license restricted use to standard-conforming implementations and retained non-GPL/LGPL compatible enforcement rights, it could not be bundled in mainstream Linux distributions' main package repositories.

By completing a rewrite of these components, we are systematically addressing licensing blockers. Following this PR, **only `tns.c`/`tns.h` and `filtbank.c` remain** under non-free licensing before the entire library codebase achieves pure compliance.

---

### 🛠️ Technical Implementation Summary
The rewritten modules have been built purely from architectural documentation and standard bitstream specifications, avoiding any mechanical translation of the old source logic. Key design elements include:

* **Element-Centric Data Model:** Built original structures (`AACElement`) that cleanly decouple raw audio channel arrays from MPEG-specified structural paradigms (Single Channel Elements (`SCE`), Channel Pair Elements (`CPE`), and Low Frequency Elements (`LFE`)).
* **Tail-First Byte Packer:** Implemented an optimized tail-first byte packing engine inside `PutBit` to cleanly handle shifting boundaries.
* **BitAccumulator Batching:** Added an original buffering methodology for batching bit strings on the hot Huffman-coefficient execution path, reducing overhead in performance-critical loops.
* **Specification Compliance:** Channel-to-element mapping and layout constraints perfectly map onto the algorithmic descriptions provided by **ISO/IEC 14496-3**. Because functional bitstream layouts and standardized parameters represent an implementation blueprint rather than copyrightable creative expressions, this rewrite remains cleanly unencumbered.
* **Memory Hygiene:** Fixed a minor leak in the frontend wrapper (`frontend/main.c`) where `chanmap` was missing a `free()` lifecycle call during application termination.

---

### 🧪 Verification & Testing
To ensure zero regression or behavior mutation, the new modules were heavily verified against production targets:
1.  **Bit-Exact Identity:** Output bitstreams were systematically cross-examined and confirmed **byte-identical** to the previous implementation across a robust suite of validation material (including `mono`, `stereo`, `multichannel`, and real `5.1` audio sources).
2.  **Sanitizer Passes:** Validated with clean execution runs under both AddressSanitizer (**ASan**) and UndefinedBehaviorSanitizer (**UBSan**), ensuring no memory regressions, alignments, or indexing boundary overflows were introduced by the updated data structures.

Benchmark: https://github.com/nschimme/faac/actions/runs/28898030818

<img width="776" height="407" alt="image" src="https://github.com/user-attachments/assets/c4e8e36c-9648-4330-a3e6-0eea449d0a5e" />

---

### 📋 Checklist
- [x] All newly implemented code is authored from scratch and cleanly licensed under **LGPL-2.1-or-later**.
- [x] Output verified byte-for-byte against legacy encoder baselines.
- [x] Confirmed zero runtime warnings under ASan/UBSan configurations.