### PR TITLE
sbr: widen the reconstruction toward 20 kHz

### DIFF
--- a/libfaac/sbr.c
+++ b/libfaac/sbr.c
@@ -73,6 +73,18 @@ static int compute_k2(int sampleRate, int kx, int bs_stop_freq)
     return clamp_int(k2, kx + 1, kx + max_span > 64 ? 64 : kx + max_span);
 }
 
+/* Smallest stop-frequency index reaching targetHz, or the largest useful one.
+ * Searched rather than tabulated: the index-to-frequency mapping comes from
+ * compute_k2 and shifts with sample rate, so a fixed table would overshoot
+ * at some rates. */
+static int pick_stop_freq(int sampleRate, int kx, int targetHz)
+{
+    for (int sf = SBR_STOP_FREQ_MIN; sf < SBR_STOP_FREQ_MAX; sf++)
+        if ((long)compute_k2(sampleRate, kx, sf) * sampleRate / (2 * SBR_QMF_BANDS_64) >= targetHz)
+            return sf;
+    return SBR_STOP_FREQ_MAX;
+}
+
 /* Distribute QMF bands into SBR master bands using uniform dk-spacing.
  * Residual bands are merged into the first/last pairs to maintain a
  * monotonic frequency grid. */
@@ -141,11 +153,14 @@ void SbrUpdate(SBRInfo *sbr, unsigned long bitRate)
         sbr->bs_alter_scale = 0;
         sbr->dk = 1;
     }
-    /* Stop frequency covers approximately 75% of the upper octave. */
-    sbr->bs_stop_freq = 10;
     sbr->bs_freq_res = 1; /* HIGH resolution */
     sbr->bs_xover_band = 0; /* every master band is an SBR band; no low-res split */
     sbr->kx = compute_kx(sampleRate, sbr->bs_start_freq);
+
+    /* Where the reconstruction stops. Aim at hearing rather than k2's ceiling:
+     * bands above the target cost the same envelope bits as the ones below, so
+     * there's no reason to stop short of what's audible. */
+    sbr->bs_stop_freq = pick_stop_freq(sampleRate, sbr->kx, SBR_STOP_FREQ_TARGET_HZ);
     sbr->k2 = compute_k2(sampleRate, sbr->kx, sbr->bs_stop_freq);
 
     build_freq_table(sbr);

--- a/libfaac/sbr.h
+++ b/libfaac/sbr.h
@@ -99,6 +99,14 @@ struct BitStream;
 /* Rate-dependent resolution thresholds. */
 #define SBR_AMP_RES_BITRATE_BPS         20000u
 #define SBR_COARSE_TABLE_BITRATE_BPS    32000u
+/* Stop-frequency search bounds (bs_stop_freq). 13 is the largest worth
+ * searching: it already pins k2 to its 64-band ceiling at every supported
+ * rate, so higher indices would just signal more range for the same band. */
+#define SBR_STOP_FREQ_MIN               10
+#define SBR_STOP_FREQ_MAX               13
+/* Where widening aims. Past this the bands are inaudible to essentially every
+ * listener while costing exactly as much as the ones below. */
+#define SBR_STOP_FREQ_TARGET_HZ         20000
 /* Max delta-coded step for envelope data, per bs_amp_res grid (ISO 14496-3
  * §4.6.18.3.6): the fine (amp_res=1) grid has half the step size of the coarse
  * grid, so its delta range must be roughly double to cover the same dB span. */


### PR DESCRIPTION
This is a quality improvement.

SBR (Spectral Band Replication) enables HE-AAC to reconstruct high frequencies above the core encoder's bitrate limit by sending a coarse envelope for the decoder to resynthesize. The parameter `bs_stop_freq` dictates the upper bound of this reconstruction. 

Previously, this parameter was hardcoded well below the format's capabilities. As a result, HE-AAC encodes were quietly discarding the top of the audible range—even though encoding these higher bands costs no extra envelope bits.

## What Changed
*   **The Problem:** `bs_stop_freq` was fixed at index 10 (capping `k2` at 51 out of a possible 64). This prematurely stopped reconstruction at **17.6 kHz** (for 44.1 kHz output) and **18.4 kHz** (for 48 kHz). This discarded roughly a fifth of SBR band energy on tonal sources and up to half on cymbal-like sounds.
*   **The Solution:** The encoder now actively searches for the smallest index that reaches roughly **20 kHz** (`pick_stop_freq`).
*   **How it Works:** Because the index-to-frequency mapping (via `compute_k2`) shifts with the sample rate (e.g., index 12 is 20.3 kHz at 44.1 kHz, but 22.1 kHz at 48 kHz), the target index is searched dynamically rather than tabulated. The target prioritizes human hearing limits rather than the absolute `k2` ceiling, keeping envelope bit costs identical.

## Benchmark

https://github.com/nschimme/faac/actions/runs/32552843122

<img width="1072" height="1273" alt="image" src="https://github.com/user-attachments/assets/9e781f02-2d05-41a9-b921-e25f90eb9e2b" />
