### PR TITLE
frontend: fix GUI PCM clipping bug and MSVC warnings in input/mp4write

### DIFF
--- a/frontend/input.c
+++ b/frontend/input.c
@@ -251,11 +251,17 @@ pcmfile_t *wav_open_read(const char *name, bool rawinput)
   memset(sndf, 0, sizeof(*sndf));
   sndf->f = wave_f;
 
-  if (UINT16(wave.Format.wFormatTag) == WAVE_FORMAT_FLOAT) {
-    sndf->isfloat = true;
-  } else {
-    sndf->isfloat = (wave.SubFormat[0] == WAVE_FORMAT_FLOAT);
+  /* rawinput never populates `wave` (no header to parse), and raw mode has
+     no float flag of its own -- isfloat stays false, its memset() default. */
+  if (!rawinput)
+  {
+    if (UINT16(wave.Format.wFormatTag) == WAVE_FORMAT_FLOAT) {
+      sndf->isfloat = true;
+    } else {
+      sndf->isfloat = (wave.SubFormat[0] == WAVE_FORMAT_FLOAT);
+    }
   }
+
   if (rawinput)
   {
     sndf->bigendian = true;
@@ -475,87 +481,9 @@ size_t wav_read_float32(pcmfile_t *sndf, float *buf, size_t num, int *map)
   }
 
   if (map)
-    chan_remap((int32_t *)buf, sndf->channels, cnt / sndf->channels, map);
+    chan_remap((int32_t *)buf, sndf->channels, (int)(cnt / sndf->channels), map);
 
   return cnt;
-}
-
-size_t wav_read_int24(pcmfile_t *sndf, int32_t *buf, size_t num, int *map)
-{
-  int size;
-  int i;
-  uint8_t *bufi;
-
-  if ((sndf->samplebytes > 4) || (sndf->samplebytes < 1))
-    return 0;
-
-  bufi = (uint8_t *)buf + sizeof(*buf) * num - sndf->samplebytes * (num - 1) - sizeof(*buf);
-
-  size = fread(bufi, sndf->samplebytes, num, sndf->f);
-
-  // convert to 24 bit
-  // fix endianness
-  switch (sndf->samplebytes) {
-  case 1:
-    /* this is endian clean */
-    for (i = 0; i < size; i++)
-      buf[i] = (bufi[i] - 128) * 65536;
-    break;
-
-  case 2:
-    {
-      int swap = sndf->swap;
-      int16_t *in = (int16_t *)bufi;
-      if (swap)
-      {
-        for (i = 0; i < size; i++)
-          buf[i] = ((uint32_t)SWAP16(in[i])) << 8;
-      }
-      else
-      {
-        for (i = 0; i < size; i++)
-          buf[i] = ((int32_t)in[i]) << 8;
-      }
-    }
-    break;
-
-  case 3:
-    if (!sndf->bigendian)
-    {
-      for (i = 0; i < size; i++)
-      {
-	int s = bufi[3 * i] | (bufi[3 * i + 1] << 8) | (bufi[3 * i + 2] << 16);
-	if (s & 0x800000) s |= 0xff000000;
-	buf[i] = s;
-      }
-    }
-    else // big endian input
-    {
-      for (i = 0; i < size; i++)
-      {
-	int s = (bufi[3 * i] << 16) | (bufi[3 * i + 1] << 8) | bufi[3 * i + 2];
-	if (s & 0x800000) s |= 0xff000000;
-	buf[i] = s;
-      }
-    }
-    break;
-
-  case 4:
-    {
-      int swap = sndf->swap;
-      if (swap)
-      {
-        for (i = 0; i < size; i++)
-          buf[i] = SWAP32(buf[i]);
-      }
-    }
-    break;
-  }
-
-  if (map)
-    chan_remap(buf, sndf->channels, size / sndf->channels, map);
-
-  return size;
 }
 
 int wav_close(pcmfile_t *sndf)

--- a/frontend/input.h
+++ b/frontend/input.h
@@ -44,11 +44,10 @@ typedef struct
 
 pcmfile_t *wav_open_read(const char *path, bool rawchans);
 size_t wav_read_float32(pcmfile_t *sndf, float *buf, size_t num, int *map);
-size_t wav_read_int24(pcmfile_t *sndf, int32_t *buf, size_t num, int *map);
 int wav_close(pcmfile_t *file);
 
 /* Create channel remapping array for multi-channel input, consumed by
-   wav_read_float32()/wav_read_int24()'s internal chan_remap(). */
+   wav_read_float32()'s internal chan_remap(). */
 int *mk_chan_map(uint16_t channels, uint16_t center, uint16_t lf);
 
 #ifdef __cplusplus

--- a/frontend/maingui.c
+++ b/frontend/maingui.c
@@ -151,7 +151,7 @@ static DWORD WINAPI EncodeFile(LPVOID pParam)
         faac_params_init(&params, sizeof(params));
         params.sample_rate  = sampleRate;
         params.num_channels = numChannels;
-        params.input_format = FAAC_INPUT_32BIT;   /* wav_read_int24 -> 24-in-32 int */
+        params.input_format = FAAC_INPUT_FLOAT;   /* wav_read_float32 -> scaled float */
         {
             HWND hOT = GetDlgItem(hWnd, IDC_OBJECTTYPE);
             LRESULT sel  = SendMessage(hOT, CB_GETCURSEL, 0, 0);
@@ -206,12 +206,12 @@ static DWORD WINAPI EncodeFile(LPVOID pParam)
 
                 unsigned int bytesInput = 0;
                 DWORD numberOfBytesWritten = 0;
-                int *pcmbuf;
+                float *pcmbuf;
                 unsigned char *bitbuf;
                 char HeaderText[50];
                 char Percentage[5];
 
-                pcmbuf = (int*)LocalAlloc(0, inputSamples*sizeof(int));
+                pcmbuf = (float*)LocalAlloc(0, inputSamples*sizeof(float));
                 bitbuf = (unsigned char*)LocalAlloc(0, maxOutputBytes*sizeof(unsigned char));
 
                 SendDlgItemMessage(hWnd, IDC_PROGRESS, PBM_SETRANGE, 0, MAKELPARAM(0, 1024));
@@ -222,7 +222,7 @@ static DWORD WINAPI EncodeFile(LPVOID pParam)
                     int bytesWritten;
                     UINT timeElapsed, timeEncoded;
 
-                    bytesInput = wav_read_int24(infile, pcmbuf, inputSamples, NULL) * sizeof(int);
+                    bytesInput = wav_read_float32(infile, pcmbuf, inputSamples, NULL) * sizeof(float);
 
                     SendDlgItemMessage (hWnd, IDC_PROGRESS, PBM_SETPOS, (unsigned long)((float)totalBytesRead * 1024.0f / (infile->samples*sizeof(int)*numChannels)), 0);
 
@@ -264,7 +264,7 @@ static DWORD WINAPI EncodeFile(LPVOID pParam)
                         uint32_t nbytes = 0;
                         faac_status st = faac_encoder_encode(hEncoder,
                             pcmbuf,
-                            (uint32_t)(bytesInput/sizeof(int)),
+                            (uint32_t)(bytesInput/sizeof(float)),
                             bitbuf,
                             (uint32_t)maxOutputBytes,
                             &nbytes);

--- a/frontend/mp4write.c
+++ b/frontend/mp4write.c
@@ -667,8 +667,11 @@ int mp4_finish(void) {
     long mp4a = start_atom("mp4a");
     put_u8(0); put_u8(0); put_u8(0); put_u8(0); put_u8(0); put_u8(0);
     put_u16(1); put_u32(0); put_u32(0);
-    put_u16(g_mp4.channels); put_u16(g_mp4.bits);
-    put_u16(0); put_u16(0); put_u16(g_mp4.samplerate); put_u16(0);
+    put_u16((uint16_t)g_mp4.channels); put_u16((uint16_t)g_mp4.bits);
+    /* Field is 16-bit; the real rate lives in mdhd and the decoder config. */
+    put_u16(0); put_u16(0);
+    put_u16((uint16_t)(g_mp4.samplerate > UINT16_MAX ? UINT16_MAX : g_mp4.samplerate));
+    put_u16(0);
 
     long esds = start_atom("esds");
     put_u32(0);
@@ -681,7 +684,7 @@ int mp4_finish(void) {
     put_u8(MP4_OBJECT_TYPE_AUDIO_ISO_14496_3); put_u8(MP4_STREAM_TYPE_AUDIO);
     put_u8((uint8_t)(MP4_DECODER_BUFFER_SIZE >> 16));
     put_u8((uint8_t)(MP4_DECODER_BUFFER_SIZE >> 8));
-    put_u8((uint8_t)MP4_DECODER_BUFFER_SIZE);
+    put_u8((uint8_t)(MP4_DECODER_BUFFER_SIZE & 0xff));
     put_u32(g_mp4.bitrate.max); put_u32(g_mp4.bitrate.avg);
     put_descriptor(5, g_mp4.asc.size);
     put_data(g_mp4.asc.data, g_mp4.asc.size);

--- a/meson.build
+++ b/meson.build
@@ -10,11 +10,16 @@ project('faac', 'c',
 
 add_global_arguments('-DHAVE_CONFIG_H', language: 'c')
 
+cc = meson.get_compiler('c')
+if cc.get_argument_syntax() == 'msvc'
+    # _s variants buy nothing here and aren't portable; suppress instead.
+    add_global_arguments('-D_CRT_SECURE_NO_WARNINGS', language: 'c')
+endif
+
 config_h = configuration_data()
 config_h.set_quoted('PACKAGE', meson.project_name())
 config_h.set_quoted('PACKAGE_VERSION', meson.project_version())
 
-cc = meson.get_compiler('c')
 foreach h: ['getopt.h', 'immintrin.h']
     config_h.set('HAVE_' + h.underscorify().to_upper(), cc.has_header(h))
 endforeach


### PR DESCRIPTION
This is a correctness PR.

This PR addresses an audio clipping bug in the Win32 GUI frontend and resolves several MSVC build warnings across `frontend/` and `meson.build`.

---

### Key Changes

* **Fix GUI Audio Clipping (`maingui.c`):**
  * Switched `EncodeFile()` from `wav_read_int24()` / `FAAC_INPUT_32BIT` to `wav_read_float32()` / `FAAC_INPUT_FLOAT`.
  * *Reasoning:* For true 32-bit WAV input, `FAAC_INPUT_32BIT` expected a $\pm 2^{23}$ range but received raw $\pm 2^{31}$ values, overscaling input by 256× and causing hard clipping. This aligns the GUI pipeline with the existing CLI implementation. Tested and verified with a 96 kHz test WAV.

* **Remove Dead Code (`input.c`, `input.h`):**
  * Removed `wav_read_int24()` and its header declaration as it no longer has active callers.

* **Fix Uninitialized Stack Read (`input.c`):**
  * Bypassed the `wave.Format.wFormatTag` check in `wav_open_read()` when `rawinput` is `true`.
  * *Reasoning:* Raw PCM mode never populates the `wave` header struct, leading to a read of uninitialized stack memory (`MSVC C4701`).

* **Fix Truncation & Silence Compiler Warnings (`mp4write.c`, `input.c`):**
  * Clamped legacy 16-bit `AudioSampleEntry` sample rate to `65535` instead of wrapping modulo 65536 (`MSVC C4244`).
  * Masked low byte on 24-bit buffer size writes (`MSVC C4310`).
  * Cast `size_t` to `int` in `chan_remap()` call site (`MSVC C4267`).

* **Build System (`meson.build`):**
  * Suppressed MSVC CRT secure deprecation warnings (`-D_CRT_SECURE_NO_WARNINGS`) for `strdup`, `sscanf`, and `getenv`, as non-portable `_s` replacements offer no benefit in these paths.

---

### Verification
* Encoded 96 kHz / 32-bit WAV via the Win32 GUI interface; confirmed output audio no longer exhibits hard clipping.
* Clean build achieved under MSVC with targeted C4701, C4267, C4244, C4310, and CRT deprecation warnings resolved.