### PR TITLE
build: remove __stdcall calling convention for x86 Windows

### DIFF
--- a/include/faac.h
+++ b/include/faac.h
@@ -59,17 +59,15 @@ extern "C" {
 #define FAAC_VERSION_HEX \
     ((FAAC_VERSION_MAJOR << 16) | (FAAC_VERSION_MINOR << 8) | FAAC_VERSION_PATCH)
 
-/* Export/visibility marker. Shared with <faac.h>; guarded so including both
- * headers is harmless. */
-#if !defined(FAACAPI) && defined(__GNUC__) && (__GNUC__ >= 4)
-# if defined(_WIN32)
-#  define FAACAPI __stdcall __declspec(dllexport)
-# else
-#  define FAACAPI __attribute__((visibility("default")))
-# endif
-#endif
+/* Export/visibility marker. */
 #ifndef FAACAPI
+# if defined(_WIN32)
+#  define FAACAPI __declspec(dllexport)
+# elif defined(__GNUC__) && (__GNUC__ >= 4)
+#  define FAACAPI __attribute__((visibility("default")))
+# else
 #  define FAACAPI
+# endif
 #endif
 
 /* Opaque encoder handle */

--- a/libfaac/meson.build
+++ b/libfaac/meson.build
@@ -1,10 +1,3 @@
-link_args = []
-if host_machine.system() == 'windows' and meson.get_compiler('c').get_id() == 'gcc'
-    # identifies mingw
-    link_args += '-Wl,--add-stdcall-alias'
-endif
-
-
 quantize_simd_libs = []
 
 if config_h.get('HAVE_SSE2')
@@ -64,7 +57,6 @@ libfaac = disabler()
 common_args = {
     'include_directories' : ['..', '../include'],
     'c_args' : c_args,
-    'link_args' : link_args,
     'dependencies' : [libm],
     'link_with' : quantize_simd_libs,
     'install' : true,


### PR DESCRIPTION
While we're bumping the soname anyway, let's also remove the `__stdcall` calling convention from exported functions.

The definition was broken in that it added `__stdcall` only when compiling with GCC/Clang, but not when building with MSVC, so (on x86 Windows) a library build with GCC/Clang was incompatible with a program built with MSVC and vice versa.

`__stdcall` is supported on x86 only and has no effect on x86-64.