### PR TITLE
enforce proper baseline size check in info getter APIs

### DIFF
--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -63,6 +63,12 @@ _Static_assert((int)FAAC_INPUT_NULL  == INPUT_NULL  && (int)FAAC_INPUT_16BIT == 
 #define PARAMS_BASELINE_SIZE \
     ((uint32_t)(offsetof(faac_params, max_bit_rate) + sizeof(uint32_t)))
 
+/* Same pattern as PARAMS_BASELINE_SIZE above. */
+#define LIBRARY_INFO_BASELINE_SIZE \
+    ((uint32_t)(offsetof(faac_library_info, sbr_decimation) + sizeof(uint32_t)))
+#define ENCODER_INFO_BASELINE_SIZE \
+    ((uint32_t)(offsetof(faac_encoder_info, pns_level) + sizeof(int32_t)))
+
 /* faac_encoder* and faacEncHandle are the same underlying object. */
 static inline faacEncStruct *unwrap(faac_encoder *enc) { return (faacEncStruct *)enc; }
 
@@ -75,7 +81,7 @@ FAACAPI faac_status faac_get_library_info(faac_library_info *out)
     if (!out)
         return FAAC_ERR_INVALID_ARGUMENT;
     caller_size = out->struct_size;
-    if (caller_size < sizeof(info.struct_size))
+    if (caller_size < LIBRARY_INFO_BASELINE_SIZE)
         return FAAC_ERR_INVALID_ARGUMENT;
 
     faacEncGetVersion(&vid, &vcopy);
@@ -269,7 +275,7 @@ FAACAPI faac_status faac_encoder_get_info(faac_encoder *enc, faac_encoder_info *
     if (!enc || !out)
         return FAAC_ERR_INVALID_ARGUMENT;
     caller_size = out->struct_size;
-    if (caller_size < sizeof(info.struct_size))
+    if (caller_size < ENCODER_INFO_BASELINE_SIZE)
         return FAAC_ERR_INVALID_ARGUMENT;
     h = unwrap(enc);
 


### PR DESCRIPTION
Fixes a bug where `faac_get_library_info` and `faac_encoder_get_info` allowed callers to pass undersized structs, resulting in uninitialized memory reads without returning an error. Does not cause an ABI breakage but was discovered as part of investigating the ABI. Similar to https://github.com/knik0/faac/pull/158 in scope.

### Bug Description
Both API functions previously checked `caller_size` against `sizeof(info.struct_size)` (4 bytes) rather than the actual baseline size of the output structs. 

If a caller passed a struct with `struct_size = 4`:
1. The boundary check `caller_size < sizeof(info.struct_size)` passed.
2. The function returned `FAAC_OK`.
3. The caller read back uninitialized memory for fields beyond `struct_size` (such as `version`, `copyright`, `max_channels`, or `frame_samples`).

### Solution
- Introduced `LIBRARY_INFO_BASELINE_SIZE` anchored on `sbr_decimation`.
- Introduced `ENCODER_INFO_BASELINE_SIZE` anchored on `pns_level`.
- Updated `faac_get_library_info` and `faac_encoder_get_info` to enforce these baseline sizes.

### ABI Compatibility
Validation uses fixed `offsetof` boundaries rather than `sizeof(struct)` to maintain ABI compatibility with legacy callers compiled against older struct revisions.