### PR TITLE
enforce ISO/IEC 14496-3 per-channel frame ceiling by default

### DIFF
--- a/docs/libfaac.html
+++ b/docs/libfaac.html
@@ -134,9 +134,11 @@ Packet-oriented transports often cannot fragment a frame: one that overruns the
 link MTU is dropped, not split. <i>bit_rate</i> cannot prevent that, being an
 average individual frames are free to exceed &mdash; a transient easily produces
 a frame several times the mean. <i>faac_params.max_bit_rate</i> puts a hard
-ceiling on any single frame; 0, the default, means none. Unlike <i>bit_rate</i>
-it is a whole-stream rate, so it stays independent of <i>num_channels</i> and
-follows directly from the payload one packet can carry:
+ceiling on any single frame; 0, the default, means none beyond the encoder's
+own ISO/IEC 14496-3 peak ceiling of 6144 bits per channel per frame, enforced
+unconditionally to guarantee decoder compatibility across portable devices.
+Unlike <i>bit_rate</i> it is a whole-stream rate, so it stays independent of
+<i>num_channels</i> and follows directly from the payload one packet can carry:
 <pre>
     max_bit_rate = payload_bytes * 8 * sample_rate / 1024
 </pre>

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -114,7 +114,8 @@ static help_t help_qual[] = {
     },
     {"-b <bitrate>\tSet average bitrate to x kbps. (ABR)\n",
     "\t\tSet average bitrate (ABR) to approximately <bitrate> kbps.\n"
-    "\t\tmax. ~500 (stereo)\n"},
+    "\t\tmax. ~529 (stereo, 44.1kHz) to ~576 (stereo, 48kHz), the ISO\n"
+    "\t\t6144 bits/channel/frame limit\n"},
     {"-c <freq>\tSet the bandwidth in Hz.\n",
     "\t\tThe actual frequency is adjusted to maximize upper spectral band\n"
     "\t\tusage.\n"},

--- a/include/faac.h
+++ b/include/faac.h
@@ -180,7 +180,8 @@ typedef struct faac_params {
     /* Ceiling on any single frame, for packet-oriented transports that cannot
      * fragment one -- a frame that overruns the link MTU is dropped, not split.
      * Unlike bit_rate this is a WHOLE-STREAM rate, so it stays independent of
-     * num_channels and follows from the payload a packet can carry:
+     * num_channels and follows from the payload a packet can carry or standard
+     * ISO/IEC 14496-3 limits (6144 bits/channel per frame):
      *
      *     max_bit_rate = payload_bytes * 8 * sample_rate / 1024
      *

--- a/libfaac/coder.h
+++ b/libfaac/coder.h
@@ -22,6 +22,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #define FRAME_LEN 1024
+#define AAC_MAX_BITS_PER_CH 6144
 #define BLOCK_LEN_LONG 1024
 #define BLOCK_LEN_SHORT 128
 

--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -33,6 +33,7 @@
 #include "frame.h"
 #include "bitstream.h"
 #include "sbr.h"
+#include "util.h"
 
 /* The public enums are width-pinned to 32 bits by their FAAC_*_MAX sentinels;
  * verify the compiler honored that so the ABI matches the documented layout. */
@@ -186,6 +187,10 @@ static faac_status validate_params(const faac_params *p)
             if (p->channel_map[i] < 0 || (uint32_t)p->channel_map[i] >= p->num_channels)
                 return FAAC_ERR_INVALID_ARGUMENT;
     }
+    /* bit_rate is per channel; reject a target above what a channel can carry
+     * under the ISO/IEC 14496-3 per-frame ceiling regardless of max_bit_rate. */
+    if (p->bit_rate && p->bit_rate > MaxBitrate(p->sample_rate))
+        return FAAC_ERR_INVALID_ARGUMENT;
     if (p->max_bit_rate) {
         /* Bounded because it is converted into a per-frame bit budget; an
          * absurd value is a caller error, not a request for an unlimited

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -338,8 +338,8 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
 
     hEncoder->config.maxBitRate = config->maxBitRate;
 
-    /* Peak-limiter retry scratch: only encoders that set maxBitRate pay for it. */
-    if (hEncoder->config.maxBitRate) {
+    /* Peak-limiter retry scratch: allocated for all encoders to enforce ISO 6144 bits/ch frame ceiling. */
+    {
         unsigned int ch;
         for (ch = 0; ch < hEncoder->numChannels; ch++) {
             if (!hEncoder->peakSnap[ch])
@@ -796,21 +796,35 @@ int faacEncEncode(faacEncHandle hpEncoder,
     int sfbnSnap[MAX_CHANNELS];
     int attempt;
 
+    /* ISO/IEC 14496-3 standard frame limit: 6144 bits per channel */
+    peakBits = (unsigned long long)numChannels * AAC_MAX_BITS_PER_CH;
+
+    /* If output format is ADTS (outputFormat == 1), respect the 13-bit ADTS
+     * container frame length limit (ADTS_MAX_FRAME_SIZE = 8191 bytes = 65528 bits). */
+    if (hEncoder->config.outputFormat == 1)
+    {
+        unsigned long long adtsPeakBits = (unsigned long long)ADTS_MAX_FRAME_SIZE * 8;
+        if (adtsPeakBits < peakBits)
+            peakBits = adtsPeakBits;
+    }
+
     if (hEncoder->config.maxBitRate)
     {
         /* maxBitRate is whole-stream, so no channel factor here. For HE-AAC
          * sampleRate is the halved core rate, which is what makes FRAME_LEN
          * cover the right span of output samples. */
-        peakBits = (unsigned long long)hEncoder->config.maxBitRate
+        unsigned long long userPeakBits = (unsigned long long)hEncoder->config.maxBitRate
             * FRAME_LEN / hEncoder->sampleRate;
+        if (userPeakBits < peakBits)
+            peakBits = userPeakBits;
+    }
 
-        for (channel = 0; channel < numChannels; channel++) {
-            memcpy(hEncoder->peakSnap[channel], coderInfo[channel].book,
-                   MAX_SCFAC_BANDS * sizeof(int));
-            memcpy(hEncoder->peakSnap[channel] + MAX_SCFAC_BANDS, coderInfo[channel].sf,
-                   MAX_SCFAC_BANDS * sizeof(int));
-            sfbnSnap[channel] = coderInfo[channel].sfbn;
-        }
+    for (channel = 0; channel < numChannels; channel++) {
+        memcpy(hEncoder->peakSnap[channel], coderInfo[channel].book,
+               MAX_SCFAC_BANDS * sizeof(int));
+        memcpy(hEncoder->peakSnap[channel] + MAX_SCFAC_BANDS, coderInfo[channel].sf,
+               MAX_SCFAC_BANDS * sizeof(int));
+        sfbnSnap[channel] = coderInfo[channel].sfbn;
     }
 
     /* Retry while the frame busts peakBits. The search is bounded, not

--- a/libfaac/frame.h
+++ b/libfaac/frame.h
@@ -109,8 +109,8 @@ typedef struct faacEncStruct {
     /* HE-AAC / SBR state */
     struct SBRContext *sbrContext;   /* SBR analysis state and bitstream data */
 
-    /* Peak-limiter retry scratch, NULL unless config.maxBitRate is set: one
-     * buffer per channel holding book[] at [0] and sf[] at [MAX_SCFAC_BANDS]. */
+    /* Peak-limiter retry scratch: one buffer per channel holding book[] at
+     * [0] and sf[] at [MAX_SCFAC_BANDS]. */
     int *peakSnap[MAX_CHANNELS];
 } faacEncStruct;
 

--- a/libfaac/util.c
+++ b/libfaac/util.c
@@ -41,8 +41,8 @@ int GetSRIndex(unsigned int sampleRate)
 /* Returns the maximum bitrate for that sampling frequency */
 unsigned int MaxBitrate(unsigned long sampleRate)
 {
-    /* max ADTS frame size 8k */
-    return 0x2000 * 8 * (float)sampleRate/(float)FRAME_LEN;
+    /* ISO/IEC 14496-3 maximum frame payload: 6144 bits per channel */
+    return AAC_MAX_BITS_PER_CH * sampleRate / FRAME_LEN;
 }
 
 /* Returns the minimum bitrate per channel for that sampling frequency */


### PR DESCRIPTION
This improves compatibility with hardware decoders and fixes #15

#### Context & Problem
In VBR mode (especially at quality settings above 1000), complex or high-transient sequences can cause FAAC to write frame sizes exceeding standard AAC bit limits. This leads to playback issues or failures on hardware players and mobile devices (e.g., iPhone / iOS stock decoders) that strictly enforce spec compliance. 

While FFmpeg's decoder handles these over-spec frames without issue—because software decoders often allocate oversized dynamic bitstream buffers and ignore standard limits unless an explicit buffer overflow occurs—strict hardware and system decoders drop or fail to parse them.

#### Summary of Changes
- **Unconditional Spec Ceiling:** Enforces the standard ISO/IEC 14496-3 limit of **6144 bits per channel per frame** as an absolute peak ceiling (`AAC_MAX_BITS_PER_CH`), regardless of whether `max_bit_rate` is explicitly configured.
- **Leveraging Peak Bitrate Limiter:** Conveniently reuses the existing `maxBitRate` peak-limiter and retry scratch infrastructure, running it universally to guarantee spec compliance without duplicating logic.
- **ADTS Safety:** Respects the 13-bit ADTS container frame length limit (8,191 bytes = 65,528 bits) when ADTS output mode is active (`outputFormat == 1`).
- **Bitrate Validation:** Updates `MaxBitrate()` and `validate_params()` to reject requested target bitrates that violate the 6144 bits/ch/frame ceiling.
- **Documentation & CLI Help:** Updated `libfaac.html`, public header comments, and CLI help strings to reflect the standard frame ceiling and peak bitrate limits (~529 kbps for stereo @ 44.1 kHz, ~576 kbps @ 48 kHz).

Benchmark: https://github.com/nschimme/faac/actions/runs/32596733318

<img width="1019" height="493" alt="image" src="https://github.com/user-attachments/assets/0e5fd0be-f16d-434c-a8fe-e9e0deafd8b9" />
