### PR TITLE
sbr: expand HE-AAC v1 auto-resolution threshold to 96k

### DIFF
--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -32,8 +32,9 @@
 /* HE-AAC auto-mode thresholds; tuned via ViSQOL on a 49-clip corpus. */
 #define HE_MIN_SAMPLE_RATE    32000  /* Fs/2 < 16 kHz below this → core too narrow for SBR */
 #define HE_MIN_BITRATE_PER_CH 12000  /* below floor HE wins by an ever-widening margin */
-#define HE_MAX_BITRATE_PER_CH 28000  /* above ceiling LC wins: SBR costs up to 1 MOS on transients */
-#define HE_VBR_QUANTQUAL_MAX  60     /* quality ≤60 ≈ ≤100 kbps; HE saves bits */
+#define HE_MAX_BITRATE_PER_CH 48000  /* above ceiling LC wins: SBR costs up to 1 MOS on transients */
+/* quantqual == totalBitrate/1280 (see faacEncApplyConfig); derived to stay in sync with HE_MAX_BITRATE_PER_CH. */
+#define HE_VBR_QUANTQUAL_MAX  (2 * HE_MAX_BITRATE_PER_CH / 1280)
 
 #if (defined WIN32 || defined _WIN32 || defined WIN64 || defined _WIN64) && !defined(PACKAGE_VERSION)
 #include "win32_ver.h"
@@ -219,10 +220,15 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
         unsigned long rate_per_ch = config->bitRate;
         int rate_ok;
         if (rate_per_ch > 0) {
-            /* Threshold scales with Fs: (3/4)*Fs - 4 kHz gives ~20 kbps at 32 kHz,
-             * saturating at HE_MAX_BITRATE_PER_CH for Fs ≥ 44.1 kHz. */
-            unsigned int max_he_rate = (unsigned int)(hEncoder->sampleRate * 3 / 4 - 4000);
-            if (max_he_rate > HE_MAX_BITRATE_PER_CH) max_he_rate = HE_MAX_BITRATE_PER_CH;
+            /* Below 44.1 kHz, SBR has less core bandwidth to extend from, so the
+             * ceiling ramps down toward 20000 bps/ch at the HE_MIN_SAMPLE_RATE floor. */
+            unsigned int max_he_rate = 0;
+            if (hEncoder->sampleRate >= 44100) {
+                max_he_rate = HE_MAX_BITRATE_PER_CH;
+            } else if (hEncoder->sampleRate >= HE_MIN_SAMPLE_RATE) {
+                max_he_rate = 20000 + (unsigned int)((hEncoder->sampleRate - 32000) *
+                              (HE_MAX_BITRATE_PER_CH - 20000) / (44100 - 32000));
+            }
             rate_ok = (rate_per_ch >= HE_MIN_BITRATE_PER_CH && rate_per_ch <= max_he_rate);
         } else {
             rate_ok = (config->quantqual <= HE_VBR_QUANTQUAL_MAX);


### PR DESCRIPTION
Expands the HE-AAC v1 auto-resolution ceiling (`HE_MAX_BITRATE_PER_CH`) from 56 kbps to 96 kbps total stream bitrate (48 kbps per channel). The SBR payload timing fix in [#159](https://github.com/knik0/faac/pull/159) unlocked this additional headroom by eliminating envelope leading offset and stabilizing quality across higher bitrates.

Derives `HE_VBR_QUANTQUAL_MAX` dynamically from `HE_MAX_BITRATE_PER_CH` to keep VBR and CBR cutoffs in sync automatically, and updates `max_he_rate` in `libfaac/frame.c` with piecewise interpolation to prevent underflow.

Special thanks to [@BergmannAtmet](https://github.com/BergmannAtmet) for noticing the quality drop-off between 56k and 64k in the [benchmark discussion](https://github.com/nschimme/faac-benchmark/discussions/38), which prompted re-evaluating the cutoff threshold.

## Evidence
ViSQOL sweep of the full 49-clip faac-benchmark stereo corpus (LC vs forced HE-AAC v1):

| Bitrate | Mean dMOS | Wins/Losses | Worst clip |
| ------- | --------- | ----------- | ---------- |
| 72k     | +0.755    | 49/0        | +0.024     |
| 80k     | +0.757    | 49/0        | +0.024     |
| 88k     | +0.307    | 45/3        | -0.176     |
| 96k     | +0.303    | 45/3        | -0.187     |
| 104k    | -0.118    | 8/40        | -0.415 (cliff) |
| 128k    | -0.240    | 0/48        | -0.685     |

In the added 80k–96k range, HE-AAC beats LC on 45 of 49 clips, making 96k the optimal threshold before performance drops off sharply at 104k+.

Benchmark: https://github.com/nschimme/faac/actions/runs/32539192930

<img width="1011" height="1271" alt="image" src="https://github.com/user-attachments/assets/7ba7dc23-a65c-4253-85a7-eabc57690069" />
