### PR TITLE
frontend: make maingui.c consistent and keep TNS off by default

### DIFF
--- a/frontend/maingui.c
+++ b/frontend/maingui.c
@@ -333,7 +333,7 @@ static BOOL WINAPI DialogProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
         CheckDlgButton(hWnd, IDC_USELFE, FALSE);
         CheckDlgButton(hWnd, IDC_USERAW, FALSE);
-        CheckDlgButton(hWnd, IDC_USETNS, TRUE);
+        CheckDlgButton(hWnd, IDC_USETNS, FALSE);
         SetDlgItemText(hWnd, IDC_QUALITY, "100");
         SetDlgItemText(hWnd, IDC_BANDWIDTH, "0");
 


### PR DESCRIPTION
main.c has TNS as disabled by default