### PR TITLE
frontend: add UTF-8 and wide-character support across CLI and GUI

### DIFF
--- a/frontend/charset.c
+++ b/frontend/charset.c
@@ -1,0 +1,251 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#elif defined(HAVE_ICONV)
+#include <langinfo.h>
+#include <iconv.h>
+#include <strings.h>
+#endif
+
+#include "charset.h"
+
+/* Structural check only (continuation-byte pattern, NUL-termination): does
+   not reject overlong encodings, surrogates, or code points past U+10FFFF.
+   A plausibility check, not a strict validator -- good enough to decide
+   "does this need repair_to_utf8()", not for security-sensitive callers. */
+static bool utf8_is_valid(const char *str)
+{
+    if (!str)
+        return true;
+
+    const unsigned char *bytes = (const unsigned char *)str;
+    while (*bytes)
+    {
+        if (bytes[0] <= 0x7F)
+        {
+            bytes += 1;
+        }
+        else if ((bytes[0] & 0xE0) == 0xC0)
+        {
+            if (bytes[1] == '\0' || (bytes[1] & 0xC0) != 0x80) return false;
+            bytes += 2;
+        }
+        else if ((bytes[0] & 0xF0) == 0xE0)
+        {
+            if (bytes[1] == '\0' || (bytes[1] & 0xC0) != 0x80 ||
+                bytes[2] == '\0' || (bytes[2] & 0xC0) != 0x80) return false;
+            bytes += 3;
+        }
+        else if ((bytes[0] & 0xF8) == 0xF0)
+        {
+            if (bytes[1] == '\0' || (bytes[1] & 0xC0) != 0x80 ||
+                bytes[2] == '\0' || (bytes[2] & 0xC0) != 0x80 ||
+                bytes[3] == '\0' || (bytes[3] & 0xC0) != 0x80) return false;
+            bytes += 4;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+#ifdef _WIN32
+char *win32_utf16_to_utf8(const wchar_t *wstr)
+{
+    if (!wstr)
+        return NULL;
+
+    int len = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
+    if (len <= 0)
+        return NULL;
+
+    char *str = malloc((size_t)len);
+    if (str)
+    {
+        WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, len, NULL, NULL);
+    }
+    return str;
+}
+
+/* Attempts to repair str, assumed to be in the current Windows ANSI code
+   page, into UTF-8. Returns NULL if it can't. */
+static char *repair_to_utf8(const char *str)
+{
+    int wn = MultiByteToWideChar(CP_ACP, 0, str, -1, NULL, 0);
+    if (wn <= 0)
+        return NULL;
+
+    wchar_t *ws = malloc((size_t)wn * sizeof(wchar_t));
+    if (!ws)
+        return NULL;
+
+    MultiByteToWideChar(CP_ACP, 0, str, -1, ws, wn);
+    char *utf8 = win32_utf16_to_utf8(ws);
+    free(ws);
+    return utf8;
+}
+
+wchar_t *win32_utf8_to_utf16(const char *utf8_str)
+{
+    if (!utf8_str)
+        return NULL;
+
+    int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8_str, -1, NULL, 0);
+    if (wlen <= 0)
+        return NULL;
+
+    wchar_t *wstr = malloc((size_t)wlen * sizeof(wchar_t));
+    if (wstr)
+        MultiByteToWideChar(CP_UTF8, 0, utf8_str, -1, wstr, wlen);
+
+    return wstr;
+}
+
+FILE *win32_fopen_utf8(const char *utf8_path, const char *mode)
+{
+    if (!utf8_path || !mode)
+        return NULL;
+
+    wchar_t *wpath = win32_utf8_to_utf16(utf8_path);
+    if (!wpath)
+        return NULL;
+
+    wchar_t *wmode = win32_utf8_to_utf16(mode);
+    if (!wmode)
+    {
+        free(wpath);
+        return NULL;
+    }
+
+    FILE *f = _wfopen(wpath, wmode);
+    free(wpath);
+    free(wmode);
+    return f;
+}
+
+int win32_access_utf8(const char *utf8_path, int amode)
+{
+    wchar_t *wpath = win32_utf8_to_utf16(utf8_path);
+    if (!wpath)
+        return -1;
+
+    int ret = _waccess(wpath, amode);
+    free(wpath);
+    return ret;
+}
+
+int win32_mtime_utf8(const char *utf8_path, time_t *mtime)
+{
+    wchar_t *wpath = win32_utf8_to_utf16(utf8_path);
+    if (!wpath)
+        return -1;
+
+    struct _stat64 st;
+    int ret = _wstat64(wpath, &st);
+    free(wpath);
+    if (ret == 0)
+        *mtime = (time_t)st.st_mtime;
+    return ret;
+}
+#else /* POSIX */
+#ifdef HAVE_ICONV
+/* Mirrors the Windows path (assume the current code page, convert to UTF-8)
+   using POSIX's equivalent: the locale's codeset name plus iconv(). Returns
+   NULL if it can't repair str. Requires setlocale(LC_CTYPE, "") to have
+   been called at startup -- otherwise nl_langinfo() reports the "C"
+   locale's codeset (ASCII) regardless of the environment. */
+static char *repair_to_utf8(const char *str)
+{
+    const char *codeset = nl_langinfo(CODESET);
+    if (!codeset || !strcasecmp(codeset, "UTF-8") || !strcasecmp(codeset, "UTF8"))
+        return NULL; /* locale already claims UTF-8 (or is unknown): this is
+                        corrupt input, not a different encoding */
+
+    iconv_t cd = iconv_open("UTF-8", codeset);
+    if (cd == (iconv_t)-1)
+        return NULL;
+
+    size_t inbytes = strlen(str);
+    size_t outcap = inbytes * 4 + 16; /* worst-case UTF-8 expansion + headroom */
+    char *outbuf = malloc(outcap);
+    if (!outbuf)
+    {
+        iconv_close(cd);
+        return NULL;
+    }
+
+    char *inp = (char *)str;
+    char *outp = outbuf;
+    size_t inleft = inbytes;
+    size_t outleft = outcap - 1; /* leave room for the NUL below */
+
+    size_t rc = iconv(cd, &inp, &inleft, &outp, &outleft);
+    /* Flush to the initial shift state: a no-op for simple codesets like
+       ISO-8859-*, but stateful ones (e.g. ISO-2022-JP) need a trailing
+       escape sequence emitted here, or the converted tag is truncated. */
+    if (rc != (size_t)-1 && inleft == 0)
+        iconv(cd, NULL, NULL, &outp, &outleft);
+    iconv_close(cd);
+
+    if (rc == (size_t)-1 || inleft != 0)
+    {
+        free(outbuf);
+        return NULL;
+    }
+
+    *outp = '\0';
+    return outbuf;
+}
+#else
+/* No iconv available on this platform: can't attempt repair. */
+static char *repair_to_utf8(const char *str)
+{
+    (void)str;
+    return NULL;
+}
+#endif
+#endif
+
+char *utf8_ensure(const char *str)
+{
+    if (!str)
+        return NULL;
+
+    if (utf8_is_valid(str))
+        return strdup(str);
+
+    char *fixed = repair_to_utf8(str);
+    if (fixed)
+        return fixed;
+
+    fprintf(stderr, "warning: tag value is not valid UTF-8, writing as-is\n");
+    return strdup(str);
+}

--- a/frontend/charset.h
+++ b/frontend/charset.h
@@ -1,0 +1,55 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#ifndef CHARSET_H
+#define CHARSET_H
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Ensure string is valid UTF-8, converting from system encoding if needed */
+char *utf8_ensure(const char *str);
+
+#ifdef _WIN32
+#include <windows.h>
+/* Convert UTF-16 wchar_t string to heap-allocated UTF-8 string */
+char *win32_utf16_to_utf8(const wchar_t *wstr);
+
+/* Convert UTF-8 string to heap-allocated UTF-16 wchar_t string */
+wchar_t *win32_utf8_to_utf16(const char *utf8_str);
+
+/* fopen() on a UTF-8 path: converts to UTF-16 and calls _wfopen(), since the
+   narrow CRT's fopen() interprets its argument in the current ANSI code
+   page, not UTF-8. */
+FILE *win32_fopen_utf8(const char *utf8_path, const char *mode);
+
+/* access() on a UTF-8 path, same rationale as win32_fopen_utf8(). */
+int win32_access_utf8(const char *utf8_path, int amode);
+
+/* mtime of a UTF-8 path, same rationale as win32_fopen_utf8(). Returns 0 and
+   sets *mtime on success, -1 on failure (path not found, etc). */
+int win32_mtime_utf8(const char *utf8_path, time_t *mtime);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CHARSET_H */

--- a/frontend/input.c
+++ b/frontend/input.c
@@ -27,6 +27,7 @@
 #endif
 
 #include "input.h"
+#include "charset.h"
 
 #define SWAP32(x) (((x & 0xff) << 24) | ((x & 0xff00) << 8) \
 	| ((x & 0xff0000) >> 8) | ((x & 0xff000000) >> 24))
@@ -174,10 +175,18 @@ pcmfile_t *wav_open_read(const char *name, bool rawinput)
     wave_f = stdin;
     dostdin = 1;
   }
-  else if (!(wave_f = fopen(name, "rb")))
+  else
   {
-    perror(name);
-    return NULL;
+#ifdef _WIN32
+    wave_f = win32_fopen_utf8(name, "rb");
+#else
+    wave_f = fopen(name, "rb");
+#endif
+    if (!wave_f)
+    {
+      perror(name);
+      return NULL;
+    }
   }
 
   if (!rawinput) // header input

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -44,6 +44,7 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <locale.h>
 
 #ifdef HAVE_GETOPT_H
 # include <getopt.h>
@@ -53,6 +54,7 @@
 #endif
 
 #include "mp4write.h"
+#include "charset.h"
 #include "output.h"
 
 #ifdef _WIN32
@@ -339,6 +341,55 @@ static void help(int mode)
 int main(int argc, char *argv[])
 {
     int frames, currentFrame;
+
+#ifndef _WIN32
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+    /* So charset.c's utf8_ensure() can read the real locale codeset via
+       nl_langinfo() instead of always seeing the default "C" locale. */
+    setlocale(LC_CTYPE, "");
+#endif
+
+#ifdef _WIN32
+    int wargc = 0;
+    wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+    char **allocated_argv = NULL;
+    if (wargv && wargc > 0)
+    {
+        allocated_argv = calloc((size_t)wargc, sizeof(char *));
+        if (allocated_argv)
+        {
+            bool conv_ok = true;
+            for (int i = 0; i < wargc; i++)
+            {
+                char *utf8_arg = win32_utf16_to_utf8(wargv[i]);
+                if (!utf8_arg)
+                {
+                    conv_ok = false;
+                    break;
+                }
+                allocated_argv[i] = utf8_arg;
+            }
+
+            if (conv_ok)
+            {
+                argc = wargc;
+                argv = allocated_argv;
+            }
+            else
+            {
+                for (int i = 0; i < wargc; i++)
+                {
+                    if (allocated_argv[i])
+                        free(allocated_argv[i]);
+                }
+                free(allocated_argv);
+                allocated_argv = NULL;
+            }
+        }
+        LocalFree(wargv);
+    }
+#endif
     faac_encoder *hEncoder = NULL;
     pcmfile_t *infile = NULL;
 
@@ -636,8 +687,20 @@ int main(int argc, char *argv[])
                 dieMessage = "Missing tag value.\n";
             else
                 *(char *)tagval++ = 0;
-            if (!dieMessage && mp4_add_custom_tag(tagname, tagval))
-                dieMessage = "Couldn't add tag (out of memory).\n";
+            if (!dieMessage)
+            {
+                char *utf8_tagval = utf8_ensure(tagval);
+                if (utf8_tagval)
+                {
+                    if (mp4_add_custom_tag(tagname, utf8_tagval))
+                        dieMessage = "Couldn't add tag (out of memory).\n";
+                    free(utf8_tagval);
+                }
+                else
+                {
+                    dieMessage = "Couldn't add tag (out of memory).\n";
+                }
+            }
             break;
         case CREATION_TIME_FLAG:
             creation_time_str = optarg;
@@ -647,7 +710,11 @@ int main(int argc, char *argv[])
             break;
         case COVER_ART_FLAG:
             {
+#ifdef _WIN32
+                FILE *artFile = win32_fopen_utf8(optarg, "rb");
+#else
                 FILE *artFile = fopen(optarg, "rb");
+#endif
 
                 if (artFile)
                 {
@@ -958,7 +1025,11 @@ int main(int argc, char *argv[])
         }
         else
         {
+#ifdef _WIN32
+            outfile = win32_fopen_utf8(aacFileName, "wb");
+#else
             outfile = fopen(aacFileName, "wb");
+#endif
         }
         if (!outfile)
         {
@@ -1201,7 +1272,17 @@ int main(int argc, char *argv[])
 
         mp4_set_encoder(version_string);
 
-#define SETTAG(id, x) if(x) mp4_set_tag(id, x)
+        char *allocated_tags[MP4TAG_COUNT] = { 0 };
+        int num_allocated = 0;
+
+#define SETTAG(id, x) \
+    if (x) { \
+        char *utf8_val = utf8_ensure(x); \
+        if (utf8_val && num_allocated < MP4TAG_COUNT) { \
+            mp4_set_tag(id, utf8_val); \
+            allocated_tags[num_allocated++] = utf8_val; \
+        } \
+    }
         SETTAG(MP4TAG_ARTIST, artist);
         SETTAG(MP4TAG_ARTISTSORT, artistsort);
         SETTAG(MP4TAG_COMPOSER, composer);
@@ -1234,11 +1315,19 @@ int main(int argc, char *argv[])
                     }
                     else
                     {
+#ifdef _WIN32
+                        time_t mtime = 0;
+                        if (win32_mtime_utf8(audioFileName, &mtime) == 0)
+                        {
+                            final_creation_time = (uint32_t)mtime;
+                        }
+#else
                         struct stat st;
                         if (stat(audioFileName, &st) == 0)
                         {
                             final_creation_time = (uint32_t)st.st_mtime;
                         }
+#endif
                         else
                         {
                             fprintf(stderr, "couldn't stat() input file %s, defaulting to 0\n", audioFileName);
@@ -1283,6 +1372,9 @@ int main(int argc, char *argv[])
             fprintf(stderr, "mp4_finish() failed: output file may be incomplete\n");
         mp4_close();
 
+        for (int i = 0; i < num_allocated; i++)
+            free(allocated_tags[i]);
+
         free(version_string);
 
         if (verbose >= 2)
@@ -1313,6 +1405,18 @@ int main(int argc, char *argv[])
         free(aacFileName);
     if (chanmap)
         free(chanmap);
+
+#ifdef _WIN32
+    if (allocated_argv)
+    {
+        for (int i = 0; i < argc; i++)
+        {
+            if (allocated_argv[i])
+                free(allocated_argv[i]);
+        }
+        free(allocated_argv);
+    }
+#endif
 
     return 0;
 }

--- a/frontend/maingui.c
+++ b/frontend/maingui.c
@@ -22,61 +22,55 @@
 
 #include <faac.h>
 #include "resource.h"
+#include "charset.h"
 
 
 static HINSTANCE hInstance;
 
-static char inputFilename[_MAX_PATH], outputFilename[_MAX_PATH];
+static WCHAR inputFilename[_MAX_PATH], outputFilename[_MAX_PATH];
 
 static BOOL Encoding = FALSE;
 
-static BOOL SelectFileName(HWND hParent, char *filename, BOOL forReading)
+static BOOL SelectFileName(HWND hParent, WCHAR *filename, BOOL forReading)
 {
-    OPENFILENAME ofn;
+    OPENFILENAMEW ofn;
 
-    ofn.lStructSize = sizeof(OPENFILENAME);
+    memset(&ofn, 0, sizeof(ofn));
+    ofn.lStructSize = sizeof(ofn);
     ofn.hwndOwner = hParent;
     ofn.hInstance = hInstance;
     ofn.nFilterIndex = 0;
     ofn.lpstrFileTitle = NULL;
-    ofn.nMaxFileTitle = 31;
-    filename [0] = 0x00;
-    ofn.lpstrFile = (LPSTR)filename;
+    ofn.nMaxFileTitle = 0;
+    filename[0] = L'\0';
+    ofn.lpstrFile = filename;
     ofn.nMaxFile = _MAX_PATH;
-    ofn.lpstrInitialDir = NULL;
-    ofn.lpstrCustomFilter = NULL;
-    ofn.nMaxCustFilter = 0;
-    ofn.nFileOffset = 0;
-    ofn.nFileExtension = 0;
-    ofn.lCustData = 0;
-    ofn.lpfnHook = NULL;
-    ofn.lpTemplateName = NULL;
 
     if (forReading)
     {
-        char filters[] = { "Wave Files (*.wav)\0*.wav\0" \
-            "AIFF Files (*.aif;*.aiff;*.aifc)\0*.aif;*.aiff;*.aifc\0" \
-            "AU Files (*.au)\0*.au\0" \
-            "All Files (*.*)\0*.*\0\0" };
+        static const WCHAR filters[] =
+            L"Wave Files (*.wav)\0*.wav\0"
+            L"AIFF Files (*.aif;*.aiff;*.aifc)\0*.aif;*.aiff;*.aifc\0"
+            L"AU Files (*.au)\0*.au\0"
+            L"All Files (*.*)\0*.*\0\0";
 
         ofn.lpstrFilter = filters;
-        ofn.lpstrDefExt = "wav";
-
+        ofn.lpstrDefExt = L"wav";
         ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
-        ofn.lpstrTitle = "Select Source File";
+        ofn.lpstrTitle = L"Select Source File";
 
-        return GetOpenFileName (&ofn);
+        return GetOpenFileNameW(&ofn);
     } else {
-        char filters [] = { "AAC Files (*.aac)\0*.aac\0" \
-            "All Files (*.*)\0*.*\0\0" };
+        static const WCHAR filters[] =
+            L"AAC Files (*.aac)\0*.aac\0"
+            L"All Files (*.*)\0*.*\0\0";
 
         ofn.lpstrFilter = filters;
-        ofn.lpstrDefExt = "aac";
-
+        ofn.lpstrDefExt = L"aac";
         ofn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY;
-        ofn.lpstrTitle = "Select Output File";
+        ofn.lpstrTitle = L"Select Output File";
 
-        return GetSaveFileName(&ofn);
+        return GetSaveFileNameW(&ofn);
     }
 }
 
@@ -85,9 +79,16 @@ static void AwakeDialogControls(HWND hWnd)
     char szTemp[64];
     pcmfile_t *infile = NULL;
     unsigned int sampleRate, numChannels;
-    char *pExt;
+    WCHAR *pExt;
 
-    if ((infile = wav_open_read(inputFilename, 0)) == NULL)
+    char *utf8_input = win32_utf16_to_utf8(inputFilename);
+    if (!utf8_input)
+        return;
+
+    infile = wav_open_read(utf8_input, 0);
+    free(utf8_input);
+
+    if (!infile)
         return;
 
     /* determine input file parameters */
@@ -96,20 +97,20 @@ static void AwakeDialogControls(HWND hWnd)
 
     wav_close(infile);
 
-    SetDlgItemText (hWnd, IDC_INPUTFILENAME, inputFilename);
+    SetDlgItemTextW(hWnd, IDC_INPUTFILENAME, inputFilename);
 
-    strncpy(outputFilename, inputFilename, sizeof(outputFilename) - 5);
-    outputFilename[sizeof(outputFilename) - 5] = '\0';
+    wcsncpy(outputFilename, inputFilename, (sizeof(outputFilename) / sizeof(WCHAR)) - 5);
+    outputFilename[(sizeof(outputFilename) / sizeof(WCHAR)) - 5] = L'\0';
 
-    pExt = strrchr(outputFilename, '.');
+    pExt = wcsrchr(outputFilename, L'.');
 
-    if (pExt == NULL) lstrcat(outputFilename, ".aac");
-    else lstrcpy(pExt, ".aac");
+    if (pExt == NULL) wcscat(outputFilename, L".aac");
+    else wcscpy(pExt, L".aac");
 
     EnableWindow(GetDlgItem(hWnd, IDC_OUTPUTFILENAME), TRUE);
     EnableWindow(GetDlgItem(hWnd, IDC_SELECT_OUTPUTFILE), TRUE);
 
-    SetDlgItemText(hWnd, IDC_OUTPUTFILENAME, outputFilename);
+    SetDlgItemTextW(hWnd, IDC_OUTPUTFILENAME, outputFilename);
 
     wsprintf(szTemp, "%iHz %ich", sampleRate, numChannels);
     SetDlgItemText(hWnd, IDC_INPUTPARAMS, szTemp);
@@ -122,11 +123,18 @@ static DWORD WINAPI EncodeFile(LPVOID pParam)
     HWND hWnd = (HWND) pParam;
     pcmfile_t *infile = NULL;
 
-    GetDlgItemText(hWnd, IDC_INPUTFILENAME, inputFilename, sizeof(inputFilename));
-    GetDlgItemText(hWnd, IDC_OUTPUTFILENAME, outputFilename, sizeof(outputFilename));
+    GetDlgItemTextW(hWnd, IDC_INPUTFILENAME, inputFilename, sizeof(inputFilename) / sizeof(WCHAR));
+    GetDlgItemTextW(hWnd, IDC_OUTPUTFILENAME, outputFilename, sizeof(outputFilename) / sizeof(WCHAR));
+
+    char *utf8_input = win32_utf16_to_utf8(inputFilename);
+    if (utf8_input)
+    {
+        infile = wav_open_read(utf8_input, 0);
+        free(utf8_input);
+    }
 
     /* open the input file */
-    if ((infile = wav_open_read(inputFilename, 0)) != NULL)
+    if (infile != NULL)
     {
         /* determine input file parameters */
         unsigned int sampleRate = infile->samplerate;
@@ -188,7 +196,7 @@ static DWORD WINAPI EncodeFile(LPVOID pParam)
 	    SetDlgItemText(hWnd, IDC_BANDWIDTH, szTemp);
 
             /* open the output file */
-            hOutfile = CreateFile(outputFilename, GENERIC_WRITE, 0, NULL,
+            hOutfile = CreateFileW(outputFilename, GENERIC_WRITE, 0, NULL,
                 CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 
             if (hOutfile != INVALID_HANDLE_VALUE)
@@ -351,7 +359,7 @@ static BOOL WINAPI DialogProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
     case WM_DROPFILES:
 
-        if (DragQueryFile((HDROP) wParam, 0, (LPSTR) inputFilename, _MAX_PATH - 1))
+        if (DragQueryFileW((HDROP) wParam, 0, inputFilename, _MAX_PATH - 1))
             AwakeDialogControls(hWnd);
 
         DragFinish((HDROP) wParam);
@@ -393,7 +401,7 @@ static BOOL WINAPI DialogProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
             if (SelectFileName(hWnd, outputFilename, FALSE))
             {
-                SetDlgItemText(hWnd, IDC_OUTPUTFILENAME, outputFilename);
+                SetDlgItemTextW(hWnd, IDC_OUTPUTFILENAME, outputFilename);
             }
 
             break;

--- a/frontend/meson.build
+++ b/frontend/meson.build
@@ -1,7 +1,20 @@
+libiconv = cc.find_library('iconv', required: false)
+has_iconv = cc.has_header('iconv.h') and cc.has_function('iconv_open', dependencies: [libiconv])
+
+faac_c_args = []
+if has_iconv
+    faac_c_args += '-DHAVE_ICONV'
+endif
+
+libshell32 = cc.find_library('shell32', required: target_machine.system() == 'windows')
+
 faac = executable('faac',
-    ['main.c', 'input.c', 'mp4write.c', 'output.c', 'input.h', 'mp4write.h', 'output.h'],
+    ['main.c', 'input.c', 'mp4write.c', 'output.c', 'charset.c',
+     'input.h', 'mp4write.h', 'output.h', 'charset.h'],
     include_directories: ['..', '../include'],
+    c_args: faac_c_args,
     link_with: libfaac,
+    dependencies: [libshell32, libiconv],
     install: true
 )
 
@@ -9,7 +22,7 @@ if target_machine.system() == 'windows'
     windows = import('windows')
     resource_src = windows.compile_resources('faacgui.rc', 'icon.rc')
     faacgui = executable('faacgui',
-        ['input.c', 'input.h', 'maingui.c', 'resource.h'] + resource_src,
+        ['input.c', 'input.h', 'maingui.c', 'charset.c', 'charset.h', 'resource.h'] + resource_src,
         include_directories: ['..', '../include'],
         link_with: libfaac,
         win_subsystem: 'windows',

--- a/frontend/mp4write.c
+++ b/frontend/mp4write.c
@@ -26,6 +26,7 @@
 #endif
 
 #include "mp4write.h"
+#include "charset.h"
 
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_bswap32) && __has_builtin(__builtin_bswap16)
@@ -348,8 +349,13 @@ int mp4_open(const char *path, bool overwrite) {
     reset_write_state(); /* in case of a retry after a failed previous mp4_open() */
     g_mem_error = 0;
 
+#ifdef _WIN32
+    if (!overwrite && win32_access_utf8(path, 0) == 0) return 1;
+    g_mp4.fout = win32_fopen_utf8(path, "wb");
+#else
     if (!overwrite && access(path, 0) == 0) return 1;
     g_mp4.fout = fopen(path, "wb");
+#endif
     if (!g_mp4.fout) return 1;
     setvbuf(g_mp4.fout, NULL, _IOFBF, MP4_IO_BUFSIZE);
 


### PR DESCRIPTION
This is a correctness fix for https://github.com/knik0/faac/issues/42 and is performance neutral

Adds cross-platform UTF-8 string handling and wide-character Win32 API support to the FAAC frontend CLI (`faac`) and GUI (`faacgui`). 

This resolves issues where non-ASCII file paths (e.g., unicode filenames, accented characters) failed to open on Windows, as well as character encoding corruption when reading/writing metadata tags from system locales.

## Changes
- **Charset Helpers (`frontend/charset.c`, `frontend/charset.h`)**:
  - Added `utf8_ensure()` to validate UTF-8 strings and attempt legacy locale repair via `iconv` (POSIX) or `MultiByteToWideChar` (Windows ACP).
  - Added Win32 UTF-8 wrapper functions: `win32_fopen_utf8`, `win32_access_utf8`, and `win32_mtime_utf8`.
- **CLI (`frontend/main.c`)**:
  - Converted Windows CLI entry to retrieve wide arguments via `CommandLineToArgvW` and map them to UTF-8.
  - Set `LC_CTYPE` on POSIX to enable proper codeset detection for `iconv`.
  - Wrapped metadata tag inputs through `utf8_ensure()` before passing to MP4 write functions.
- **GUI (`frontend/maingui.c`)**:
  - Migrated path buffers, file dialogs (`GetOpenFileNameW`, `GetSaveFileNameW`), control updates, and drag-and-drop handling (`DragQueryFileW`) to wide Win32 APIs.
  - Converted paths to UTF-8 dynamically before calling lower-level audio readers.
- **I/O & Build (`input.c`, `mp4write.c`, `meson.build`)**:
  - Swapped narrow CRT file calls with `win32_*_utf8` helpers on Windows.
  - Updated Meson build configuration to link `shell32` (Windows) and check for `iconv` (POSIX).

## Dependency Impact
- **Dependency Neutral:** No new third-party dependencies required across platforms.
  - **macOS / Linux:** POSIX environments provide `iconv` out of the box (either natively in `libc` on Linux or via system libraries on macOS). Meson probes for a standalone `libiconv` only as a fallback for niche environments.
  - **Windows:** Uses native Win32 APIs (`MultiByteToWideChar`, `WideCharToMultiByte`, `CommandLineToArgvW`) and standard system DLLs (`shell32`).
  
## Testing
Tested and verified on both **Windows** and **Linux**:
- [x] **Windows**: Verified non-ASCII/Unicode file paths open correctly in both CLI and GUI. Confirmed drag-and-drop and file selection dialogs process UTF-16 paths smoothly.
- [x] **Linux**: Verified compilation with `iconv` detection and confirmed metadata tag parsing works as expected under non-UTF-8 locales.
- [x] **Benchmark**: https://github.com/nschimme/faac/actions/runs/32676132998