### PR TITLE
sbr: align payload timing with core audio frames

### DIFF
--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -593,9 +593,12 @@ int faacEncEncode(faacEncHandle hpEncoder,
     if (hEncoder->flushFrame > (LOOKAHEAD_DEPTH + 1))
         return 0;
 
-    /* HE-AAC: run SBR + downsample first; the core then encodes heHalfRate. */
+    /* HE-AAC: run SBR + downsample first; the core then encodes heHalfRate.
+     * Flush frames (realPerCh == 0) included -- the SBR payload runs
+     * SBR_FRAME_FIFO-1 frames behind, so the pipeline has to keep ticking
+     * through the drain or the tail access units re-emit stale envelopes. */
     float *heHalfRate[MAX_CHANNELS] = {0};
-    if (realPerCh > 0 && hEncoder->config.aacObjectType == HE_V1 && SbrContextIsPresent(hEncoder->sbrContext))
+    if (hEncoder->config.aacObjectType == HE_V1 && SbrContextIsPresent(hEncoder->sbrContext))
         doHEAACFrame(hEncoder, (unsigned int)realPerCh, heHalfRate);
 
     /* Update current sample buffers */

--- a/libfaac/sbr.c
+++ b/libfaac/sbr.c
@@ -145,8 +145,6 @@ void SbrUpdate(SBRInfo *sbr, unsigned long bitRate)
     sbr->bs_stop_freq = 10;
     sbr->bs_freq_res = 1; /* HIGH resolution */
     sbr->bs_xover_band = 0; /* every master band is an SBR band; no low-res split */
-    sbr->numEnvelopes = 1;
-    sbr->eff_amp_res = (sbr->numEnvelopes == 1) ? 0 : sbr->bs_amp_res;
     sbr->kx = compute_kx(sampleRate, sbr->bs_start_freq);
     sbr->k2 = compute_k2(sampleRate, sbr->kx, sbr->bs_stop_freq);
 
@@ -160,6 +158,24 @@ void SbrEnd(SBRInfo *sbr)
     FreeMemory(sbr);
 }
 
+/* What analysing a silent frame yields. Needed because zeroed memory is not a
+ * legal payload: numEnvelopes == 0 encodes no grid at all. */
+static void sbr_frame_silence(SbrFrameData *fd)
+{
+    SetMemory(fd, 0, sizeof(*fd));
+    fd->numEnvelopes = 1;
+    fd->eff_amp_res  = 0;
+    fd->frameClass   = SBR_FRAME_CLASS_FIXFIX;
+    fd->tEnv[0]      = 0;
+    fd->tEnv[1]      = SBR_NUM_TIME_SLOTS;
+    fd->bsPointer    = 0;
+    for (int ch = 0; ch < SBR_MAX_CODED_CHANNELS; ch++) {
+        fd->ch[ch].invfMode = 3;
+        for (int ne = 0; ne < SBR_MAX_NOISE_ENVELOPES; ne++)
+            fd->ch[ch].noiseData[ne][0] = SBR_NOISE_LEVEL_DEFAULT;
+    }
+}
+
 SBRContext *SbrContextInit(int channels)
 {
     SBRContext *sbrCtx = (SBRContext *)AllocMemory(sizeof(SBRContext));
@@ -170,6 +186,10 @@ SBRContext *SbrContextInit(int channels)
             FreeMemory(sbrCtx);
             return NULL;
         }
+        /* The first access units carry the core's silent lead-in, so the ring
+         * has to start full of payloads that describe silence. */
+        for (int i = 0; i < SBR_FRAME_FIFO; i++)
+            sbr_frame_silence(&sbrCtx->frameFIFO[i]);
     }
     return sbrCtx;
 }
@@ -234,20 +254,44 @@ void SbrContextProcessFrame(SBRContext *sCtx, int numChannels, int realPerCh, fl
     Resampler *rs = sCtx->resampler;
     float *fullPtrs[MAX_CHANNELS];
 
+    /* SbrEncode quantizes into the new head; SbrWrite (via SbrContextGetBits)
+     * emits the oldest slot, which is the payload for this frame's core audio. */
+    sCtx->frameHead = (sCtx->frameHead + 1) % SBR_FRAME_FIFO;
+    SbrFrameData *fd = &sCtx->frameFIFO[sCtx->frameHead];
+
+    /* Flush frames are silence, whose analysis result is known up front: no
+     * transient, one FIXFIX envelope, floored levels, default noise floors.
+     * Skip straight to it -- the core signal is substituted with silence in
+     * frame.c anyway -- but keep the delay lines advancing so the payloads
+     * still in flight drain out. */
+    if (realPerCh == 0) {
+        sbr_frame_silence(fd);
+        for (channel = 0; channel < (unsigned int)numChannels; channel++) {
+            memmove(&sCtx->transientStrengthFIFO[channel][0], &sCtx->transientStrengthFIFO[channel][1], (SBR_DETECT_FIFO - 1) * sizeof(float));
+            sCtx->transientStrengthFIFO[channel][SBR_DETECT_FIFO - 1] = 0.0f;
+            memmove(&sCtx->wantShortFIFO[channel][0], &sCtx->wantShortFIFO[channel][1], (SBR_DETECT_FIFO - 1) * sizeof(int));
+            sCtx->wantShortFIFO[channel][SBR_DETECT_FIFO - 1] = 0;
+            heHalfRate[channel] = rs->halfRate[channel];
+        }
+        return;
+    }
+
     for (channel = 0; channel < (unsigned int)numChannels; channel++) {
         float *fullRate = rs->fullRate[channel];
         fullPtrs[channel] = fullRate;
         memcpy(fullRate, inputFifo[channel], realPerCh * sizeof(float));
         /* Final partial frame: silence-pad the unfilled full-rate tail to
-         * prevent the resampler from consuming stale data. SbrEncode reads
-         * only [0, realPerCh), so it is unaffected. */
+         * prevent the resampler from consuming stale data. */
         if (realPerCh < 2 * FRAME_LEN)
             memset(fullRate + realPerCh, 0, (2 * FRAME_LEN - realPerCh) * sizeof(float));
         heHalfRate[channel] = rs->halfRate[channel];
     }
 
-    /* Shared signal analysis. */
-    SbrAnalyze(&sCtx->signalAnalysis, fullPtrs, numChannels, realPerCh, sCtx->sbrInfo);
+    /* Always the full padded frame, never [0, realPerCh): the grid unconditionally
+     * claims SBR_NUM_TIME_SLOTS, so normalising a short frame over fewer slots
+     * would inflate its levels, and the QMF-overlap save below reads the last
+     * SBR_QMF_OVL_LEN_64 samples -- behind the buffer for a short frame. */
+    SbrAnalyze(&sCtx->signalAnalysis, fullPtrs, numChannels, 2 * FRAME_LEN, sCtx->sbrInfo);
 
     /* Update the transient FIFO. Shift down by one and push
      * the newest decision at SBR_DETECT_FIFO-1; index 0 stays aligned with the
@@ -259,7 +303,7 @@ void SbrContextProcessFrame(SBRContext *sCtx, int numChannels, int realPerCh, fl
         sCtx->wantShortFIFO[channel][SBR_DETECT_FIFO - 1] = sCtx->signalAnalysis.ch[channel].wantShort;
     }
 
-    SbrEncode(sCtx->sbrInfo, fullPtrs, numChannels, realPerCh, &sCtx->signalAnalysis);
+    SbrEncode(sCtx->sbrInfo, fullPtrs, numChannels, 2 * FRAME_LEN, &sCtx->signalAnalysis, fd);
 
     /* Dual-rate decimation: produces the halved-rate core signal. */
     Resample(rs, 2 * FRAME_LEN);
@@ -375,26 +419,27 @@ void SbrQmfAnalysis(SBRInfo *sbr, const float * restrict ovl_pos, float * restri
 }
 
 
-static void sbr_adopt_envelope_grid(SBRInfo *sbr, struct SignalAnalysis *sa)
+static void sbr_adopt_envelope_grid(const SBRInfo *sbr, const struct SignalAnalysis *sa, SbrFrameData *fd)
 {
-    sbr->numEnvelopes = sa->numEnvelopes;
-    sbr->frameClass   = sa->frameClass;
-    sbr->bsPointer    = sa->bsPointer;
-    for (int i = 0; i <= sa->numEnvelopes; i++) sbr->tEnv[i] = sa->tEnv[i];
-    sbr->eff_amp_res = (sbr->numEnvelopes == 1) ? 0 : sbr->bs_amp_res;
+    fd->numEnvelopes = sa->numEnvelopes;
+    fd->frameClass   = sa->frameClass;
+    fd->bsPointer    = sa->bsPointer;
+    for (int i = 0; i <= sa->numEnvelopes; i++) fd->tEnv[i] = sa->tEnv[i];
+    fd->eff_amp_res = (fd->numEnvelopes == 1) ? 0 : sbr->bs_amp_res;
 }
 
-static void sbr_quantize_envelopes(SBRInfo *sbr, int nch, int sampled,
-                                   struct SignalAnalysis *sa,
-                                   float bandHalfE[2][2][SBR_QMF_BANDS_64])
+static void sbr_quantize_envelopes(const SBRInfo *sbr, int nch, int sampled,
+                                   const struct SignalAnalysis *sa, SbrFrameData *fd)
 {
-    int n_env = sbr->numEnvelopes;
+    int n_env = fd->numEnvelopes;
 
     for (int ch = 0; ch < nch; ch++) {
+        /* Read-only alias; the quantizer never writes back through it. */
+        const float (* restrict bandHalfE)[SBR_QMF_BANDS_64] = sa->ch[ch].bandHalfE;
         int noise_level = SBR_NOISE_LEVEL_DEFAULT;
-        sbr->ch[ch].invfMode = 3;
+        fd->ch[ch].invfMode = 3;
 
-        int dlav = sbr->eff_amp_res ? SBR_ENV_DELTA_LIMIT_HIRES : SBR_ENV_DELTA_LIMIT_LORES;
+        int dlav = fd->eff_amp_res ? SBR_ENV_DELTA_LIMIT_HIRES : SBR_ENV_DELTA_LIMIT_LORES;
         for (int e = 0; e < n_env; e++) {
             int prevLevel = -1;
             for (int b = 0; b < sbr->numBands; b++) {
@@ -405,21 +450,21 @@ static void sbr_quantize_envelopes(SBRInfo *sbr, int nch, int sampled,
                 if (e_slots < 1) e_slots = 1;
                 float E = 0;
                 if (n_env == 1) {
-                    for (int k = k_lo; k < k_hi; k++) E += bandHalfE[ch][0][k] + bandHalfE[ch][1][k];
+                    for (int k = k_lo; k < k_hi; k++) E += bandHalfE[0][k] + bandHalfE[1][k];
                 } else {
-                    for (int k = k_lo; k < k_hi; k++) E += bandHalfE[ch][e][k];
+                    for (int k = k_lo; k < k_hi; k++) E += bandHalfE[e][k];
                 }
                 E /= (float)(e_slots * (k_hi - k_lo));
-                float factor = sbr->eff_amp_res ? 1.0f : 2.0f;
+                float factor = fd->eff_amp_res ? 1.0f : 2.0f;
                 int level = lrintf(factor * (fast_log2(E + SBR_LOG_ENERGY_FLOOR) - SBR_ENV_LEVEL_LOG2_OFFSET));
                 int raw_level = clamp_int(level, 0, 127);
                 if (prevLevel < 0) {
-                    raw_level = clamp_int(raw_level, 0, sbr->eff_amp_res ? 63 : 127);
-                    sbr->ch[ch].envData[e][b] = raw_level;
+                    raw_level = clamp_int(raw_level, 0, fd->eff_amp_res ? 63 : 127);
+                    fd->ch[ch].envData[e][b] = raw_level;
                     prevLevel = raw_level;
                 } else {
                     int delta = clamp_int(raw_level - prevLevel, -dlav, dlav);
-                    sbr->ch[ch].envData[e][b] = delta;
+                    fd->ch[ch].envData[e][b] = delta;
                     prevLevel += delta;
                 }
             }
@@ -429,35 +474,30 @@ static void sbr_quantize_envelopes(SBRInfo *sbr, int nch, int sampled,
             int prevNoise = -1;
             for (int nb = 0; nb < sbr->numNoiseBands; nb++) {
                 if (prevNoise < 0) {
-                    sbr->ch[ch].noiseData[ne][nb] = noise_level;
+                    fd->ch[ch].noiseData[ne][nb] = noise_level;
                     prevNoise = noise_level;
                 } else {
                     int delta = clamp_int(noise_level - prevNoise, -15, 15);
-                    sbr->ch[ch].noiseData[ne][nb] = delta; prevNoise += delta;
+                    fd->ch[ch].noiseData[ne][nb] = delta; prevNoise += delta;
                 }
             }
         }
     }
 }
 
-void SbrEncode(SBRInfo *sbr, float *timeDomain[MAX_CHANNELS], int numChannels, int numSamples, struct SignalAnalysis *sa)
+void SbrEncode(SBRInfo *sbr, float *timeDomain[MAX_CHANNELS], int numChannels, int numSamples, struct SignalAnalysis *sa, SbrFrameData *fd)
 {
-    int nch = clamp_int(numChannels, 1, 2);
-    float bandHalfE[2][2][SBR_QMF_BANDS_64];
+    int nch = clamp_int(numChannels, 1, SBR_MAX_CODED_CHANNELS);
 
     /* New frame: freeze the header-send decision now, before SbrWrite's write
      * pass (later, in the bitstream stage) mutates headerSent/frameCount. */
     sbr->sendHeaderThisFrame = (!sbr->headerSent || (sbr->frameCount % SBR_HEADER_PERIOD == 0));
 
-    for (int ch = 0; ch < nch; ch++) {
-        /* Use shared transient strength and accumulated energies from SbrAnalyze. */
-        memcpy(bandHalfE[ch][0], sa->ch[ch].bandHalfE[0], SBR_QMF_BANDS_64 * sizeof(float));
-        memcpy(bandHalfE[ch][1], sa->ch[ch].bandHalfE[1], SBR_QMF_BANDS_64 * sizeof(float));
+    for (int ch = 0; ch < nch; ch++)
         memcpy(sbr->ch[ch].qmfOvl64, timeDomain[ch] + numSamples - SBR_QMF_OVL_LEN_64, SBR_QMF_OVL_LEN_64 * sizeof(float));
-    }
 
-    sbr_adopt_envelope_grid(sbr, sa);
-    sbr_quantize_envelopes(sbr, nch, sa->sampled, sa, bandHalfE);
+    sbr_adopt_envelope_grid(sbr, sa, fd);
+    sbr_quantize_envelopes(sbr, nch, sa->sampled, sa, fd);
 }
 
 /* SBR bitstream writer. Emits the SBR fill element payload into the bitstream.

--- a/libfaac/sbr.h
+++ b/libfaac/sbr.h
@@ -41,6 +41,22 @@
    the newest (one extra slot for the newest entry itself). */
 #define SBR_DETECT_FIFO (LOOKAHEAD_DEPTH + 1)
 
+/* Depth of the coded-SBR-payload delay ring. Envelopes must describe the audio
+   the access unit actually carries, which is FIFO_PAST: the MDCT window spans
+   (FIFO_PAST, FIFO_CURR) and, at 50% overlap, an access unit completes the first
+   half of its own window. So the payload emitted on call N belongs to frame
+   N-(LOOKAHEAD_DEPTH+1), while SbrEncode has just analysed frame N -- that delay,
+   plus a slot for the newest entry.
+
+   Note this is one deeper than SBR_DETECT_FIFO: block switching wants the frame
+   *after* the coded one, so a transient gets a start window now and a short
+   window next, whereas envelopes must land on the coded frame itself. */
+#define SBR_FRAME_FIFO (LOOKAHEAD_DEPTH + 2)
+
+/* SBR codes exactly one element, an SCE or a CPE, so the payload never spans
+   more than two channels regardless of the core's channel count. */
+#define SBR_MAX_CODED_CHANNELS 2
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libfaac/sbr_bitstream.c
+++ b/libfaac/sbr_bitstream.c
@@ -33,7 +33,7 @@ static int put_huff(BitStream *bs, bool write, const SBRHuffEntry *table, int ns
     return table[sym].len;
 }
 
-static int write_sbr_header(SBRInfo *sbr, BitStream *bs, bool write)
+static int write_sbr_header(const SBRInfo *sbr, BitStream *bs, bool write)
 {
     int bits = 0;
 #define WB(v,n) do { if (write) PutBit(bs,(v),(n)); bits += (n); } while(0)
@@ -56,60 +56,60 @@ static int write_sbr_header(SBRInfo *sbr, BitStream *bs, bool write)
 /* Width of the transient pointer field, indexed by number of envelopes. */
 static const int sbr_ceil_log2[] = { 0, 1, 2, 2, 3, 3 };
 
-static int write_sbr_grid(SBRInfo *sbr, BitStream *bs, bool write)
+static int write_sbr_grid(const SBRInfo *sbr, const SbrFrameData *fd, BitStream *bs, bool write)
 {
     int bits = 0;
 #define WB(v,n) do { if (write) PutBit(bs,(v),(n)); bits += (n); } while(0)
-    if (sbr->frameClass == SBR_FRAME_CLASS_VARFIX) {
+    if (fd->frameClass == SBR_FRAME_CLASS_VARFIX) {
         /* VARFIX: variable leading borders, fixed trailing border. Mirrors the
          * inverse of FFmpeg read_sbr_grid()'s VARFIX case: t_env[0]=bs_var_bord_0,
          * each lead border adds 2*bs_rel+2, the trailing border is numTimeSlots
          * (not transmitted), then bs_pointer and per-envelope bs_freq_res. */
-        int num_env = sbr->numEnvelopes;
+        int num_env = fd->numEnvelopes;
         WB(SBR_FRAME_CLASS_VARFIX, 2);
-        WB(sbr->tEnv[0], 2);                 /* bs_var_bord_0 */
+        WB(fd->tEnv[0], 2);                 /* bs_var_bord_0 */
         WB(num_env - 1, 2);                  /* bs_num_rel_0   */
         for (int i = 0; i < num_env - 1; i++)
-            WB((sbr->tEnv[i + 1] - sbr->tEnv[i] - 2) / 2, 2); /* bs_rel_bord */
-        WB(sbr->bsPointer, sbr_ceil_log2[num_env]);
+            WB((fd->tEnv[i + 1] - fd->tEnv[i] - 2) / 2, 2); /* bs_rel_bord */
+        WB(fd->bsPointer, sbr_ceil_log2[num_env]);
         for (int i = 0; i < num_env; i++)    /* bs_freq_res[1..num_env] */
             WB(sbr->bs_freq_res, 1);
     } else {
         /* FIXFIX: equal-spaced borders, one bs_freq_res for all envelopes. */
         WB(SBR_FRAME_CLASS_FIXFIX, 2);
-        WB(sbr->numEnvelopes > 1 ? 1 : 0, 2);
+        WB(fd->numEnvelopes > 1 ? 1 : 0, 2);
         WB(sbr->bs_freq_res, 1);
     }
 #undef WB
     return bits;
 }
 
-static int write_sbr_dtdf(SBRInfo *sbr, BitStream *bs, bool write)
+static int write_sbr_dtdf(const SbrFrameData *fd, BitStream *bs, bool write)
 {
-    int n_q = sbr->numEnvelopes > 1 ? 2 : 1;
-    int bits = sbr->numEnvelopes + n_q;
+    int n_q = fd->numEnvelopes > 1 ? 2 : 1;
+    int bits = fd->numEnvelopes + n_q;
     if (write) for (int i = 0; i < bits; i++) PutBit(bs, 0, 1);
     return bits;
 }
 
-static int write_sbr_invf(SBRInfo *sbr, BitStream *bs, int ch, bool write)
+static int write_sbr_invf(const SBRInfo *sbr, const SbrFrameData *fd, BitStream *bs, int ch, bool write)
 {
-    if (write) for (int nb = 0; nb < sbr->numNoiseBands; nb++) PutBit(bs, sbr->ch[ch].invfMode, 2);
+    if (write) for (int nb = 0; nb < sbr->numNoiseBands; nb++) PutBit(bs, fd->ch[ch].invfMode, 2);
     return sbr->numNoiseBands * 2;
 }
 
-static int write_sbr_envelope(SBRInfo *sbr, BitStream *bs, int ch, bool write)
+static int write_sbr_envelope(const SBRInfo *sbr, const SbrFrameData *fd, BitStream *bs, int ch, bool write)
 {
-    const SBRHuffEntry *table = sbr->eff_amp_res ? f_huff_env_3_0dB : f_huff_env_1_5dB;
-    int nsyms = sbr->eff_amp_res ? F_HUFF_ENV_3_0DB_NSYMS : F_HUFF_ENV_1_5DB_NSYMS;
-    int offset = sbr->eff_amp_res ? F_HUFF_ENV_3_0DB_OFFSET : F_HUFF_ENV_1_5DB_OFFSET;
+    const SBRHuffEntry *table = fd->eff_amp_res ? f_huff_env_3_0dB : f_huff_env_1_5dB;
+    int nsyms = fd->eff_amp_res ? F_HUFF_ENV_3_0DB_NSYMS : F_HUFF_ENV_1_5DB_NSYMS;
+    int offset = fd->eff_amp_res ? F_HUFF_ENV_3_0DB_OFFSET : F_HUFF_ENV_1_5DB_OFFSET;
     int bits = 0;
 
-    for (int e = 0; e < sbr->numEnvelopes; e++) {
+    for (int e = 0; e < fd->numEnvelopes; e++) {
         for (int b = 0; b < sbr->numBands; b++) {
-            int val = sbr->ch[ch].envData[e][b];
+            int val = fd->ch[ch].envData[e][b];
             if (b == 0) {
-                int first_bits = sbr->eff_amp_res ? 6 : 7;
+                int first_bits = fd->eff_amp_res ? 6 : 7;
                 if (write) PutBit(bs, clamp_int(val, 0, (1 << first_bits) - 1), first_bits);
                 bits += first_bits;
             } else {
@@ -120,13 +120,13 @@ static int write_sbr_envelope(SBRInfo *sbr, BitStream *bs, int ch, bool write)
     return bits;
 }
 
-static int write_sbr_noise(SBRInfo *sbr, BitStream *bs, int ch, bool write)
+static int write_sbr_noise(const SBRInfo *sbr, const SbrFrameData *fd, BitStream *bs, int ch, bool write)
 {
-    int n_q = sbr->numEnvelopes > 1 ? 2 : 1;
+    int n_q = fd->numEnvelopes > 1 ? 2 : 1;
     int bits = 0;
     for (int ne = 0; ne < n_q; ne++) {
         for (int nb = 0; nb < sbr->numNoiseBands; nb++) {
-            int val = sbr->ch[ch].noiseData[ne][nb];
+            int val = fd->ch[ch].noiseData[ne][nb];
             if (nb == 0) {
                 if (write) PutBit(bs, clamp_int(val, 0, 30), 5);
                 bits += 5;
@@ -138,30 +138,30 @@ static int write_sbr_noise(SBRInfo *sbr, BitStream *bs, int ch, bool write)
     return bits;
 }
 
-static int write_sbr_data(SBRInfo *sbr, BitStream *bs, int id_aac, bool write)
+static int write_sbr_data(const SBRInfo *sbr, const SbrFrameData *fd, BitStream *bs, int id_aac, bool write)
 {
     int bits = 0;
 #define WB(v,n) do { if (write) PutBit(bs,(v),(n)); bits += (n); } while(0)
     if (id_aac == ID_CPE) {
         WB(0, 1); WB(0, 1);     /* bs_coupling=0, reserved */
-        bits += write_sbr_grid(sbr, bs, write);
-        bits += write_sbr_grid(sbr, bs, write);
-        bits += write_sbr_dtdf(sbr, bs, write);
-        bits += write_sbr_dtdf(sbr, bs, write);
-        bits += write_sbr_invf(sbr, bs, 0, write);
-        bits += write_sbr_invf(sbr, bs, 1, write);
-        bits += write_sbr_envelope(sbr, bs, 0, write);
-        bits += write_sbr_envelope(sbr, bs, 1, write);
-        bits += write_sbr_noise(sbr, bs, 0, write);
-        bits += write_sbr_noise(sbr, bs, 1, write);
+        bits += write_sbr_grid(sbr, fd, bs, write);
+        bits += write_sbr_grid(sbr, fd, bs, write);
+        bits += write_sbr_dtdf(fd, bs, write);
+        bits += write_sbr_dtdf(fd, bs, write);
+        bits += write_sbr_invf(sbr, fd, bs, 0, write);
+        bits += write_sbr_invf(sbr, fd, bs, 1, write);
+        bits += write_sbr_envelope(sbr, fd, bs, 0, write);
+        bits += write_sbr_envelope(sbr, fd, bs, 1, write);
+        bits += write_sbr_noise(sbr, fd, bs, 0, write);
+        bits += write_sbr_noise(sbr, fd, bs, 1, write);
         WB(0, 1); WB(0, 1); WB(0, 1); /* add_harmonic / extended data flags */
     } else {
         WB(0, 1);               /* reserved */
-        bits += write_sbr_grid(sbr, bs, write);
-        bits += write_sbr_dtdf(sbr, bs, write);
-        bits += write_sbr_invf(sbr, bs, 0, write);
-        bits += write_sbr_envelope(sbr, bs, 0, write);
-        bits += write_sbr_noise(sbr, bs, 0, write);
+        bits += write_sbr_grid(sbr, fd, bs, write);
+        bits += write_sbr_dtdf(fd, bs, write);
+        bits += write_sbr_invf(sbr, fd, bs, 0, write);
+        bits += write_sbr_envelope(sbr, fd, bs, 0, write);
+        bits += write_sbr_noise(sbr, fd, bs, 0, write);
         WB(0, 1); WB(0, 1);      /* add_harmonic / extended data flags */
     }
 #undef WB
@@ -170,7 +170,7 @@ static int write_sbr_data(SBRInfo *sbr, BitStream *bs, int id_aac, bool write)
 
 /* Emit the full extension_payload body for EXT_SBR_DATA: the 4-bit extension
  * type, the 1-bit header flag, the optional header, and the channel data. */
-static int emit_sbr_payload(SBRInfo *sbr, BitStream *bs, int id_aac, int sendHeader, bool write)
+static int emit_sbr_payload(SBRInfo *sbr, const SbrFrameData *fd, BitStream *bs, int id_aac, int sendHeader, bool write)
 {
     int bits = 0;
 #define WB(v,n) do { if (write) PutBit(bs,(v),(n)); bits += (n); } while(0)
@@ -178,11 +178,11 @@ static int emit_sbr_payload(SBRInfo *sbr, BitStream *bs, int id_aac, int sendHea
     WB(sendHeader, 1);
 #undef WB
     if (sendHeader) bits += write_sbr_header(sbr, bs, write);
-    bits += write_sbr_data(sbr, bs, id_aac, write);
+    bits += write_sbr_data(sbr, fd, bs, id_aac, write);
     return bits;
 }
 
-int SbrWrite(SBRInfo *sbr, BitStream *bs, int id_aac, int writeFlag)
+int SbrWrite(SBRInfo *sbr, const SbrFrameData *fd, BitStream *bs, int id_aac, int writeFlag)
 {
     if (!sbr || !sbr->sbrPresent) return 0;
 
@@ -197,7 +197,7 @@ int SbrWrite(SBRInfo *sbr, BitStream *bs, int id_aac, int writeFlag)
      * just re-derives them from sbr's already-quantized envelope/noise data,
      * the same way channels.c's WriteElement/WriteICS do for the rest of the
      * frame. */
-    int payloadBits = emit_sbr_payload(sbr, NULL, id_aac, sendHeader, false);
+    int payloadBits = emit_sbr_payload(sbr, fd, NULL, id_aac, sendHeader, false);
     int fillBytes = (payloadBits + 7) / 8;
     int padBits = fillBytes * 8 - payloadBits;
 
@@ -215,7 +215,7 @@ int SbrWrite(SBRInfo *sbr, BitStream *bs, int id_aac, int writeFlag)
     else { WB(15, 4); WB(fillBytes - 14, 8); }
 #undef WB
 
-    if (writeFlag) emit_sbr_payload(sbr, bs, id_aac, sendHeader, true);
+    if (writeFlag) emit_sbr_payload(sbr, fd, bs, id_aac, sendHeader, true);
     totalBits += payloadBits;
     if (padBits > 0) { if (writeFlag) PutBit(bs, 0, padBits); totalBits += padBits; }
 
@@ -228,7 +228,10 @@ int SbrContextGetBits(SBRContext *sCtx, BitStream *bs, int channels, int aacObje
     if (aacObjectType == HE_V1 && sCtx) {
         if (sCtx->sbrInfo) {
             int id_aac = (channels > 1) ? ID_CPE : ID_SCE;
-            return SbrWrite(sCtx->sbrInfo, bs, id_aac, writeFlag);
+            /* One step past the newest slot is the oldest: the payload whose
+             * audio this access unit's core carries. See SBR_FRAME_FIFO. */
+            const SbrFrameData *fd = &sCtx->frameFIFO[(sCtx->frameHead + 1) % SBR_FRAME_FIFO];
+            return SbrWrite(sCtx->sbrInfo, fd, bs, id_aac, writeFlag);
         }
     }
     return 0;

--- a/libfaac/sbr_internal.h
+++ b/libfaac/sbr_internal.h
@@ -20,13 +20,30 @@
 #include "sbr_analysis.h"
 #include "resample.h"
 
-/* Per-channel SBR state. Everything indexed [ch] in SBRInfo lives here. */
+/* Per-channel SBR analysis state. Everything indexed [ch] in SBRInfo lives here. */
 typedef struct SBRChannel {
     float qmfOvl64[SBR_QMF_OVL_LEN_64]; /* QMF overlap state (carries across frames) */
-    int envData  [SBR_MAX_ENVELOPES][SBR_MAX_BANDS]; /* quantised envelope indices */
-    int noiseData[SBR_MAX_NOISE_ENVELOPES][SBR_MAX_NOISE_BANDS]; /* quantised noise floor indices */
-    int invfMode;                                    /* bs_invf_mode (0–3) */
 } SBRChannel;
+
+/* One frame's coded SBR payload: every field SbrWrite reads that varies per
+ * frame. What it reads that is constant for the stream (bs_* header fields,
+ * numBands, numNoiseBands) stays in SBRInfo.
+ *
+ * Sole home for these values: SbrEncode quantizes into a SBRContext.frameFIFO
+ * slot and SbrWrite reads an older one, so the delay costs a ring index. Caching
+ * a copy anywhere else reintroduces the skew this ring exists to remove. */
+typedef struct SbrFrameData {
+    int numEnvelopes;
+    int eff_amp_res;
+    int frameClass;
+    int tEnv[SBR_MAX_ENVELOPES + 1];
+    int bsPointer;
+    struct {
+        int envData  [SBR_MAX_ENVELOPES][SBR_MAX_BANDS];
+        int noiseData[SBR_MAX_NOISE_ENVELOPES][SBR_MAX_NOISE_BANDS];
+        int invfMode;
+    } ch[SBR_MAX_CODED_CHANNELS];
+} SbrFrameData;
 
 struct SBRInfo {
     int sbrPresent;
@@ -52,17 +69,6 @@ struct SBRInfo {
     int bs_alter_scale;
 
     /* --- per-frame state --- */
-    int numEnvelopes;      /* 1 or 2, set by transient detection in SbrEncode */
-    int eff_amp_res;       /* forced to 0 for single-envelope FIXFIX (ISO 14496-3:2009 §4.6.18.3) */
-
-    /* Envelope time grid for the frame (frame-global, shared by both channels of
-     * a CPE). frameClass selects FIXFIX or VARFIX; tEnv[0..numEnvelopes] are the
-     * envelope borders in SBR time slots ([0, SBR_NUM_TIME_SLOTS]) and are only
-     * emitted for the variable classes. bsPointer marks the transient envelope. */
-    int frameClass;
-    int tEnv[SBR_MAX_ENVELOPES + 1];
-    int bsPointer;
-
     /* Whether SbrWrite should (re)send the sbr_header this frame. Frozen once
      * per frame (in SbrEncode) rather than recomputed in SbrWrite, since
      * headerSent/frameCount only advance on SbrWrite's real write pass, and
@@ -95,6 +101,12 @@ struct SBRContext {
        lookahead (LOOKAHEAD_DEPTH frames); newest sits at SBR_DETECT_FIFO-1. */
     float transientStrengthFIFO[MAX_CHANNELS][SBR_DETECT_FIFO];
     int       wantShortFIFO[MAX_CHANNELS][SBR_DETECT_FIFO];
+
+    /* Coded-payload delay ring; see SBR_FRAME_FIFO. frameHead is the newest
+       entry, so its successor (frameHead + 1) % SBR_FRAME_FIFO is the oldest --
+       the payload the current access unit emits. */
+    SbrFrameData frameFIFO[SBR_FRAME_FIFO];
+    int          frameHead;
 };
 
 SBRInfo *SbrInit(int channels, int sampleRate, unsigned long bitRate, FFT_Tables *fft_tables);
@@ -104,7 +116,9 @@ void SbrUpdate(SBRInfo *sbr, unsigned long bitRate);
 void SbrEnd(SBRInfo *sbr);
 
 void SbrQmfAnalysis(SBRInfo *sbr, const float * restrict ovl_pos, float * restrict energy, int kx, int k2);
-void SbrEncode(SBRInfo *sbr, float *timeDomain[MAX_CHANNELS], int numChannels, int numSamples, struct SignalAnalysis *sa);
-int SbrWrite(SBRInfo *sbr, struct BitStream *bs, int id_aac, int writeFlag);
+/* Quantizes this frame's payload directly into *fd (a delay-line slot). */
+void SbrEncode(SBRInfo *sbr, float *timeDomain[MAX_CHANNELS], int numChannels, int numSamples, struct SignalAnalysis *sa, SbrFrameData *fd);
+/* Emits the payload in *fd, which is a delayed slot, not the newest one. */
+int SbrWrite(SBRInfo *sbr, const SbrFrameData *fd, struct BitStream *bs, int id_aac, int writeFlag);
 
 #endif


### PR DESCRIPTION
### 🔗 Reporter & Bug Origin
Reported by **maikmerten** on Hydrogenaudio ([Thread Link](https://hydrogenaudio.org/index.php/topic,129764.msg1084794.html#msg1084794)):
> *"it appears that energy in the SBR-part of the spectrum is shifted compared to the non-SBR-signal, arriving early. Is this just how AAC-HE operates, or something specific to this encoder?"*

* **Test Case:** Encoded using sample from HA post [#1083604](https://hydrogenaudio.org/index.php/topic,129691.msg1083604.html#msg1083604) via `faac -b 56 test.wav` (which auto-selects HE-AAC v1).
* **Conclusion:** This is specific to FAAC's payload delay handling, not an inherent property of HE-AAC.

<img width="638" height="479" alt="image" src="https://github.com/user-attachments/assets/63afa899-b93a-4008-9255-af8820ce6646" />


### 🐛 Summary & Core Issue
Fixes a **3-frame (~139 ms at 44.1 kHz)** timing misalignment where SBR envelope payloads were emitted ahead of their corresponding core audio in HE-AAC v1 access units (`faac -b 56`). 

**Root Cause:** `SbrEncode` quantizes envelopes for frame $N$, and `SbrWrite` emitted them immediately in the same `faacEncEncode()` call. However, due to 50% MDCT window overlap, that call actually completes core frame $N-3$. While block switching compensated via `wantShortFIFO`, the coded payload lacked an equivalent delay line.

---

### 🛠️ Changes Made
* **SBR Delay Line (`SbrFrameData`):** Split per-frame coded payloads out of `SBRInfo` into `SbrFrameData` and held them in a ring buffer (`SBR_FRAME_FIFO`) inside `SBRContext`. Emits oldest slot on write (zero payload copies).
* **Flush Frame Handling:** Ran SBR pipeline through a silence fast-path on flush/drain frames instead of skipping it entirely. This drains the new delay line and prevents re-emitting stale envelopes.
* **Short Frame Analysis:** Fixed QMF analysis to evaluate full zero-padded frames instead of truncating to `realPerCh`, preventing inflated envelope levels and out-of-bounds reads during QMF overlap save.

---

### 🧪 Verification & Testing
* **Timing Alignment:** Instrumented access units to compare core block RMS against SBR levels. Pre-fix envelope peaks led core peaks by 3 units; post-fix, they coincide aligned (including bursts during flush).
* **Regression:** LC output is **bit-identical**. Clean under ASan / UBSan for both SCE and CPE.
* **Memory Footprint:** Net zero. `SBRInfo` loses 4,480 B, `SBRContext` gains 4,560 B for the ring. Stripped binary size is unchanged.
* **Throughput:** **+1.5% to +2.8%** speedup vs `master` (tested on 120s 48 kHz stereo @ 40 kbps, min-of-7 CPU time), primarily from eliminating a per-frame energy copy in the quantizer.

Benchmark: https://github.com/nschimme/faac/actions/runs/30632928110

<img width="701" height="605" alt="image" src="https://github.com/user-attachments/assets/0b1b72a3-d396-4ee9-a9a4-722c3407b428" />


---

### 📌 Known Residuals
* **Sub-slot Delay:** A minor 31-sample (~0.7 ms) group delay offset remains from the uncompensated half-band decimator. This is under half a QMF slot and cannot be expressed in the SBR time grid.