### PR TITLE
bump ABI to 2 for safe faac_params_init caller sizing

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -924,7 +924,7 @@ int main(int argc, char *argv[])
     }
 
     /* put the options into the parameter struct and open the encoder */
-    faac_params_init(&params);
+    faac_params_init(&params, sizeof(params));
     params.sample_rate   = infile->samplerate;
     params.num_channels  = infile->channels;
     params.mpeg_version  = mpegVersion;

--- a/frontend/maingui.c
+++ b/frontend/maingui.c
@@ -140,7 +140,7 @@ static DWORD WINAPI EncodeFile(LPVOID pParam)
         faac_encoder *hEncoder = NULL;
 	char szTemp[256];
 
-        faac_params_init(&params);
+        faac_params_init(&params, sizeof(params));
         params.sample_rate  = sampleRate;
         params.num_channels = numChannels;
         params.input_format = FAAC_INPUT_32BIT;   /* wav_read_int24 -> 24-in-32 int */

--- a/include/faac.h
+++ b/include/faac.h
@@ -255,7 +255,15 @@ FAACAPI faac_status faac_get_library_info(faac_library_info *out);
  * sizeof(faac_params)), so a caller stays safe even if the loaded library's
  * faac_params has grown since the caller was built. Returns
  * FAAC_ERR_INVALID_ARGUMENT if p is NULL or caller_size is smaller than
- * faac_params's original (baseline) layout. */
+ * faac_params's original (baseline) layout.
+ *
+ * caller_size was added in SONAME 2; code that must build against both:
+ *   #if FAAC_VERSION_MAJOR >= 2
+ *       faac_params_init(&params, sizeof(params));
+ *   #else
+ *       faac_params_init(&params);
+ *   #endif
+ */
 FAACAPI faac_status faac_params_init(faac_params *p, uint32_t caller_size);
 
 /*

--- a/include/faac.h
+++ b/include/faac.h
@@ -53,8 +53,8 @@ extern "C" {
  *
  *   #if defined(FAAC_VERSION_MAJOR) && (FAAC_VERSION_MAJOR >= 1)
  */
-#define FAAC_VERSION_MAJOR 1
-#define FAAC_VERSION_MINOR 1
+#define FAAC_VERSION_MAJOR 2
+#define FAAC_VERSION_MINOR 0
 #define FAAC_VERSION_PATCH 0
 #define FAAC_VERSION_HEX \
     ((FAAC_VERSION_MAJOR << 16) | (FAAC_VERSION_MINOR << 8) | FAAC_VERSION_PATCH)
@@ -152,7 +152,7 @@ enum faac_input_format {
  * open() will reject it. The struct only ever grows by appending named fields.
  */
 typedef struct faac_params {
-    uint32_t                struct_size;   /* set by faac_params_init to sizeof(faac_params) */
+    uint32_t                struct_size;   /* set by faac_params_init() */
 
     uint32_t                sample_rate;   /* input/output sample rate in Hz (required)      */
     uint32_t                num_channels;  /* channel count, 1..max_channels (required)       */
@@ -250,9 +250,13 @@ typedef struct faac_library_info {
 
 FAACAPI faac_status faac_get_library_info(faac_library_info *out);
 
-/* Zero-initialize *p and fill in library defaults and struct_size. Returns
- * FAAC_ERR_INVALID_ARGUMENT if p is NULL. */
-FAACAPI faac_status faac_params_init(faac_params *p);
+/* Zero-initialize *p and fill in library defaults and struct_size. Pass
+ * sizeof(*p) as caller_size; never writes past min(caller_size,
+ * sizeof(faac_params)), so a caller stays safe even if the loaded library's
+ * faac_params has grown since the caller was built. Returns
+ * FAAC_ERR_INVALID_ARGUMENT if p is NULL or caller_size is smaller than
+ * faac_params's original (baseline) layout. */
+FAACAPI faac_status faac_params_init(faac_params *p, uint32_t caller_size);
 
 /*
  * Create an encoder from a fully-specified faac_params. On success writes the

--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -96,6 +96,7 @@ FAACAPI faac_status faac_get_library_info(faac_library_info *out)
 
 FAACAPI faac_status faac_params_init(faac_params *p, uint32_t caller_size)
 {
+    faac_params tmp;
     uint32_t n;
 
     if (!p)
@@ -103,22 +104,26 @@ FAACAPI faac_status faac_params_init(faac_params *p, uint32_t caller_size)
     if (caller_size < PARAMS_BASELINE_SIZE)
         return FAAC_ERR_INVALID_ARGUMENT;
 
-    n = caller_size < (uint32_t)sizeof(*p) ? caller_size : (uint32_t)sizeof(*p);
-    memset(p, 0, n);
-    p->struct_size   = n;
-    p->mpeg_version  = FAAC_MPEG4;
-    p->object_type   = FAAC_OBJ_LOW;
-    p->joint_mode    = FAAC_JOINT_MIXED;
-    p->use_lfe       = false;
-    p->use_tns       = false;
-    p->bit_rate      = 64000;          /* per channel; 0 would defer to quant_quality */
-    p->bandwidth     = 0;              /* derive from bit_rate */
-    p->quant_quality = 0;              /* derive from bit_rate */
-    p->max_bit_rate  = 0;              /* no per-frame peak cap */
-    p->output_format = FAAC_STREAM_ADTS;
-    p->input_format  = FAAC_INPUT_16BIT;
-    p->short_control = FAAC_SHORTCTL_NORMAL;
-    p->pns_level     = 4;
+    memset(&tmp, 0, sizeof(tmp));
+    tmp.mpeg_version  = FAAC_MPEG4;
+    tmp.object_type   = FAAC_OBJ_LOW;
+    tmp.joint_mode    = FAAC_JOINT_MIXED;
+    tmp.use_lfe       = false;
+    tmp.use_tns       = false;
+    tmp.bit_rate      = 64000;          /* per channel; 0 would defer to quant_quality */
+    tmp.bandwidth     = 0;              /* derive from bit_rate */
+    tmp.quant_quality = 0;              /* derive from bit_rate */
+    tmp.max_bit_rate  = 0;              /* no per-frame peak cap */
+    tmp.output_format = FAAC_STREAM_ADTS;
+    tmp.input_format  = FAAC_INPUT_16BIT;
+    tmp.short_control = FAAC_SHORTCTL_NORMAL;
+    tmp.pns_level     = 4;
+
+    /* Write at most the caller's struct_size so a newer library cannot overrun
+     * an older, smaller faac_params; report the byte count actually set. */
+    n = caller_size < (uint32_t)sizeof(faac_params) ? caller_size : (uint32_t)sizeof(faac_params);
+    tmp.struct_size = n;
+    memcpy(p, &tmp, n);
     return FAAC_OK;
 }
 

--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -94,13 +94,18 @@ FAACAPI faac_status faac_get_library_info(faac_library_info *out)
     return FAAC_OK;
 }
 
-FAACAPI faac_status faac_params_init(faac_params *p)
+FAACAPI faac_status faac_params_init(faac_params *p, uint32_t caller_size)
 {
+    uint32_t n;
+
     if (!p)
         return FAAC_ERR_INVALID_ARGUMENT;
+    if (caller_size < PARAMS_BASELINE_SIZE)
+        return FAAC_ERR_INVALID_ARGUMENT;
 
-    memset(p, 0, sizeof(*p));
-    p->struct_size   = (uint32_t)sizeof(faac_params);
+    n = caller_size < (uint32_t)sizeof(*p) ? caller_size : (uint32_t)sizeof(*p);
+    memset(p, 0, n);
+    p->struct_size   = n;
     p->mpeg_version  = FAAC_MPEG4;
     p->object_type   = FAAC_OBJ_LOW;
     p->joint_mode    = FAAC_JOINT_MIXED;

--- a/libfaac/meson.build
+++ b/libfaac/meson.build
@@ -90,7 +90,7 @@ if default_lib == 'shared' or default_lib == 'both'
         common_src,
         kwargs : common_args + {
           # Keep in sync with FAAC_VERSION_MAJOR/MINOR/PATCH in include/faac.h.
-          'version' : '1.0.0',
+          'version' : '2.0.0',
           'vs_module_defs' : 'libfaac.def',
           'override_options' : ['b_lto=true'],
         },


### PR DESCRIPTION
`faac_params_init(p)` previously zeroed memory and populated default settings using the library's compiled `sizeof(faac_params)` rather than the caller's header layout. 

When `faac_params` grows additively in future releases, an application built against an older header (where `sizeof(faac_params)` is smaller) and dynamically linked against a newer `libfaac.so` will suffer an out-of-bounds write during `faac_params_init()`.

This PR updates `faac_params_init()` to accept the caller's allocation size.

## Changes
* **API / ABI Update:** Updated `faac_params_init` signature:
  ```c
  FAACAPI faac_status faac_params_init(faac_params *p, uint32_t caller_size);
Bounds Clamping: All memory operations (memset and struct_size) are clamped to min(caller_size, sizeof(faac_params)).

Baseline Validation: Returns FAAC_ERR_INVALID_ARGUMENT if caller_size < PARAMS_BASELINE_SIZE to ensure core initialization requirements are met.

Versioning: Bumped FAAC_VERSION_MAJOR (1 -> 2) and shared object version / SONAME (1.0.0 -> 2.0.0) due to the C API signature change.

Internal Callers: Updated frontend CLI and GUI encoders to pass sizeof(params).

## Impact
Future Extension Safety: All future additive extensions to faac_params become permanently ABI-safe without requiring additional SONAME bumps for struct growth.

Adoption Timing: Changing this public API signature is a breaking change, but taking this ABI bump now ensures safe parameter initialization for all future releases.

Fixes #163