### PR TITLE
add optional hard per-frame peak-bitrate limiter (--cap-rate)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,6 +34,14 @@ jobs:
               options: -Dsbr-decimation=4,
             }
           - {
+              name: Linux GCC (32-bit),
+              os: ubuntu-latest,
+              compiler: gcc,
+              shell: bash,
+              packages: gcc-multilib,
+              options: -Dc_args=-m32 -Dc_link_args=-m32,
+            }
+          - {
               name: macOS Clang,
               os: macos-latest,
               compiler: clang,
@@ -57,7 +65,9 @@ jobs:
     steps:
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'
-        run: sudo apt install meson
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ${{ matrix.config.packages }}
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'

--- a/docs/faac.1
+++ b/docs/faac.1
@@ -94,6 +94,15 @@ stereo input file with 16 bit and 44.1 kHz sample rate
 Set average bitrate (ABR) to approximately <bitrate> kbps.
 max. ~500 (stereo)
 .TP
+.BR \-\-cap\-rate\ <\fIbitrate\fP>
+Cap any single frame at <bitrate> kbps, for packet-oriented transports that drop
+an oversized frame rather than splitting it. Must be at least the
+.B -b
+bitrate. A ceiling, not a second average: frames that already fit are left
+alone, so the stream stays ABR. Best-effort \(em a frame cannot shrink below the
+cost of its own side info, so a low enough cap is still exceeded on a few
+percent of frames.
+.TP
 .BR -c\ <\fIfreq\fP>
 Set the bandwidth in Hz.
 The actual frequency is adjusted to maximize upper spectral band usage.

--- a/docs/libfaac.html
+++ b/docs/libfaac.html
@@ -24,6 +24,7 @@ Contents
   <li><a href="#api-callseq">Calling sequence</a>
   <li><a href="#api-errors">Error handling</a>
   <li><a href="#api-funcref">Function reference</a>
+  <li><a href="#api-peak">Capping the peak frame size</a>
  </menu>
  <li><a href="#porting">Porting from the legacy faacEnc* API</a>
 </menu>
@@ -126,6 +127,32 @@ For an HE-AAC encoder the SBR core runs at half the input rate and codes a
 <i>frame_samples</i> == 2048 and <i>sample_rate</i> == the full (un-halved)
 output rate. Buffer sizing and rate reporting therefore stay correct without
 the caller knowing any SBR internals.
+
+<a name="api-peak">
+<h5>Capping the peak frame size</h5>
+Packet-oriented transports often cannot fragment a frame: one that overruns the
+link MTU is dropped, not split. <i>bit_rate</i> cannot prevent that, being an
+average individual frames are free to exceed &mdash; a transient easily produces
+a frame several times the mean. <i>faac_params.max_bit_rate</i> puts a hard
+ceiling on any single frame; 0, the default, means none. Unlike <i>bit_rate</i>
+it is a whole-stream rate, so it stays independent of <i>num_channels</i> and
+follows directly from the payload one packet can carry:
+<pre>
+    max_bit_rate = payload_bytes * 8 * sample_rate / 1024
+</pre>
+It must be at least <i>bit_rate</i> &times; <i>num_channels</i> &mdash; a peak
+below the average is unsatisfiable &mdash; and at most
+<i>FAAC_MAX_BIT_RATE</i>; <i>faac_encoder_open()</i> returns
+<i>FAAC_ERR_INVALID_ARGUMENT</i> otherwise. More headroom means fewer retries.
+<br><br>
+It is a ceiling, not a second average: frames that already fit are untouched, so
+the stream stays ABR rather than becoming CBR, and a frame re-quantized to meet
+the cap does not drag down the frames after it. Enforcement is best-effort
+&mdash; a frame cannot shrink below the cost of its own side info and
+scalefactors, so a small enough cap is still exceeded on a few percent of frames
+(measured on transient-heavy stereo, the cap holds everywhere at and above
+roughly 64 kbit/s and starts to slip around 48). Callers that must guarantee the
+packet fits should check <i>bytes_written</i> and drop the frame themselves.
 
 <a name="porting">
 <h4>Porting from the legacy faacEnc* API</h4>

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -93,7 +93,8 @@ enum flags
     HELP_ADVANCED,
     OPT_JOINT,
     OPT_PNS,
-    OBJTYPE_FLAG
+    OBJTYPE_FLAG,
+    CAP_RATE_FLAG
 };
 
 typedef struct {
@@ -117,6 +118,11 @@ static help_t help_qual[] = {
     {"-c <freq>\tSet the bandwidth in Hz.\n",
     "\t\tThe actual frequency is adjusted to maximize upper spectral band\n"
     "\t\tusage.\n"},
+    {"--cap-rate <bitrate>\tCap any single frame at x kbps.\n",
+    "\t\tFor packet-oriented transports that cannot fragment a frame, where\n"
+    "\t\tan oversized frame is dropped rather than split. Must be >= the -b\n"
+    "\t\tbitrate. Best-effort: quality is backed off until the frame fits,\n"
+    "\t\tso pathological input can still exceed the cap.\n"},
     {NULL, NULL}
 };
 
@@ -408,6 +414,7 @@ int main(int argc, char *argv[])
     int cutOff = -1;
     int bitRate = 0;
     unsigned long quantqual = 0;
+    unsigned int capRate = 0;
     int chanC = 3;
     int chanLF = 4;
 
@@ -529,6 +536,7 @@ int main(int argc, char *argv[])
             {"tag", 1, 0, TAG_FLAG},
             {"overwrite", 0, &overwrite, 1},
             {"creation-time", 1, 0, CREATION_TIME_FLAG},
+            {"cap-rate", 1, 0, CAP_RATE_FLAG},
             {0, 0, 0, 0}
         };
         int c = -1;
@@ -765,6 +773,15 @@ int main(int argc, char *argv[])
             else
                 dieMessage = "Unrecognised object type (use lc, he-aac-v1, or auto)!\n";
             break;
+        case CAP_RATE_FLAG:
+            {
+                unsigned int i;
+                if (sscanf(optarg, "%u", &i) > 0)
+                {
+                    capRate = i;
+                }
+                break;
+            }
         case 'L':
             fprintf(stderr, "%s", faac_copyright_string);
             dieMessage = license;
@@ -926,6 +943,9 @@ int main(int argc, char *argv[])
     }
     if (bitRate)
         params.bit_rate = bitRate / infile->channels;
+    /* max_bit_rate is already whole-stream, unlike bit_rate above. */
+    if (capRate)
+        params.max_bit_rate = capRate * 1000;
     params.bandwidth     = cutOff;
     params.output_format = stream;
     params.input_format  = FAAC_INPUT_FLOAT;

--- a/include/faac.h
+++ b/include/faac.h
@@ -54,7 +54,7 @@ extern "C" {
  *   #if defined(FAAC_VERSION_MAJOR) && (FAAC_VERSION_MAJOR >= 1)
  */
 #define FAAC_VERSION_MAJOR 1
-#define FAAC_VERSION_MINOR 0
+#define FAAC_VERSION_MINOR 1
 #define FAAC_VERSION_PATCH 0
 #define FAAC_VERSION_HEX \
     ((FAAC_VERSION_MAJOR << 16) | (FAAC_VERSION_MINOR << 8) | FAAC_VERSION_PATCH)
@@ -179,8 +179,28 @@ typedef struct faac_params {
                                             * NULL = identity. Caller-owned; copied by open(). */
     uint32_t                channel_map_count; /* entries in channel_map (0 if NULL) */
 
-    uint32_t                reserved_trailing; /* explicit pad to 8-byte boundary; must be 0 */
+    /* Ceiling on any single frame, for packet-oriented transports that cannot
+     * fragment one -- a frame that overruns the link MTU is dropped, not split.
+     * Unlike bit_rate this is a WHOLE-STREAM rate, so it stays independent of
+     * num_channels and follows from the payload a packet can carry:
+     *
+     *     max_bit_rate = payload_bytes * 8 * sample_rate / 1024
+     *
+     * Must be >= bit_rate * num_channels (a peak below the average is
+     * unsatisfiable) and <= FAAC_MAX_BIT_RATE; open() rejects anything else.
+     * More headroom means fewer retries.
+     *
+     * Best-effort: enforced by backing off quality over bounded retries, which
+     * cannot beat the irreducible per-frame cost of side info and scalefactors.
+     * Measured on transient-heavy stereo, the cap holds for every frame at and
+     * above ~64 kbit/s; below that the floor starts to show (~48 kbit/s
+     * overshoots on a few percent of frames). */
+    uint32_t                max_bit_rate;  /* whole-stream peak bits/sec; 0 = unlimited */
 } faac_params;
+
+/* Upper bound on faac_params.max_bit_rate: far above any real stream rate, and
+ * low enough that converting it to a per-frame bit budget cannot overflow. */
+#define FAAC_MAX_BIT_RATE ((uint32_t)100000000)
 
 /*
  * Resolved encoder properties, filled by faac_encoder_get_info(). All values are
@@ -203,6 +223,7 @@ typedef struct faac_encoder_info {
     uint32_t                bandwidth;        /* resolved cutoff in Hz                               */
     uint32_t                quant_quality;    /* resolved quantizer quality                          */
     int32_t                 pns_level;        /* resolved PNS level, 0..10                           */
+    uint32_t                max_bit_rate;     /* resolved peak cap, 0 if unlimited                   */
 } faac_encoder_info;
 
 /*

--- a/libfaac/channels.c
+++ b/libfaac/channels.c
@@ -297,12 +297,36 @@ static int BuildFrame(struct faacEncStruct *hEncoder, CoderInfo *coder, AACEleme
     return bits + pad;
 }
 
+/* ADTS carries a frame length that is only known once the frame is written.
+ * Patching the 7 fixed-layout header bytes afterwards keeps BuildFrame to a
+ * single pass. Must reproduce WriteADTSHeader byte for byte. */
+static void PatchADTSHeader(struct faacEncStruct *hEncoder, BitStream *bs, int frameBytes)
+{
+    if (hEncoder->config.outputFormat == 1 && bs->data) {
+        bs->data[0] = 0xFF;
+        bs->data[1] = 0xF0 | (hEncoder->config.mpegVersion << 3) | 1;
+        bs->data[2] = ((LOW - 1) << 6) | (hEncoder->sampleRateIdx << 2) | (hEncoder->numChannels >> 2);
+        bs->data[3] = ((hEncoder->numChannels & 3) << 6) | (frameBytes >> 11);
+        bs->data[4] = (frameBytes >> 3) & 0xFF;
+        bs->data[5] = ((frameBytes & 7) << 5) | 0x1F;
+        bs->data[6] = 0xFC;
+    }
+}
+
 int WriteBitstream(struct faacEncStruct *hEncoder, CoderInfo *coder, AACElement *elems, int nElems, BitStream *bs)
 {
-    int bits = BuildFrame(hEncoder, coder, elems, nElems, bs, false);
+    /* Zero so the header's own length field is written as zero, then patched. */
+    hEncoder->usedBytes = 0;
+    bs->currentBit = 0;
+    int bits = BuildFrame(hEncoder, coder, elems, nElems, bs, true);
     if (bits < 0) return -1;
+
+    /* Safe to bounds-check after writing: PutBit refuses to write past
+     * bs->size, so an oversized frame truncates rather than overflowing. */
     hEncoder->usedBytes = (bits + 7) >> 3;
     if (hEncoder->usedBytes > bs->size) return -1;
     if (hEncoder->usedBytes > ADTS_MAX_FRAME_SIZE) return -1;
-    return BuildFrame(hEncoder, coder, elems, nElems, bs, true);
+
+    PatchADTSHeader(hEncoder, bs, hEncoder->usedBytes);
+    return bits;
 }

--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -57,11 +57,11 @@ _Static_assert((int)FAAC_INPUT_NULL  == INPUT_NULL  && (int)FAAC_INPUT_16BIT == 
             && (int)FAAC_INPUT_FLOAT == INPUT_FLOAT, "input format drift");
 
 /* Baseline layout as first shipped. Frozen by the append-only rule: new fields
- * go after reserved_trailing, so this offset never moves. Not sizeof(), which
+ * go after max_bit_rate, so this offset never moves. Not sizeof(), which
  * grows with every appended field and would reject older callers' binaries.
  * A literal would be wrong too: the layout depends on pointer width. */
 #define PARAMS_BASELINE_SIZE \
-    ((uint32_t)(offsetof(faac_params, reserved_trailing) + sizeof(uint32_t)))
+    ((uint32_t)(offsetof(faac_params, max_bit_rate) + sizeof(uint32_t)))
 
 /* faac_encoder* and faacEncHandle are the same underlying object. */
 static inline faacEncStruct *unwrap(faac_encoder *enc) { return (faacEncStruct *)enc; }
@@ -109,6 +109,7 @@ FAACAPI faac_status faac_params_init(faac_params *p)
     p->bit_rate      = 64000;          /* per channel; 0 would defer to quant_quality */
     p->bandwidth     = 0;              /* derive from bit_rate */
     p->quant_quality = 0;              /* derive from bit_rate */
+    p->max_bit_rate  = 0;              /* no per-frame peak cap */
     p->output_format = FAAC_STREAM_ADTS;
     p->input_format  = FAAC_INPUT_16BIT;
     p->short_control = FAAC_SHORTCTL_NORMAL;
@@ -169,8 +170,23 @@ static faac_status validate_params(const faac_params *p)
             if (p->channel_map[i] < 0 || (uint32_t)p->channel_map[i] >= p->num_channels)
                 return FAAC_ERR_INVALID_ARGUMENT;
     }
+    if (p->max_bit_rate) {
+        /* Bounded because it is converted into a per-frame bit budget; an
+         * absurd value is a caller error, not a request for an unlimited
+         * frame. */
+        if (p->max_bit_rate > FAAC_MAX_BIT_RATE)
+            return FAAC_ERR_INVALID_ARGUMENT;
+        /* A peak below the average is unsatisfiable by definition, and the two
+         * controllers actively fight: rate control raises quality to reach
+         * bit_rate while the limiter cuts it to stay under the cap, so frames
+         * end up larger the tighter the cap gets. Reject it rather than emit a
+         * stream that quietly busts the ceiling it was asked to respect.
+         * bit_rate is per channel and max_bit_rate is not, so scale to compare. */
+        if (p->bit_rate && p->max_bit_rate < (uint64_t)p->bit_rate * p->num_channels)
+            return FAAC_ERR_INVALID_ARGUMENT;
+    }
     /* reserved padding must be zero so future fields can claim it safely */
-    if (p->reserved[0] || p->reserved[1] || p->reserved_trailing)
+    if (p->reserved[0] || p->reserved[1])
         return FAAC_ERR_INVALID_ARGUMENT;
     return FAAC_OK;
 }
@@ -216,6 +232,7 @@ FAACAPI faac_status faac_encoder_open(const faac_params *p, faac_encoder **out)
     cfg->inputFormat   = (unsigned int)p->input_format;
     cfg->shortctl      = (int)p->short_control;
     cfg->pnslevel      = p->pns_level;
+    cfg->maxBitRate    = p->max_bit_rate;
     if (p->channel_map) {
         uint32_t i;
         for (i = 0; i < p->num_channels; i++)
@@ -267,6 +284,7 @@ FAACAPI faac_status faac_encoder_get_info(faac_encoder *enc, faac_encoder_info *
     info.bandwidth        = (uint32_t)h->config.bandWidth;
     info.quant_quality    = (uint32_t)h->config.quantqual;
     info.pns_level        = (int32_t)h->config.pnslevel;
+    info.max_bit_rate     = (uint32_t)h->config.maxBitRate;
 
     /* Write at most the caller's struct_size so a newer library cannot overrun
      * an older, smaller faac_encoder_info; report the byte count actually set. */

--- a/libfaac/faac_internal.h
+++ b/libfaac/faac_internal.h
@@ -57,6 +57,7 @@ typedef struct faacEncConfiguration
     unsigned long bitRate;           /* per channel */
     unsigned int bandWidth;
     unsigned long quantqual;
+    unsigned long maxBitRate;        /* per channel, hard per-frame ceiling; 0 = unlimited */
     unsigned int outputFormat;       /* 0 = raw, 1 = ADTS */
     unsigned int inputFormat;
     int shortctl;

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -43,6 +43,13 @@
 #define RC_DEADBAND_THRESHOLD  0.05f  /* +/- 5% deadband */
 #define RC_DAMPING_FACTOR      0.6f   /* Control loop damping */
 
+/* Bounds on the peak limiter's quality scale factor: the ceiling guarantees
+ * each retry makes progress, the floor keeps one outsized frame from
+ * collapsing quality to MINQUAL in a single step. */
+#define PEAK_BACKOFF_CEILING   0.85f
+#define PEAK_BACKOFF_FLOOR     0.10f
+#define PEAK_MAX_RETRIES       12
+
 static char *libfaacName = PACKAGE_VERSION;
 static char *libCopyright =
   "FAAC - Freeware Advanced Audio Coder (http://faac.sourceforge.net/)\n"
@@ -323,6 +330,19 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
         hEncoder->inputFifoFill = 0;
     }
 
+    hEncoder->config.maxBitRate = config->maxBitRate;
+
+    /* Peak-limiter retry scratch: only encoders that set maxBitRate pay for it. */
+    if (hEncoder->config.maxBitRate) {
+        unsigned int ch;
+        for (ch = 0; ch < hEncoder->numChannels; ch++) {
+            if (!hEncoder->peakSnap[ch])
+                hEncoder->peakSnap[ch] = (int *)AllocMemory(2 * MAX_SCFAC_BANDS * sizeof(int));
+            if (!hEncoder->peakSnap[ch])
+                return 0;
+        }
+    }
+
     CalcBW(&hEncoder->config.bandWidth,
               hEncoder->sampleRate,
               hEncoder->srInfo,
@@ -508,6 +528,8 @@ int faacEncClose(faacEncHandle hpEncoder)
         }
 		if (hEncoder->inputFifo[channel])
 			FreeMemory (hEncoder->inputFifo[channel]);
+        if (hEncoder->peakSnap[channel])
+            FreeMemory(hEncoder->peakSnap[channel]);
     }
 
     if (hEncoder->ascCache) free(hEncoder->ascCache);
@@ -740,34 +762,96 @@ int faacEncEncode(faacEncHandle hpEncoder,
     AACstereo(coderInfo, hEncoder->elements, hEncoder->numElements, hEncoder->freqBuff,
               (float)hEncoder->aacquantCfg.quality/DEFQUAL, jointmode, hEncoder->sampleRate);
 
-    for (channel = 0; channel < numChannels; channel++) {
-        BlocQuant(&coderInfo[channel], hEncoder->freqBuff[channel],
-                  &(hEncoder->aacquantCfg));
-    }
+    /* AACstereo has already consumed freqBuff in place and BlocQuant
+     * accumulates into sf[] while reading book[], so a retry can re-run
+     * neither. Snapshot what they produce -- book, sf, and the sfbn the CPE fix
+     * below rewrites -- so a retry restarts from identical state. */
+    unsigned long long peakBits = 0;
+    float baseQuality = hEncoder->aacquantCfg.quality;
+    int sfbnSnap[MAX_CHANNELS];
+    int attempt;
 
-    // fix max_sfb in CPE mode
-    for (int e = 0; e < hEncoder->numElements; e++)
+    if (hEncoder->config.maxBitRate)
     {
-		if (hEncoder->elements[e].type == ID_CPE)
-		{
-			CoderInfo *cil, *cir;
+        /* maxBitRate is whole-stream, so no channel factor here. For HE-AAC
+         * sampleRate is the halved core rate, which is what makes FRAME_LEN
+         * cover the right span of output samples. */
+        peakBits = (unsigned long long)hEncoder->config.maxBitRate
+            * FRAME_LEN / hEncoder->sampleRate;
 
-			cil = &coderInfo[hEncoder->elements[e].channels[0]];
-			cir = &coderInfo[hEncoder->elements[e].channels[1]];
-
-                        cil->sfbn = cir->sfbn = max(cil->sfbn, cir->sfbn);
-		}
+        for (channel = 0; channel < numChannels; channel++) {
+            memcpy(hEncoder->peakSnap[channel], coderInfo[channel].book,
+                   MAX_SCFAC_BANDS * sizeof(int));
+            memcpy(hEncoder->peakSnap[channel] + MAX_SCFAC_BANDS, coderInfo[channel].sf,
+                   MAX_SCFAC_BANDS * sizeof(int));
+            sfbnSnap[channel] = coderInfo[channel].sfbn;
+        }
     }
-    /* Write the AAC bitstream */
-    bitStream = OpenBitStream(bufferSize, outputBuffer);
-    if (!bitStream)
-        return -1;
 
-    if (WriteBitstream(hEncoder, coderInfo, hEncoder->elements, hEncoder->numElements, bitStream) < 0)
-        return -1;
+    /* Retry while the frame busts peakBits. The search is bounded, not
+     * exact-fit: an exact fit can fail to terminate on pathological input. */
+    for (attempt = 0; attempt <= PEAK_MAX_RETRIES; attempt++)
+    {
+        for (channel = 0; channel < numChannels; channel++) {
+            BlocQuant(&coderInfo[channel], hEncoder->freqBuff[channel],
+                      &(hEncoder->aacquantCfg));
+        }
 
-    /* Close the bitstream and return the number of bytes written */
-    frameBytes = CloseBitStream(bitStream);
+        // fix max_sfb in CPE mode
+        for (int e = 0; e < hEncoder->numElements; e++)
+        {
+            if (hEncoder->elements[e].type == ID_CPE)
+            {
+                CoderInfo *cil, *cir;
+
+                cil = &coderInfo[hEncoder->elements[e].channels[0]];
+                cir = &coderInfo[hEncoder->elements[e].channels[1]];
+
+                cil->sfbn = cir->sfbn = max(cil->sfbn, cir->sfbn);
+            }
+        }
+
+        /* Write the AAC bitstream; the write doubles as the size probe. */
+        bitStream = OpenBitStream(bufferSize, outputBuffer);
+        if (!bitStream)
+            return -1;
+
+        if (WriteBitstream(hEncoder, coderInfo, hEncoder->elements, hEncoder->numElements, bitStream) < 0)
+            return -1;
+
+        /* Close the bitstream and return the number of bytes written */
+        frameBytes = CloseBitStream(bitStream);
+
+        if (!peakBits || (unsigned long long)frameBytes * 8 <= peakBits
+            || hEncoder->aacquantCfg.quality <= MINQUAL)
+            break;
+
+        /* Aim at the budget rather than stepping down by a fixed factor: rate
+         * control can park quality anywhere up to MAXQUAL (5000), and a fixed
+         * halving needs ~9 passes to cross that to MINQUAL (10), more than any
+         * sane retry budget. Frame bits grow sub-linearly with quality, so
+         * scaling by the bit ratio undershoots the budget and converges in a
+         * pass or two. */
+        float scale = (float)peakBits / (float)((unsigned long long)frameBytes * 8);
+        if (scale > PEAK_BACKOFF_CEILING) scale = PEAK_BACKOFF_CEILING;
+        if (scale < PEAK_BACKOFF_FLOOR)   scale = PEAK_BACKOFF_FLOOR;
+        hEncoder->aacquantCfg.quality *= scale;
+        if (hEncoder->aacquantCfg.quality < MINQUAL)
+            hEncoder->aacquantCfg.quality = MINQUAL;
+
+        for (channel = 0; channel < numChannels; channel++) {
+            memcpy(coderInfo[channel].book, hEncoder->peakSnap[channel],
+                   MAX_SCFAC_BANDS * sizeof(int));
+            memcpy(coderInfo[channel].sf, hEncoder->peakSnap[channel] + MAX_SCFAC_BANDS,
+                   MAX_SCFAC_BANDS * sizeof(int));
+            coderInfo[channel].sfbn = sfbnSnap[channel];
+        }
+    }
+
+    /* The cap is per frame, so the backoff must not outlive it: left sticky,
+     * one hard frame drags the rest of the stream down, and with bitRate == 0
+     * the rate controller below never runs to claw the quality back. */
+    hEncoder->aacquantCfg.quality = baseQuality;
 
     /* Adjust quality to get correct average bitrate */
     if (hEncoder->config.bitRate)

--- a/libfaac/frame.h
+++ b/libfaac/frame.h
@@ -108,6 +108,10 @@ typedef struct faacEncStruct {
 
     /* HE-AAC / SBR state */
     struct SBRContext *sbrContext;   /* SBR analysis state and bitstream data */
+
+    /* Peak-limiter retry scratch, NULL unless config.maxBitRate is set: one
+     * buffer per channel holding book[] at [0] and sf[] at [MAX_SCFAC_BANDS]. */
+    int *peakSnap[MAX_CHANNELS];
 } faacEncStruct;
 
 /* Configuration worker behind faac_encoder_open(): validates the config,


### PR DESCRIPTION
Fixes #157

### Overview
This PR adds an optional hard per-frame peak-bitrate limiter (`max_bit_rate` / `--cap-rate`) to FAAC.

Packet-oriented transports—most notably **Bluetooth A2DP**—cannot fragment audio frames. If an encoded AAC frame exceeds the negotiated L2CAP/MTU payload budget, the transport drops the frame entirely rather than splitting it across packets, causing audible audio glitches. 

Because `bit_rate` in FAAC is a long-term average (ABR), transient signals can easily produce individual frames several times the mean. Setting `max_bit_rate` enforces a strict upper ceiling on frame size while leaving normal frames and average rate targeting untouched.

---

### Key Changes

* **Semantics:** Unlike `bit_rate` (which is per-channel), `max_bit_rate` is a whole-stream rate matching packet payload capacity. `faac_encoder_open()` rejects any cap below the total average bitrate (`bit_rate` × `num_channels`) to prevent the rate controller and limiter from fighting.
* **Peak Limiter:** Enforces a hard ceiling without altering fitting frames. Re-quantization quality backoff is reverted after every frame to prevent a single hard transient from dragging down the rest of the stream. Uses bit-ratio scaling with bounded retries for fast convergence.
* **Single-Pass ADTS:** Refactors `WriteBitstream()` to write frame data in a single pass and patch the 7-byte ADTS header once length is known. This single pass doubles as the limiter's size probe, offsetting its computational cost.
* **API / ABI Safety:** Reclaims `faac_params.reserved_trailing` to add `max_bit_rate` with zero layout or `sizeof()` changes across LP64 and ILP32 platforms. Existing callers passing zero remain uncapped and fully binary-compatible.
* **CI Coverage:** Added a 32-bit Linux GCC job to the build matrix to validate pointer-offset ABI rules across architectures.
* **CLI & Docs:** Added `--cap-rate <kbps>` to the CLI frontend; updated documentation in `faac.1` and `libfaac.html`.

---

### Benchmark & Validation

* **Benchmark Run:** [#30821713166](https://github.com/nschimme/faac/actions/runs/30821713166)

The benchmark demonstrates the peak limiter holding frame sizes under the cap during high-transient passages while maintaining standard ABR behavior across the rest of the stream:

<img width="674" height="418" alt="Peak Bitrate Limiter Benchmark" src="https://github.com/user-attachments/assets/59c979de-0a18-4680-9feb-4902ba1c734b" />