### PR TITLE
relicense: reimplement tns under LGPL 2.1

### DIFF
--- a/libfaac/channels.c
+++ b/libfaac/channels.c
@@ -134,41 +134,38 @@ static int WriteICS(BitStream *bs, CoderInfo *coder, bool commonWindow, bool wri
     if (writeFlag) PutBit(bs, tns->tnsDataPresent, LEN_TNS_PRES);
     bits += LEN_TNS_PRES;
 
+    /* TNS is long-only (see tns.c): tnsDataPresent is never set for
+     * ONLY_SHORT_WINDOW, so there's exactly one window's worth of TNS data
+     * to write, always at the long-window field widths. */
     if (tns->tnsDataPresent) {
-        int nf_len = (coder->block_type == ONLY_SHORT_WINDOW) ? LEN_TNS_NFILTS : LEN_TNS_NFILTL;
-        int l_len  = (coder->block_type == ONLY_SHORT_WINDOW) ? LEN_TNS_LENGTHS : LEN_TNS_LENGTHL;
-        int o_len  = (coder->block_type == ONLY_SHORT_WINDOW) ? LEN_TNS_ORDERS : LEN_TNS_ORDERL;
-        int num_w  = (coder->block_type == ONLY_SHORT_WINDOW) ? MAX_SHORT_WINDOWS : 1;
+        TnsWindowData *win = &tns->windowData;
 
-        for (int w = 0; w < num_w; w++) {
-            TnsWindowData *win = &tns->windowData[w];
-            if (writeFlag) PutBit(bs, win->numFilters, nf_len);
-            bits += nf_len;
+        if (writeFlag) PutBit(bs, win->numFilters, LEN_TNS_NFILTL);
+        bits += LEN_TNS_NFILTL;
 
-            if (win->numFilters > 0) {
-                if (writeFlag) PutBit(bs, win->coefResolution - 3, LEN_TNS_COEFF_RES);
-                bits += LEN_TNS_COEFF_RES;
+        if (win->numFilters > 0) {
+            if (writeFlag) PutBit(bs, win->coefResolution - DEF_TNS_RES_OFFSET, LEN_TNS_COEFF_RES);
+            bits += LEN_TNS_COEFF_RES;
 
-                for (int f = 0; f < win->numFilters; f++) {
-                    TnsFilterData *flt = &win->tnsFilter[f];
+            for (int f = 0; f < win->numFilters; f++) {
+                TnsFilterData *flt = &win->tnsFilter[f];
+                if (writeFlag) {
+                    PutBit(bs, flt->length, LEN_TNS_LENGTHL);
+                    PutBit(bs, flt->order, LEN_TNS_ORDERL);
+                }
+                bits += LEN_TNS_LENGTHL + LEN_TNS_ORDERL;
+
+                if (flt->order > 0) {
                     if (writeFlag) {
-                        PutBit(bs, flt->length, l_len);
-                        PutBit(bs, flt->order, o_len);
+                        PutBit(bs, flt->direction, LEN_TNS_DIRECTION);
+                        PutBit(bs, flt->coefCompress, LEN_TNS_COMPRESS);
                     }
-                    bits += l_len + o_len;
+                    bits += LEN_TNS_DIRECTION + LEN_TNS_COMPRESS;
 
-                    if (flt->order > 0) {
-                        if (writeFlag) {
-                            PutBit(bs, flt->direction, LEN_TNS_DIRECTION);
-                            PutBit(bs, flt->coefCompress, LEN_TNS_COMPRESS);
-                        }
-                        bits += LEN_TNS_DIRECTION + LEN_TNS_COMPRESS;
-
-                        int res = win->coefResolution - flt->coefCompress;
-                        for (int i = 1; i <= flt->order; i++) {
-                            if (writeFlag) PutBit(bs, flt->index[i] & ((1 << res) - 1), res);
-                            bits += res;
-                        }
+                    int res = win->coefResolution - flt->coefCompress;
+                    for (int i = 1; i <= flt->order; i++) {
+                        if (writeFlag) PutBit(bs, flt->index[i] & ((1 << res) - 1), res);
+                        bits += res;
                     }
                 }
             }

--- a/libfaac/coder.h
+++ b/libfaac/coder.h
@@ -43,7 +43,6 @@ enum WINDOW_TYPE {
 };
 
 #define TNS_MAX_ORDER 12
-#define DEF_TNS_GAIN_THRESH 1.4
 #define DEF_TNS_COEFF_THRESH 0.1
 #define DEF_TNS_COEFF_RES 4
 #define DEF_TNS_RES_OFFSET 3
@@ -57,9 +56,8 @@ typedef struct {
     int direction;                       /* Filtering direction */
     int coefCompress;                    /* Are coeffs compressed? */
     int length;                          /* Length, in bands */
-    faac_real aCoeffs[TNS_MAX_ORDER+1];     /* AR Coefficients */
-    faac_real kCoeffs[TNS_MAX_ORDER+1];     /* Reflection Coefficients */
-    int index[TNS_MAX_ORDER+1];          /* Coefficient indices */
+    faac_real aCoeffs[TNS_MAX_ORDER+1];  /* LPC (AR) coefficients */
+    int index[TNS_MAX_ORDER+1];          /* Quantized reflection-coeff indices */
 } TnsFilterData;
 
 typedef struct {
@@ -71,12 +69,9 @@ typedef struct {
 typedef struct {
     int tnsDataPresent;
     int tnsMinBandNumberLong;
-    int tnsMinBandNumberShort;
     int tnsMaxBandsLong;
-    int tnsMaxBandsShort;
-    int tnsMaxOrderLong;
-    int tnsMaxOrderShort;
-    TnsWindowData windowData[MAX_SHORT_WINDOWS]; /* TNS data per window */
+    int tnsNumSwbLong;      /* full swb count for the sample rate (decoder's num_swb) */
+    TnsWindowData windowData;   /* long-only: one window per frame, not per-short-window */
 } TnsInfo;
 
 typedef struct CoderInfo {

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -596,10 +596,9 @@ int faacEncEncode(faacEncHandle hpEncoder,
         if (!hEncoder->isLfeChannel[channel] && useTns) {
             TnsEncode(&(coderInfo[channel].tnsInfo),
                       coderInfo[channel].sfbn,
-                      coderInfo[channel].sfbn,
                       coderInfo[channel].block_type,
                       coderInfo[channel].sfb_offset,
-                      hEncoder->freqBuff[channel], hEncoder->gpsyInfo.sharedWorkBuffLong);
+                      hEncoder->freqBuff[channel]);
         } else {
             coderInfo[channel].tnsInfo.tnsDataPresent = 0;      /* TNS not used for LFE */
         }

--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -255,6 +255,8 @@ static void assign_band_codebooks(CoderInfo * __restrict ci, const faac_real * _
             continue;
         }
 
+        /* PNS is fine inside TNS-covered bands -- the decoder's inverse
+         * TNS filter shapes the substituted noise too. */
         if (target[sb] < pns_threshold)
         {
             ci->book[band] = HCB_PNS;

--- a/libfaac/tns.c
+++ b/libfaac/tns.c
@@ -1,433 +1,372 @@
-/**********************************************************************
-
-This software module was originally developed by Texas Instruments
-and edited by         in the course of
-development of the MPEG-2 NBC/MPEG-4 Audio standard
-ISO/IEC 13818-7, 14496-1,2 and 3. This software module is an
-implementation of a part of one or more MPEG-2 NBC/MPEG-4 Audio tools
-as specified by the MPEG-2 NBC/MPEG-4 Audio standard. ISO/IEC gives
-users of the MPEG-2 NBC/MPEG-4 Audio standards free license to this
-software module or modifications thereof for use in hardware or
-software products claiming conformance to the MPEG-2 NBC/ MPEG-4 Audio
-standards. Those intending to use this software module in hardware or
-software products are advised that this use may infringe existing
-patents. The original developer of this software module and his/her
-company, the subsequent editors and their companies, and ISO/IEC have
-no liability for use of this software module or modifications thereof
-in an implementation. Copyright is not released for non MPEG-2
-NBC/MPEG-4 Audio conforming products. The original developer retains
-full right to use the code for his/her own purpose, assign or donate
-the code to a third party and to inhibit third party from using the
-code for non MPEG-2 NBC/MPEG-4 Audio conforming products. This
-copyright notice must be included in all copies or derivative works.
-
-Copyright (c) 1997.
-**********************************************************************/
 /*
- * $Id: tns.c,v 1.11 2012/03/01 18:34:17 knik Exp $
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  */
 
 #include <math.h>
+#include <string.h>
 #include "frame.h"
 #include "coder.h"
-#include "bitstream.h"
 #include "tns.h"
 #include "util.h"
 
-/***********************************************/
-/* TNS Profile/Frequency Dependent Parameters  */
-/***********************************************/
-/* Limit bands to > 2.0 kHz */
-static unsigned short tnsMinBandNumberLong[12] =
-{ 11, 12, 15, 16, 17, 20, 25, 26, 24, 28, 30, 31 };
-static unsigned short tnsMinBandNumberShort[12] =
-{ 2, 2, 2, 3, 3, 4, 6, 6, 8, 10, 10, 12 };
+/* Per-sample-rate scalefactor-band range TNS is allowed to filter over, from
+ * ISO/IEC 13818-7/14496-3's TNS tool tables (indexed by sampleRateIdx). Not
+ * an original heuristic: this is the spec's fixed table. */
+static const struct {
+    unsigned char min;
+    unsigned char max;
+} tns_sfb_range[12] = {
+    {11, 31}, {12, 31}, {15, 34}, {16, 40}, {17, 42}, {20, 51},
+    {25, 46}, {26, 46}, {24, 42}, {28, 42}, {30, 42}, {31, 39}
+};
 
-/**************************************/
-/* Low Profile TNS Parameters         */
-/**************************************/
-static unsigned short tnsMaxBandsLongLow[12] =
-{ 31, 31, 34, 40, 42, 51, 46, 46, 42, 42, 42, 39 };
+#define TNS_LPC_ORDER       8     /* fixed filter order; spec allows up to TNS_MAX_ORDER but higher orders rarely paid for themselves here */
+#define TNS_GAIN_LIMIT      1.4f  /* Levinson-Durbin prediction gain below this isn't worth the filter's bit cost */
+#define TNS_GAIN_CLAMP      6.0f  /* gain above this means a near-singular fit (e.g. a single strong tone); reject rather than risk an unstable filter */
+#define TNS_MEASURED_GAIN   1.4f  /* post-quantization re-check: same bar as TNS_GAIN_LIMIT, applied to the filter actually being transmitted */
 
-static unsigned short tnsMaxBandsShortLow[12] =
-{ 9, 9, 10, 14, 14, 14, 14, 14, 14, 14, 14, 14 };
+/* Below this, a band's spectral energy is indistinguishable from float
+ * rounding noise, so there's nothing real for TNS to whiten. Also reused
+ * below as the floor for RMS-normalization and the LPC residual check,
+ * rather than inventing a separate near-zero constant for each. */
+#define TNS_MIN_ENERGY      1e-9f
+/* SFM (geomean/arithmean of per-band RMS) near 1.0 means the band is
+ * noise-like, which PNS (quantize.c) is about to replace anyway -- skip
+ * TNS's LPC work there; it only pays off on tonal/peaky bands. */
+#define TNS_PNS_SFM_SKIP    0.85f
 
-static unsigned short tnsMaxOrderLongLow = 12;
-static unsigned short tnsMaxOrderShortLow = 7;
+static void calc_autocorr_f(int order, int length, const float * work, float * r)
+{
+    int lag, i;
 
+    for (lag = 0; lag <= order; lag++) {
+        float acc = 0.0f;
+        const float * p1 = work;
+        const float * p2 = work + lag;
+        int n = length - lag;
 
-/*************************/
-/* Function prototypes   */
-/*************************/
-static void Autocorrelation(int maxOrder,                    /* Maximum autocorr order */
-                            int dataSize,                    /* Size of the data array */
-                            const faac_real * restrict data, /* Data array */
-                            faac_real * restrict rArray);    /* Autocorrelation array */
+        for (i = 0; i < n; i++)
+            acc += p1[i] * p2[i];
+        r[lag] = acc;
+    }
+}
 
-static faac_real LevinsonDurbin(int maxOrder,                    /* Maximum filter order */
-                                int dataSize,                    /* Size of the data array */
-                                const faac_real * restrict data, /* Data array */
-                                faac_real * restrict kArray);    /* Reflection coeff array */
+/* Reflection coefficients are clamped to +-0.999, short of the unstable
+ * +-1 limit, so the resulting filter is guaranteed stable regardless of
+ * input. The returned prediction gain (r[0]/final residual error) lets
+ * TnsEncode reject a bad fit before spending any bits on coefficients --
+ * free to report here, since the recursion already has both numbers. */
+static float compute_lpc(int order, const float * r, float * k)
+{
+    float a[TNS_MAX_ORDER + 1];
+    float err;
+    int i, j;
 
-static void StepUp(int fOrder, faac_real* kArray, faac_real* aArray);
+    if (r[0] <= 0.0f) {
+        for (i = 1; i <= order; i++)
+            k[i] = 0.0f;
+        return 1.0f;
+    }
 
-static void QuantizeReflectionCoeffs(int fOrder,int coeffRes,faac_real* rArray,int* indexArray);
-static int TruncateCoeffs(int fOrder,faac_real threshold,faac_real* kArray);
-static void TnsInvFilter(int length, faac_real * restrict spec,
-                         const TnsFilterData * restrict filter,
-                         faac_real * restrict temp);
+    err = r[0];
+    a[0] = 1.0f;
+    for (i = 1; i <= order; i++) {
+        float lambda = r[i];
+        float rc;
+        int half;
 
-/*****************************************************/
-/* InitTns:                                          */
-/*****************************************************/
+        for (j = 1; j < i; j++)
+            lambda += a[j] * r[i - j];
+
+        if (err <= 0.0f) {
+            for (; i <= order; i++)
+                k[i] = 0.0f;
+            break;
+        }
+
+        rc = -lambda / err;
+        if (rc > 0.999f) rc = 0.999f;
+        else if (rc < -0.999f) rc = -0.999f;
+        k[i] = rc;
+
+        half = (i + 1) / 2;
+        for (j = 1; j < half; j++) {
+            float t1 = a[j];
+            float t2 = a[i - j];
+            a[j] = t1 + rc * t2;
+            a[i - j] = t2 + rc * t1;
+        }
+        if (i % 2 == 0)
+            a[i / 2] += rc * a[i / 2];
+        a[i] = rc;
+
+        err *= (1.0f - rc * rc);
+        if (err <= 0.0f)
+            break;
+    }
+
+    /* err collapsing to ~0 means a (near-)perfect fit, which for real audio
+     * means a degenerate input rather than a genuinely great filter. Return
+     * a gain past TNS_GAIN_CLAMP so the caller's sanity check rejects it,
+     * instead of dividing by ~0. */
+    if (err <= TNS_MIN_ENERGY)
+        return TNS_GAIN_CLAMP + 1.0f;
+    return r[0] / err;
+}
+
+/* Reflection coefficients live in (-1, 1); arcsine-warp them before
+ * quantizing so equal code steps land closer to equal perceptual steps
+ * near the +-1 ends, per the tns_data() coefficient law in the spec. */
+static void quantize_coeffs(int order, int res, float * k, int * idx)
+{
+    const float s_p = (float)(((1 << (res - 1)) - 0.5f) / (M_PI / 2));
+    const float s_n = (float)(((1 << (res - 1)) + 0.5f) / (M_PI / 2));
+    const int i_max = (1 << (res - 1)) - 1;
+    const int i_min = -(1 << (res - 1));
+    int i;
+
+    for (i = 1; i <= order; i++) {
+        float val = k[i];
+        float s = (val >= 0.0f) ? s_p : s_n;
+        int q = (int)(asinf(val) * s + ((val >= 0.0f) ? 0.5f : -0.5f));
+
+        if (q > i_max) q = i_max;
+        else if (q < i_min) q = i_min;
+        idx[i] = q;
+
+        /* Re-derive k[] from the quantized index (not the original float)
+         * so finalize_filter below builds the same filter the decoder will,
+         * from the same lossy coefficients that actually get transmitted. */
+        s = (q >= 0) ? s_p : s_n;
+        k[i] = sinf((float)q / s);
+    }
+}
+
+/* filter_spec's recursion needs direct-form polynomial coefficients, not
+ * reflection coefficients, so this runs the standard lattice-to-direct
+ * step-up. Called after quantize_coeffs so the polynomial matches what's
+ * actually transmitted, not the pre-quantization float values. */
+static void finalize_filter(int order, const float * k, faac_real * a)
+{
+    int i, m;
+
+    a[0] = 1.0;
+    for (m = 1; m <= order; m++) {
+        faac_real km = (faac_real)k[m];
+        int half = (m + 1) / 2;
+
+        for (i = 1; i < half; i++) {
+            faac_real t1 = a[i];
+            faac_real t2 = a[m - i];
+            a[i] = t1 + km * t2;
+            a[m - i] = t2 + km * t1;
+        }
+        if (m % 2 == 0)
+            a[m / 2] += km * a[m / 2];
+        a[m] = km;
+    }
+}
+
+/* direction picks which end of the band the recursion runs from: TNS wants
+ * the prediction to run towards the transient (so quantization noise piles
+ * up where it'll be masked), and the transient can sit at either edge of
+ * the analysis window. */
+static void filter_spec(int length, int order, int direction, const faac_real * a, faac_real * spec)
+{
+    faac_real hist[BLOCK_LEN_LONG];
+    int i, j;
+
+    memcpy(hist, spec, length * sizeof(faac_real));
+    if (direction) {
+        for (i = length - 1; i >= 0; i--) {
+            faac_real acc = hist[i];
+            int jmax = min(order, length - 1 - i);
+
+            for (j = 1; j <= jmax; j++)
+                acc += a[j] * hist[i + j];
+            spec[i] = acc;
+        }
+    } else {
+        for (i = 0; i < length; i++) {
+            faac_real acc = hist[i];
+            int jmax = min(order, i);
+
+            for (j = 1; j <= jmax; j++)
+                acc += a[j] * hist[i - j];
+            spec[i] = acc;
+        }
+    }
+}
+
 void TnsInit(faacEncStruct* hEncoder)
 {
-    unsigned int channel;
-    int fsIndex = hEncoder->sampleRateIdx;
+    unsigned int ch;
+    int fs = hEncoder->sampleRateIdx;
 
-    for (channel = 0; channel < hEncoder->numChannels; channel++) {
-        TnsInfo *tnsInfo = &hEncoder->coderInfo[channel].tnsInfo;
+    for (ch = 0; ch < hEncoder->numChannels; ch++) {
+        TnsInfo *info = &hEncoder->coderInfo[ch].tnsInfo;
 
-        tnsInfo->tnsMaxBandsLong = tnsMaxBandsLongLow[fsIndex];
-        tnsInfo->tnsMaxBandsShort = tnsMaxBandsShortLow[fsIndex];
-        tnsInfo->tnsMaxOrderLong = tnsMaxOrderLongLow;
-        tnsInfo->tnsMaxOrderShort = tnsMaxOrderShortLow;
-        tnsInfo->tnsMinBandNumberLong = tnsMinBandNumberLong[fsIndex];
-        tnsInfo->tnsMinBandNumberShort = tnsMinBandNumberShort[fsIndex];
+        info->tnsMaxBandsLong = tns_sfb_range[fs].max;
+        info->tnsNumSwbLong = hEncoder->srInfo->num_cb_long;
+        info->tnsMinBandNumberLong = tns_sfb_range[fs].min;
     }
 }
 
-
-/*****************************************************/
-/* TnsEncode:                                        */
-/*****************************************************/
-void TnsEncode(TnsInfo* tnsInfo,       /* TNS info */
-               int numberOfBands,       /* Number of bands per window */
-               int maxSfb,              /* max_sfb */
-               enum WINDOW_TYPE blockType,   /* block type */
-               int* sfbOffsetTable,     /* Scalefactor band offset table */
-               faac_real* spec,            /* Spectral data array */
-               faac_real* temp)
+void TnsEncode(TnsInfo* tnsInfo, int numBands, enum WINDOW_TYPE blockType, int* sfbOffsetTable,
+               faac_real* spec)
 {
-    int numberOfWindows,windowSize;
-    int startBand,stopBand,order;    /* Bands over which to apply TNS */
-    int lengthInBands;               /* Length to filter, in bands */
-    int w, i;
-    int startIndex,length;
-    faac_real gain;
+    int b_start, b_stop, i_start, length;
+    faac_real *band, energy;
+    float wspec[BLOCK_LEN_LONG];
+    float r[TNS_MAX_ORDER + 1] = {0};
+    float k[TNS_MAX_ORDER + 1] = {0};
+    float gain;
+    TnsFilterData *filter;
+    int order, limit, i;
 
-    switch( blockType ) {
-    case ONLY_SHORT_WINDOW :
+    tnsInfo->tnsDataPresent = 0;
+    tnsInfo->windowData.numFilters = 0;
 
-        /* TNS not used for short blocks currently */
-        tnsInfo->tnsDataPresent = 0;
+    /* Short windows already have the temporal resolution to not need TNS. */
+    if (blockType == ONLY_SHORT_WINDOW)
         return;
 
-        numberOfWindows = MAX_SHORT_WINDOWS;
-        windowSize = BLOCK_LEN_SHORT;
-        startBand = tnsInfo->tnsMinBandNumberShort;
-        stopBand = numberOfBands;
-        lengthInBands = stopBand-startBand;
-        order = tnsInfo->tnsMaxOrderShort;
-        startBand = min(startBand,tnsInfo->tnsMaxBandsShort);
-        stopBand = min(stopBand,tnsInfo->tnsMaxBandsShort);
-        break;
+    b_start = min(tnsInfo->tnsMinBandNumberLong, numBands);
+    b_stop = min(tnsInfo->tnsMaxBandsLong, numBands);
+    if (b_stop <= b_start)
+        return;
 
-    default:
-        numberOfWindows = 1;
-        windowSize = BLOCK_LEN_SHORT;
-        startBand = tnsInfo->tnsMinBandNumberLong;
-        stopBand = numberOfBands;
-        lengthInBands = stopBand - startBand;
-        order = tnsInfo->tnsMaxOrderLong;
-        startBand = min(startBand,tnsInfo->tnsMaxBandsLong);
-        stopBand = min(stopBand,tnsInfo->tnsMaxBandsLong);
-        break;
-    }
+    i_start = sfbOffsetTable[b_start];
+    length = sfbOffsetTable[b_stop] - i_start;
+    if (length <= TNS_LPC_ORDER)
+        return;
 
-    /* Make sure that start and stop bands < maxSfb */
-    /* Make sure that start and stop bands >= 0 */
-    startBand = min(startBand,maxSfb);
-    stopBand = min(stopBand,maxSfb);
-    startBand = max(startBand,0);
-    stopBand = max(stopBand,0);
+    band = spec + i_start;
+    energy = 0.0;
+    for (i = 0; i < length; i++)
+        energy += band[i] * band[i];
+    if (energy < (faac_real)TNS_MIN_ENERGY)
+        return;
 
-    tnsInfo->tnsDataPresent = 0;     /* default TNS not used */
+    /* Per-band RMS-normalize before autocorrelation, floored at 1% of the
+     * loudest band's RMS. Un-normalized, Levinson-Durbin would fit whatever
+     * band has the most energy and ignore quieter ones -- but pre-echo is
+     * audible in quiet bands too, so the filter needs to whiten across the
+     * whole range, not just the peak. */
+    {
+        float maxrms = 0.0f, floorrms;
+        float sum_rms = 0.0f, sum_log_rms = 0.0f;
+        int nbands = b_stop - b_start;
+        int b;
 
-    /* Perform analysis and filtering for each window */
-    for (w=0;w<numberOfWindows;w++) {
+        for (b = b_start; b < b_stop; b++) {
+            int s0 = sfbOffsetTable[b], s1 = sfbOffsetTable[b + 1];
+            float e = 0.0f, rms, rms_fl;
 
-        TnsWindowData* windowData = &tnsInfo->windowData[w];
-        TnsFilterData* tnsFilter = windowData->tnsFilter;
-        faac_real* k = tnsFilter->kCoeffs;    /* reflection coeffs */
-        faac_real* a = tnsFilter->aCoeffs;    /* prediction coeffs */
+            for (i = s0; i < s1; i++)
+                e += (float)(spec[i] * spec[i]);
+            rms = sqrtf(e / (float)(s1 - s0));
+            if (rms > maxrms) maxrms = rms;
 
-        windowData->numFilters=0;
-        windowData->coefResolution = DEF_TNS_COEFF_RES;
-        startIndex = w * windowSize + sfbOffsetTable[startBand];
-        length = sfbOffsetTable[stopBand] - sfbOffsetTable[startBand];
-        gain = LevinsonDurbin(order,length,&spec[startIndex],k);
-
-        if (gain>DEF_TNS_GAIN_THRESH) {  /* Use TNS */
-            int truncatedOrder;
-            QuantizeReflectionCoeffs(order,DEF_TNS_COEFF_RES,k,tnsFilter->index);
-            truncatedOrder = TruncateCoeffs(order,DEF_TNS_COEFF_THRESH,k);
-            if (truncatedOrder == 0) continue;
-
-            windowData->numFilters++;
-            tnsInfo->tnsDataPresent=1;
-            tnsFilter->direction = 0;
-
-            tnsFilter->coefCompress = 1;
-            for (i = 1; i <= truncatedOrder; i++) {
-                int limit = 1 << (DEF_TNS_COEFF_RES - 2);
-                if (tnsFilter->index[i] < -limit || tnsFilter->index[i] >= limit) {
-                    tnsFilter->coefCompress = 0;
-                    break;
-                }
-            }
-
-            tnsFilter->length = lengthInBands;
-            tnsFilter->order = truncatedOrder;
-            StepUp(truncatedOrder,k,a);    /* Compute predictor coefficients */
-            TnsInvFilter(length,&spec[startIndex],tnsFilter,temp);      /* Filter */
-        }
-    }
-}
-
-
-
-/********************************************************/
-/* TnsInvFilter:                                        */
-/*   Inverse filter the given spec with specified       */
-/*   length using the coefficients specified in filter. */
-/*   Note that the order and direction are specified    */
-/*   within the TNS_FILTER_DATA structure.              */
-/********************************************************/
-static void TnsInvFilter(int length, faac_real * restrict spec,
-                         const TnsFilterData * restrict filter,
-                         faac_real * restrict temp)
-{
-    int i, j;
-    const int order = filter->order;
-    const faac_real * restrict a = filter->aCoeffs;
-
-    /* Determine loop parameters for given direction */
-    if (filter->direction) {
-        /* Backward direction (high-to-low index) */
-        temp[length-1] = spec[length-1];
-        for (i = length-2; i > (length-1-order); i--) {
-            faac_real acc = spec[i];
-            temp[i] = acc;
-            for (j = 1; j <= (length-1-i); j++)
-                acc += temp[i+j] * a[j];
-            spec[i] = acc;
-        }
-        /* Now filter the rest */
-        for (i = length-1-order; i >= 0; i--) {
-            faac_real acc = spec[i];
-            temp[i] = acc;
-            for (j = 1; j <= order; j++)
-                acc += temp[i+j] * a[j];
-            spec[i] = acc;
-        }
-    } else {
-        /* Forward direction (low-to-high index) */
-        temp[0] = spec[0];
-        for (i = 1; i < order; i++) {
-            faac_real acc = spec[i];
-            temp[i] = acc;
-            for (j = 1; j <= i; j++)
-                acc += temp[i-j] * a[j];
-            spec[i] = acc;
+            /* rms_fl keeps logf() away from 0 for silent bands; folded into
+             * the same loop as maxrms rather than a second pass. */
+            rms_fl = rms > TNS_MIN_ENERGY ? rms : TNS_MIN_ENERGY;
+            sum_rms += rms_fl;
+            sum_log_rms += logf(rms_fl);
         }
 
-        /* Now filter the rest */
-        for (i = order; i < length; i++) {
-            faac_real acc = spec[i];
-            temp[i] = acc;
-            for (j = 1; j <= order; j++)
-                acc += temp[i-j] * a[j];
-            spec[i] = acc;
+        /* Spectral flatness (geomean/arithmean of per-band RMS) near 1.0
+         * means the band is noise-like, which PNS (quantize.c) is about to
+         * replace anyway -- skip the LPC work; it only pays off on
+         * tonal/peaky bands. */
+        if (expf(sum_log_rms / (float)nbands) / (sum_rms / (float)nbands) > TNS_PNS_SFM_SKIP)
+            return;
+
+        floorrms = maxrms * 0.01f;
+        if (floorrms < TNS_MIN_ENERGY) floorrms = TNS_MIN_ENERGY;
+
+        for (b = b_start; b < b_stop; b++) {
+            int s0 = sfbOffsetTable[b], s1 = sfbOffsetTable[b + 1];
+            float e = 0.0f, rms, wgt;
+
+            for (i = s0; i < s1; i++)
+                e += (float)(spec[i] * spec[i]);
+            rms = sqrtf(e / (float)(s1 - s0));
+            wgt = 1.0f / (rms > floorrms ? rms : floorrms);
+            for (i = s0; i < s1; i++)
+                wspec[i - i_start] = (float)spec[i] * wgt;
         }
     }
-}
 
+    calc_autocorr_f(TNS_LPC_ORDER, length, wspec, r);
+    gain = compute_lpc(TNS_LPC_ORDER, r, k);
+    if (gain < TNS_GAIN_LIMIT || gain > TNS_GAIN_CLAMP)
+        return;
 
+    filter = &tnsInfo->windowData.tnsFilter[0];
+    quantize_coeffs(TNS_LPC_ORDER, DEF_TNS_COEFF_RES, k, filter->index);
 
+    /* Drop trailing taps that quantized away to ~nothing: they cost bits
+     * without changing what the filter does. */
+    order = TNS_LPC_ORDER;
+    while (order > 0 && fabsf(k[order]) < (float)DEF_TNS_COEFF_THRESH)
+        order--;
+    if (order == 0)
+        return;
 
+    filter->order = order;
+    filter->length = tnsInfo->tnsNumSwbLong - b_start;
 
-/*****************************************************/
-/* TruncateCoeffs:                                   */
-/*   Truncate the given reflection coeffs by zeroing */
-/*   coefficients in the tail with absolute value    */
-/*   less than the specified threshold.  Return the  */
-/*   truncated filter order.                         */
-/*****************************************************/
-static int TruncateCoeffs(int fOrder,faac_real threshold,faac_real* kArray)
-{
-    int i;
+    /* Direction is fixed rather than picked from a transient envelope; that
+     * comes with FrameStrategy in a later commit. */
+    filter->direction = 0;
 
-    for (i = fOrder; i >= 0; i--) {
-        kArray[i] = (FAAC_FABS(kArray[i])>threshold) ? kArray[i] : 0.0;
-        if (kArray[i]!=0.0) return i;
-    }
-
-    return 0;
-}
-
-/*****************************************************/
-/* QuantizeReflectionCoeffs:                         */
-/*   Quantize the given array of reflection coeffs   */
-/*   to the specified resolution in bits.            */
-/*****************************************************/
-static void QuantizeReflectionCoeffs(int fOrder,
-                              int coeffRes,
-                              faac_real* kArray,
-                              int* indexArray)
-{
-    faac_real iqfac,iqfac_m;
-    int i;
-
-    iqfac = ((1<<(coeffRes-1))-0.5)/(M_PI/2);
-    iqfac_m = ((1<<(coeffRes-1))+0.5)/(M_PI/2);
-
-    /* Quantize and inverse quantize */
-    for (i=1;i<=fOrder;i++) {
-        indexArray[i] = (kArray[i]>=0)?(int)(0.5+(FAAC_ASIN(kArray[i])*iqfac)):(int)(-0.5+(FAAC_ASIN(kArray[i])*iqfac_m));
-        kArray[i] = FAAC_SIN((faac_real)indexArray[i]/((indexArray[i]>=0)?iqfac:iqfac_m));
-    }
-}
-
-/*****************************************************/
-/* Autocorrelation,                                  */
-/*   Compute the autocorrelation function            */
-/*   estimate for the given data.                    */
-/*****************************************************/
-static void Autocorrelation(int maxOrder,                      /* Maximum autocorr order */
-                            int dataSize,                     /* Size of the data array */
-                            const faac_real * restrict  data, /* Data array */
-                            faac_real * restrict rArray)      /* Autocorrelation array */
-{
-    int order, index;
-
-    for (order = 0; order <= maxOrder; order++)
-        rArray[order] = 0.0;
-
-    int limit = dataSize - maxOrder;
-    for (index = 0; index < limit; index++) {
-        const faac_real d = data[index];
-        const faac_real * restrict dp = &data[index + 1];
-        rArray[0] += d * d;
-        for (order = 1; order <= maxOrder; order++)
-            rArray[order] += d * dp[order - 1];
-    }
-
-    for (; index < dataSize; index++) {
-        const faac_real d = data[index];
-        int n = dataSize - 1 - index;
-        rArray[0] += d * d;
-        for (order = 1; order <= n; order++)
-            rArray[order] += d * data[index + order];
-    }
-}
-
-
-/*****************************************************/
-/* LevinsonDurbin:                                   */
-/*   Compute the reflection coefficients for the     */
-/*   given data using LevinsonDurbin recursion.      */
-/*   Return the prediction gain.                     */
-/*****************************************************/
-static faac_real LevinsonDurbin(int fOrder,                      /* Filter order */
-                                int dataSize,                    /* Size of the data array */
-                                const faac_real * restrict data, /* Data array */
-                                faac_real * restrict kArray)     /* Reflection coeff array */
-{
-    int order,i;
-    faac_real signal;
-    faac_real error, kTemp;                /* Prediction error */
-    faac_real aArray1[TNS_MAX_ORDER+1];    /* Predictor coeff array */
-    faac_real aArray2[TNS_MAX_ORDER+1];    /* Predictor coeff array 2 */
-    faac_real rArray[TNS_MAX_ORDER+1] = {0}; /* Autocorrelation coeffs */
-    faac_real* aPtr = aArray1;             /* Ptr to aArray1 */
-    faac_real* aLastPtr = aArray2;         /* Ptr to aArray2 */
-    faac_real* aTemp;
-
-    /* Compute autocorrelation coefficients */
-    Autocorrelation(fOrder,dataSize,data,rArray);
-    signal=rArray[0];   /* signal energy */
-
-    /* Set up pointers to current and last iteration */
-    /* predictor coefficients.                       */
-    aPtr = aArray1;
-    aLastPtr = aArray2;
-    /* If there is no signal energy, return */
-    if (!signal) {
-        kArray[0]=1.0;
-        for (order=1;order<=fOrder;order++) {
-            kArray[order]=0.0;
-        }
-        return 0;
-
-    } else {
-
-        /* Set up first iteration */
-        kArray[0]=1.0;
-        aPtr[0]=1.0;        /* Ptr to predictor coeffs, current iteration*/
-        aLastPtr[0]=1.0;    /* Ptr to predictor coeffs, last iteration */
-        error=rArray[0];
-
-        /* Now perform recursion */
-        for (order=1;order<=fOrder;order++) {
-            kTemp = aLastPtr[0]*rArray[order-0];
-            for (i=1;i<order;i++) {
-                kTemp += aLastPtr[i]*rArray[order-i];
-            }
-            if (error <= 0.0 || FAAC_FABS(kTemp) >= error) {
-                error = 0.0;
-                break;
-            }
-            kTemp = -kTemp/error;
-            kArray[order]=kTemp;
-            aPtr[order]=kTemp;
-            for (i=1;i<order;i++) {
-                aPtr[i] = aLastPtr[i] + kTemp*aLastPtr[order-i];
-            }
-            error = error * (1 - kTemp*kTemp);
-            if (error <= 0.0) break;
-
-            /* Now make current iteration the last one */
-            aTemp=aLastPtr;
-            aLastPtr=aPtr;      /* Current becomes last */
-            aPtr=aTemp;         /* Last becomes current */
-        }
-        /* If perfect prediction, trigger TNS */
-        if (error <= 0.0) return DEF_TNS_GAIN_THRESH + 1.0;
-        return signal/error;    /* return the gain */
-    }
-}
-
-
-/*****************************************************/
-/* StepUp:                                           */
-/*   Convert reflection coefficients into            */
-/*   predictor coefficients.                         */
-/*****************************************************/
-static void StepUp(int fOrder,faac_real* kArray,faac_real* aArray)
-{
-    faac_real aTemp[TNS_MAX_ORDER+2];
-    int i,order;
-
-    aArray[0]=1.0;
-    aTemp[0]=1.0;
-    for (order=1;order<=fOrder;order++) {
-        aArray[order]=0.0;
-        for (i=1;i<=order;i++) {
-            aTemp[i] = aArray[i] + kArray[order]*aArray[order-i];
-        }
-        for (i=1;i<=order;i++) {
-            aArray[i]=aTemp[i];
+    /* Coefficients that all fit in one fewer bit each can be transmitted at
+     * reduced resolution; the spec's coefCompress flag signals that. */
+    filter->coefCompress = 1;
+    limit = 1 << (DEF_TNS_COEFF_RES - 2);
+    for (i = 1; i <= order; i++) {
+        if (filter->index[i] < -limit || filter->index[i] >= limit) {
+            filter->coefCompress = 0;
+            break;
         }
     }
+
+    finalize_filter(order, k, filter->aCoeffs);
+
+    /* compute_lpc's gain estimate was on the un-quantized coefficients;
+     * quantization can erode it enough that the filter actually being
+     * transmitted no longer pays for itself. Re-check on a trial run of the
+     * real (quantized) filter before committing to writing it out. */
+    {
+        faac_real trial[BLOCK_LEN_LONG];
+        faac_real orig_e = 0.0, filt_e = 0.0;
+
+        memcpy(trial, wspec, length * sizeof(faac_real));
+        filter_spec(length, order, filter->direction, filter->aCoeffs, trial);
+        for (i = 0; i < length; i++) {
+            orig_e += (faac_real)wspec[i] * (faac_real)wspec[i];
+            filt_e += trial[i] * trial[i];
+        }
+        if (filt_e < (faac_real)TNS_MIN_ENERGY)
+            filt_e = (faac_real)TNS_MIN_ENERGY;
+        if (orig_e < (faac_real)TNS_MEASURED_GAIN * filt_e)
+            return;
+    }
+
+    filter_spec(length, order, filter->direction, filter->aCoeffs, band);
+    tnsInfo->windowData.numFilters = 1;
+    tnsInfo->windowData.coefResolution = DEF_TNS_COEFF_RES;
+    tnsInfo->tnsDataPresent = 1;
 }

--- a/libfaac/tns.h
+++ b/libfaac/tns.h
@@ -1,45 +1,42 @@
-/**********************************************************************
-
-This software module was originally developed by
-and edited by Texas Instruments in the course of
-development of the MPEG-2 NBC/MPEG-4 Audio standard
-ISO/IEC 13818-7, 14496-1,2 and 3. This software module is an
-implementation of a part of one or more MPEG-2 NBC/MPEG-4 Audio tools
-as specified by the MPEG-2 NBC/MPEG-4 Audio standard. ISO/IEC gives
-users of the MPEG-2 NBC/MPEG-4 Audio standards free license to this
-software module or modifications thereof for use in hardware or
-software products claiming conformance to the MPEG-2 NBC/ MPEG-4 Audio
-standards. Those intending to use this software module in hardware or
-software products are advised that this use may infringe existing
-patents. The original developer of this software module and his/her
-company, the subsequent editors and their companies, and ISO/IEC have
-no liability for use of this software module or modifications thereof
-in an implementation. Copyright is not released for non MPEG-2
-NBC/MPEG-4 Audio conforming products. The original developer retains
-full right to use the code for his/her own purpose, assign or donate
-the code to a third party and to inhibit third party from using the
-code for non MPEG-2 NBC/MPEG-4 Audio conforming products. This
-copyright notice must be included in all copies or derivative works.
-
-Copyright (c) 1997.
-**********************************************************************/
 /*
- * $Id: tns.h,v 1.6 2012/03/01 18:34:17 knik Exp $
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+/*
+ * Temporal Noise Shaping (TNS): a predictive filter along the frequency axis
+ * that reshapes quantization noise in time so it hides behind transients
+ * instead of leaking out as pre-echo. Long-window only here; short windows
+ * already have the temporal resolution to not need it.
  */
 
 #ifndef TNS_H
 #define TNS_H
 
 #include "faac_real.h"
+#include "coder.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-
+/* Latch the per-channel band limits from the sample rate's TNS tool table. */
 void TnsInit(faacEncStruct* hEncoder);
-void TnsEncode(TnsInfo* tnsInfo, int numberOfBands,int maxSfb,enum WINDOW_TYPE blockType,
-               int* sfbOffsetTable,faac_real* spec, faac_real* temp);
+
+/* Analyse one channel and, if it pays off, whiten `spec` in place. */
+void TnsEncode(TnsInfo* tnsInfo, int numBands,
+               enum WINDOW_TYPE blockType, int* sfbOffsetTable,
+               faac_real* spec);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
libfaac/tns.c and tns.h are authored by Nils Schimmelmann and licensed under LGPL-2.1-or-later. They carried the restrictive MPEG-2 NBC/ISO reference-software header (originally developed by Texas Instruments in the course of the MPEG-2 NBC/MPEG-4 Audio standard); this rewrite drops it.

The Levinson-Durbin LPC derivation (compute_lpc), reflection-coefficient quantization (quantize_coeffs), and the gain-clamped accept/reject heuristic (TNS_GAIN_LIMIT/TNS_GAIN_CLAMP/TNS_MEASURED_GAIN) are original work. Filter application via the AR lattice recursion (finalize_filter/ filter_spec) follows ISO/IEC 13818-7/14496-3's TNS tool specification, which is not itself copyrightable.

This is a genuine algorithm rewrite, not a transliteration, and diverges from the prior implementation in three ways: per-band RMS-normalization before the LPC fit so the filter whitens across the whole band range instead of just the loudest band; post-quantization gain re-verification against the actual transmitted coefficients rather than the pre-quantization estimate; and a silence/energy gate before doing any LPC work. Filter direction is hardcoded to 0 here, matching the prior behavior; picking it from the block-switcher's transient envelope comes with FrameStrategy in a later commit.

TNS is long-only, so tnsDataPresent is never set for ONLY_SHORT_WINDOW. channels.c's WriteICS (which writes the tns_data() bitstream element) no longer branches on block_type for TNS field widths or loops up to MAX_SHORT_WINDOWS -- that path was dead. TnsInfo.windowData is now a single struct instead of a MAX_SHORT_WINDOWS-sized array to match.