### PR TITLE
honor ABI backward compatibility for faac_params

### DIFF
--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -56,6 +56,13 @@ _Static_assert((int)FAAC_INPUT_NULL  == INPUT_NULL  && (int)FAAC_INPUT_16BIT == 
             && (int)FAAC_INPUT_24BIT == INPUT_24BIT && (int)FAAC_INPUT_32BIT == INPUT_32BIT
             && (int)FAAC_INPUT_FLOAT == INPUT_FLOAT, "input format drift");
 
+/* Baseline layout as first shipped. Frozen by the append-only rule: new fields
+ * go after reserved_trailing, so this offset never moves. Not sizeof(), which
+ * grows with every appended field and would reject older callers' binaries.
+ * A literal would be wrong too: the layout depends on pointer width. */
+#define PARAMS_BASELINE_SIZE \
+    ((uint32_t)(offsetof(faac_params, reserved_trailing) + sizeof(uint32_t)))
+
 /* faac_encoder* and faacEncHandle are the same underlying object. */
 static inline faacEncStruct *unwrap(faac_encoder *enc) { return (faacEncStruct *)enc; }
 
@@ -181,11 +188,8 @@ FAACAPI faac_status faac_encoder_open(const faac_params *p, faac_encoder **out)
     if (!p)
         return FAAC_ERR_INVALID_ARGUMENT;
 
-    /* struct_size lets the library reconcile a caller compiled against a
-     * different header revision. A caller must be at least as new as this
-     * build's struct (older/garbage/zero is rejected); newer callers are read
-     * only through the fields this build knows. */
-    if (p->struct_size < sizeof(faac_params))
+    /* Not sizeof(faac_params): that grows, which would reject older callers. */
+    if (p->struct_size < PARAMS_BASELINE_SIZE)
         return FAAC_ERR_INVALID_ARGUMENT;
 
     st = validate_params(p);


### PR DESCRIPTION
This PR fixes a bug in `faac_encoder_open()` that would have broken ABI compatibility the first time a new field was added to `faac_params`.

### The Problem
`faac.h` promises forward compatibility: a program built against an older release of `libfaac` should be able to run against a newer one without being rebuilt. The `faac_params` struct is designed to only grow at the end, using `struct_size` to tell the library which fields the caller's copy actually has.

However, `faac_encoder_open()` demanded that the caller's `struct_size` be at least `sizeof(faac_params)`. Because `sizeof(faac_params)` grows every time a field is added, adding a single new field would instantly reject every program built against the older header. This defeats the purpose of the scheme and would force package maintainers / user space programs to rebuild all `libfaac` users in lockstep.

### The Fix
* Changed the size requirement to only demand the baseline size `faac_params` had when it first shipped.
* That baseline is derived as `offsetof(faac_params, reserved_trailing) + sizeof(uint32_t)` — the offset of the last original field. New fields are only ever appended *after* it, so the append-only rule freezes the offset and it never moves. Unlike `sizeof`, it cannot drift.
* The number stays internal to `libfaac`—callers continue to fill in `struct_size` using their own `sizeof` and never need to know about the baseline.

### Why not a hardcoded literal
An earlier revision froze the baseline as a literal `72` guarded by a `_Static_assert`. That was wrong: the struct contains a pointer (`channel_map`), so the layout is word-size dependent — on LP64 `sizeof(faac_params)` is 72, on ILP32 it is 68. The assert would have failed and the library would not have compiled at all on i386/armhf. As @fabiangreffrath noted, `sizeof(bool)` is implementation-defined too (C17 6.2.5p2 only requires `_Bool` to hold 0 and 1), which is a second way a literal could go wrong.

The `offsetof` form is correct on every ABI regardless of pointer width or `sizeof(bool)`, and stays consistent with the caller, who passes their own `sizeof` compiled against the same ABI. It is its own invariant, so the separate `_Static_assert` is gone.
