### PR TITLE
build: don't force LTO when explicitly disabled

### DIFF
--- a/libfaac/meson.build
+++ b/libfaac/meson.build
@@ -92,7 +92,6 @@ if default_lib == 'shared' or default_lib == 'both'
           # Keep in sync with FAAC_VERSION_MAJOR/MINOR/PATCH in include/faac.h.
           'version' : '1.0.0',
           'vs_module_defs' : 'libfaac.def',
-          'override_options' : ['b_lto=true'],
         },
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project('faac', 'c',
         'buildtype=release',
         'warning_level=3',
         'c_std=gnu11,c11',
+        'b_lto=true'
     ])
 
 add_global_arguments('-DHAVE_CONFIG_H', language: 'c')


### PR DESCRIPTION
LTO is currently forced for the shared library even if explicitly disabled with `-Db_lto=false`.

This change keeps LTO the default (still disabled for the static library), but allows explicitly disabling it when configuring with Meson.