### PR TITLE
tns: drop prediction-gain ceiling and screen frames before LPC analysis

### DIFF
--- a/libfaac/blockswitch.c
+++ b/libfaac/blockswitch.c
@@ -104,6 +104,42 @@ void PsyInit(GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo, unsigned int numChanne
     psyInfo[channel].sizeS = size;
 }
 
+/* Strongest relative energy jump across the sub-blocks of the window the MDCT
+   is about to transform. ENG_WIN_PREV is exactly that window -- (FIFO_PAST,
+   FIFO_CURR) -- because PsyBufferUpdate has already shifted by the time TNS
+   runs.
+
+   Exposed so TNS can gate on the temporal envelope already sitting in
+   psydata instead of recomputing it. Returns 0 if PsyBufferUpdate hasn't
+   populated the energy windows for this channel yet -- callers must treat
+   that as "no basis to judge", not "flat". */
+float PsyGetAttack(PsyInfo * psyInfo)
+{
+  psydata_t *psydata = (psydata_t *)psyInfo->data;
+  float strength = 0.0f, total = 0.0f;
+  int win;
+
+  if (!psydata)
+    return 0.0f;
+
+  for (win = 0; win < SUBBLOCKS_PER_FRAME; win++)
+  {
+    float e = (float)psydata->eng[ENG_WIN_PREV + win];
+
+    total += e;
+    if (win)
+    {
+      float p = (float)psydata->eng[ENG_WIN_PREV + win - 1];
+      float lo = (e < p) ? e : p;
+      float s = fabsf(e - p) / lo;      /* IEEE divide covers silence */
+
+      if (s > strength) strength = s;
+    }
+  }
+
+  return total > 0.0f ? strength : 0.0f;
+}
+
 void PsyEnd(PsyInfo * psyInfo, unsigned int numChannels)
 {
   unsigned int channel;

--- a/libfaac/blockswitch.h
+++ b/libfaac/blockswitch.h
@@ -45,6 +45,7 @@ typedef struct {
 void PsyInit (GlobalPsyInfo *gpsyInfo, PsyInfo *psyInfo,
 		unsigned int numChannels, unsigned int sampleRate);
 void PsyEnd (PsyInfo *psyInfo, unsigned int numChannels);
+float PsyGetAttack (PsyInfo *psyInfo);
 void PsyCalculate (AACElement *elements, int numElements, PsyInfo *psyInfo,
 		unsigned int numChannels);
 void PsyBufferUpdate (GlobalPsyInfo * gpsyInfo, PsyInfo * psyInfo,

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -558,6 +558,17 @@ static void doHEAACFrame(faacEncStruct *hEncoder, unsigned int realPerCh,
     SbrContextProcessFrame(hEncoder->sbrContext, hEncoder->numChannels, (int)realPerCh, hEncoder->inputFifo, heHalfRate);
 }
 
+/* Admission gate: TNS shapes noise along the temporal envelope, so a window
+ * with no envelope discontinuity has nothing for it to do, but the LPC gate
+ * only discovers that after normalization, autocorrelation and Levinson-Durbin
+ * have run. Screening on the envelope first skips that work for frames headed
+ * for rejection anyway.
+ *
+ * Scaled to PsyGetAttack's statistic (largest relative energy jump between
+ * adjacent sub-blocks). Not portable to a different sub-block count/size --
+ * the same transient reads as a smaller jump with fewer, longer sub-blocks. */
+#define TNS_ATTACK_MIN 0.5f
+
 int faacEncEncode(faacEncHandle hpEncoder,
                           int32_t *inputBuffer,
                           unsigned int samplesInput,
@@ -736,6 +747,14 @@ int faacEncEncode(faacEncHandle hpEncoder,
     /* Perform TNS analysis and filtering */
     for (channel = 0; channel < numChannels; channel++) {
         if (!hEncoder->isLfeChannel[channel] && useTns) {
+            float attack = PsyGetAttack(&hEncoder->psyInfo[channel]);
+
+            /* No envelope available (HE-AAC skips PsyBufferUpdate) means no
+               basis to reject on, so admit and let the LPC gates decide. */
+            if (attack > 0.0f && attack < TNS_ATTACK_MIN) {
+                coderInfo[channel].tnsInfo.tnsDataPresent = 0;
+                continue;
+            }
             TnsEncode(&(coderInfo[channel].tnsInfo),
                       coderInfo[channel].sfbn,
                       coderInfo[channel].block_type,

--- a/libfaac/tns.c
+++ b/libfaac/tns.c
@@ -33,7 +33,6 @@ static const struct {
 
 #define TNS_LPC_ORDER       8     /* fixed filter order; spec allows up to TNS_MAX_ORDER but higher orders rarely paid for themselves here */
 #define TNS_GAIN_LIMIT      1.4f  /* Levinson-Durbin prediction gain below this isn't worth the filter's bit cost */
-#define TNS_GAIN_CLAMP      6.0f  /* gain above this means a near-singular fit (e.g. a single strong tone); reject rather than risk an unstable filter */
 #define TNS_MEASURED_GAIN   1.4f  /* post-quantization re-check: same bar as TNS_GAIN_LIMIT, applied to the filter actually being transmitted */
 
 /* Below this, a band's spectral energy is indistinguishable from float
@@ -117,11 +116,11 @@ static float compute_lpc(int order, const float * r, float * k)
     }
 
     /* err collapsing to ~0 means a (near-)perfect fit, which for real audio
-     * means a degenerate input rather than a genuinely great filter. Return
-     * a gain past TNS_GAIN_CLAMP so the caller's sanity check rejects it,
-     * instead of dividing by ~0. */
+     * means a degenerate input rather than a genuinely great filter. Report
+     * infinite gain so the caller's isfinite() check rejects it, instead of
+     * dividing by ~0. */
     if (err <= TNS_MIN_ENERGY)
-        return TNS_GAIN_CLAMP + 1.0f;
+        return INFINITY;
     return r[0] / err;
 }
 
@@ -223,41 +222,30 @@ void TnsInit(faacEncStruct* hEncoder)
     }
 }
 
-void TnsEncode(TnsInfo* tnsInfo, int numBands, enum WINDOW_TYPE blockType, int* sfbOffsetTable,
-               float* spec)
+/* Fits one TNS filter over scalefactor bands [b_start, b_stop) and, if it
+ * earns its place, whitens that range of `spec` in place and fills *filter.
+ * Returns 1 when a filter was written, 0 otherwise. */
+static int tns_fit_range(int b_start, int b_stop, int *sfbOffsetTable,
+                         float *spec, TnsFilterData *filter)
 {
-    int b_start, b_stop, i_start, length;
+    int i_start = sfbOffsetTable[b_start];
+    int length = sfbOffsetTable[b_stop] - i_start;
     float *band, energy;
     float wspec[BLOCK_LEN_LONG];
     float r[TNS_MAX_ORDER + 1] = {0};
     float k[TNS_MAX_ORDER + 1] = {0};
     float gain;
-    TnsFilterData *filter;
     int order, limit, i;
 
-    tnsInfo->tnsDataPresent = 0;
-    tnsInfo->windowData.numFilters = 0;
-
-    /* Short windows already have the temporal resolution to not need TNS. */
-    if (blockType == ONLY_SHORT_WINDOW)
-        return;
-
-    b_start = min(tnsInfo->tnsMinBandNumberLong, numBands);
-    b_stop = min(tnsInfo->tnsMaxBandsLong, numBands);
-    if (b_stop <= b_start)
-        return;
-
-    i_start = sfbOffsetTable[b_start];
-    length = sfbOffsetTable[b_stop] - i_start;
     if (length <= TNS_LPC_ORDER)
-        return;
+        return 0;
 
     band = spec + i_start;
     energy = 0.0f;
     for (i = 0; i < length; i++)
         energy += band[i] * band[i];
     if (energy < TNS_MIN_ENERGY)
-        return;
+        return 0;
 
     /* Per-band RMS-normalize before autocorrelation, floored at 1% of the
      * loudest band's RMS. Un-normalized, Levinson-Durbin would fit whatever
@@ -291,7 +279,7 @@ void TnsEncode(TnsInfo* tnsInfo, int numBands, enum WINDOW_TYPE blockType, int* 
          * replace anyway -- skip the LPC work; it only pays off on
          * tonal/peaky bands. */
         if (expf(sum_log_rms / (float)nbands) / (sum_rms / (float)nbands) > TNS_PNS_SFM_SKIP)
-            return;
+            return 0;
 
         floorrms = maxrms * 0.01f;
         if (floorrms < TNS_MIN_ENERGY) floorrms = TNS_MIN_ENERGY;
@@ -311,10 +299,14 @@ void TnsEncode(TnsInfo* tnsInfo, int numBands, enum WINDOW_TYPE blockType, int* 
 
     calc_autocorr_f(TNS_LPC_ORDER, length, wspec, r);
     gain = compute_lpc(TNS_LPC_ORDER, r, k);
-    if (gain < TNS_GAIN_LIMIT || gain > TNS_GAIN_CLAMP)
-        return;
+    if (gain < TNS_GAIN_LIMIT)
+        return 0;
+    /* No upper bound: compute_lpc clamps reflection coefficients to +-0.999,
+     * so a high gain can't mean an unstable filter; isfinite() catches the
+     * genuinely degenerate (near-zero-error) fits instead. */
+    if (!isfinite(gain))
+        return 0;
 
-    filter = &tnsInfo->windowData.tnsFilter[0];
     quantize_coeffs(TNS_LPC_ORDER, DEF_TNS_COEFF_RES, k, filter->index);
 
     /* Drop trailing taps that quantized away to ~nothing: they cost bits
@@ -323,13 +315,14 @@ void TnsEncode(TnsInfo* tnsInfo, int numBands, enum WINDOW_TYPE blockType, int* 
     while (order > 0 && fabsf(k[order]) < (float)DEF_TNS_COEFF_THRESH)
         order--;
     if (order == 0)
-        return;
+        return 0;
 
     filter->order = order;
-    filter->length = tnsInfo->tnsNumSwbLong - b_start;
 
-    /* Direction is fixed rather than picked from a transient envelope; that
-     * comes with FrameStrategy in a later commit. */
+    /* Fixed at 0, not chosen: calc_autocorr_f is invariant under sequence
+     * reversal, so both directions give the same LPC fit and prediction gain.
+     * Picking the right one needs the time-domain transient position, which
+     * this function never sees. */
     filter->direction = 0;
 
     /* Coefficients that all fit in one fewer bit each can be transmitted at
@@ -362,10 +355,37 @@ void TnsEncode(TnsInfo* tnsInfo, int numBands, enum WINDOW_TYPE blockType, int* 
         if (filt_e < TNS_MIN_ENERGY)
             filt_e = TNS_MIN_ENERGY;
         if (orig_e < TNS_MEASURED_GAIN * filt_e)
-            return;
+            return 0;
     }
 
     filter_spec(length, order, filter->direction, filter->aCoeffs, band);
+    return 1;
+}
+
+void TnsEncode(TnsInfo* tnsInfo, int numBands, enum WINDOW_TYPE blockType, int* sfbOffsetTable,
+               float* spec)
+{
+    int b_start, b_stop;
+
+    tnsInfo->tnsDataPresent = 0;
+    tnsInfo->windowData.numFilters = 0;
+
+    /* Short windows already have the temporal resolution to not need TNS. */
+    if (blockType == ONLY_SHORT_WINDOW)
+        return;
+
+    b_start = min(tnsInfo->tnsMinBandNumberLong, numBands);
+    b_stop = min(tnsInfo->tnsMaxBandsLong, numBands);
+    if (b_stop <= b_start)
+        return;
+
+    if (!tns_fit_range(b_start, b_stop, sfbOffsetTable, spec,
+                       &tnsInfo->windowData.tnsFilter[0]))
+        return;
+
+    /* Declared from b_start to the top of the spectrum rather than to b_stop,
+     * over-declaring the region. */
+    tnsInfo->windowData.tnsFilter[0].length = tnsInfo->tnsNumSwbLong - b_start;
     tnsInfo->windowData.numFilters = 1;
     tnsInfo->windowData.coefResolution = DEF_TNS_COEFF_RES;
     tnsInfo->tnsDataPresent = 1;


### PR DESCRIPTION
Improves performance of Temporal Noise Shaping (TNS) in libfaac by screening flat temporal envelopes prior to LPC analysis and eliminating redundant prediction-gain clamps.

This reduces TNS CPU overhead from +20.9% down to +5.5% by avoiding heavy autocorrelation and Levinson-Durbin calculations on frames where TNS won't apply.

The default path for FAAC is TNS disabled-by-default and there is no harm to that path.

---

## Performance Impact

Running LPC analysis on flat temporal envelopes wastes CPU on frames destined for rejection.

* Strategy: Added PsyGetAttack() pre-screening before TnsEncode. This reads energy windows already computed during the psychoacoustic pass rather than recomputing them locally (recomputing added a +13.9% CPU penalty under LTO).
* Benchmark (3 min Castanets clip vs --no-tns baseline):
  * Before: +20.9% TNS overhead
  * After: +5.5% TNS overhead

---

## Technical Changes

1. Envelope Pre-Screening (blockswitch.c, frame.c)
   Exposed PsyGetAttack() to query temporal energy jumps in psydata. Screened frames in faacEncEncode() using TNS_ATTACK_MIN (0.5f) so flat frames skip TnsEncode() entirely.

2. Prediction Gain Uncapping (tns.c)
   Removed TNS_GAIN_CLAMP (6.0f). Reflection coefficients are already clamped to ±0.999 by compute_lpc(), ensuring filter stability. Replaced gain bounds with isfinite() to drop degenerate near-zero-error fits without rejecting strong transient filters.

3. Refactoring (tns.c)
   Extracted LPC fitting into tns_fit_range() to isolate admission logic from band bookkeeping.

---

## Quality & Admission Accuracy

* Filter Accuracy: Pre-screening admits 71 of 76 active filters that would have applied, preserving coverage where transients occur.
* Audio Quality Impact: Neutral to slightly positive over 9 SQAM test clips (+0.0058 zimtohrli at 32k, +0.0019 at 64k).
* Uncapped Gain Impact: +0.034 zimtohrli at 32k (concentrated in glockenspiel, castanets, and flute).

Benchmark with TNS: https://github.com/nschimme/faac/actions/runs/32379949619
Benchmark without TNS: https://github.com/nschimme/faac/actions/runs/32389755589

---

## Implementation Notes

The 0.5f threshold is calibrated specifically to PsyGetAttack's 8x256-sample sub-block layout and is non-portable to other temporal envelope granularities.