### PR TITLE
frontend: extract shared encoding engine and add GUI MP4 support

### DIFF
--- a/frontend/encode_engine.c
+++ b/frontend/encode_engine.c
@@ -1,0 +1,767 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2001 Menno Bakker
+ * Copyright (C) 2002-2017 Krzysztof Nikiel
+ * Copyright (C) 2004 Dan Villiom P. Christiansen
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <time.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <stdarg.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#else
+#include <sys/time.h>
+#endif
+
+#include "encode_engine.h"
+#include "input.h"
+#include "mp4write.h"
+#include "charset.h"
+
+void init_encode_options(encode_options_t *opts)
+{
+    if (!opts)
+        return;
+
+    memset(opts, 0, sizeof(*opts));
+    opts->mpeg_version = FAAC_MPEG4;
+    opts->object_type = FAAC_OBJ_AUTO;
+    opts->joint_mode = FAAC_JOINT_MIXED;
+    opts->stream_format = FAAC_STREAM_ADTS;
+    opts->shortctl = FAAC_SHORTCTL_NORMAL;
+    opts->use_tns = false;
+    opts->use_lfe = -1;
+    opts->pns_level = -1;
+    opts->quant_quality = 0;
+    opts->bit_rate = DEFAULT_ABR_KBPS * 1000;
+    opts->center_channel = 3;
+    opts->lfe_channel = 4;
+    opts->raw_bits = 16;
+    opts->raw_rate = 44100;
+    opts->raw_endian = true;
+    opts->verbose = 1;
+}
+
+bool add_custom_tag_to_options(encode_options_t *opts, const char *name, const char *value)
+{
+    if (!opts || !name || !value)
+        return false;
+
+    if (opts->custom_tag_count >= opts->custom_tag_cap)
+    {
+        uint16_t new_cap = opts->custom_tag_cap ? (uint16_t)(opts->custom_tag_cap * 2) : 4;
+        custom_tag_t *tmp = realloc(opts->custom_tags, (size_t)new_cap * sizeof(custom_tag_t));
+        if (!tmp)
+            return false;
+        opts->custom_tags = tmp;
+        opts->custom_tag_cap = new_cap;
+    }
+
+    char *dup_name = strdup(name);
+    char *dup_val = utf8_ensure(value);
+    if (!dup_name || !dup_val)
+    {
+        free(dup_name);
+        free(dup_val);
+        return false;
+    }
+
+    opts->custom_tags[opts->custom_tag_count].name = dup_name;
+    opts->custom_tags[opts->custom_tag_count].value = dup_val;
+    opts->custom_tag_count++;
+    return true;
+}
+
+void free_encode_options(encode_options_t *opts)
+{
+    if (!opts)
+        return;
+
+    if (opts->art_data)
+    {
+        free((void *)opts->art_data);
+        opts->art_data = NULL;
+        opts->art_size = 0;
+    }
+
+    for (uint32_t i = 0; i < opts->custom_tag_count; i++)
+    {
+        free(opts->custom_tags[i].name);
+        free(opts->custom_tags[i].value);
+    }
+    free(opts->custom_tags);
+    opts->custom_tags = NULL;
+    opts->custom_tag_count = 0;
+    opts->custom_tag_cap = 0;
+}
+
+void parse_quality_or_bitrate(const char *text, bool is_bitrate_mode,
+                               encode_options_t *opts)
+{
+    int val = text ? atoi(text) : 0;
+
+    if (is_bitrate_mode)
+    {
+        opts->bit_rate = (val > 0) ? (uint32_t)(val * 1000) : DEFAULT_ABR_KBPS * 1000;
+        opts->quant_quality = 0;
+    }
+    else
+    {
+        opts->quant_quality = (val > 0) ? (uint16_t)val : DEFAULT_QUANT_QUALITY;
+        opts->bit_rate = 0;
+    }
+}
+
+static double calc_speed(uint64_t current_sample, unsigned int sample_rate, double time_used)
+{
+    if (time_used <= 0.0 || sample_rate == 0)
+        return 0.0;
+
+    return ((double)current_sample / (double)sample_rate) / time_used;
+}
+
+static double calc_eta(uint64_t current_sample, uint64_t total_samples, double time_used)
+{
+    if (current_sample == 0 || time_used <= 0.0 || total_samples < current_sample)
+        return 0.0;
+
+    return time_used * (double)(total_samples - current_sample) / (double)current_sample;
+}
+
+static double get_wall_time_sec(void)
+{
+#ifdef _WIN32
+    return (double)GetTickCount() / 1000.0;
+#else
+#ifdef CLOCK_MONOTONIC
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
+        return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+#endif
+    struct timeval tv;
+    if (gettimeofday(&tv, NULL) == 0)
+        return (double)tv.tv_sec + (double)tv.tv_usec * 1e-6;
+    return (double)clock() / CLOCKS_PER_SEC;
+#endif
+}
+
+static inline bool write_output_bytes(FILE *outfile, const unsigned char *buf, size_t size)
+{
+    return outfile && (fwrite(buf, 1, size, outfile) == size);
+}
+
+static progress_info_t build_progress_info(uint64_t current_input_samples,
+                                            uint64_t total_input_samples,
+                                            uint32_t sample_rate, uint16_t num_channels,
+                                            uint32_t current_frame, uint32_t total_frames,
+                                            uint64_t total_bytes_written, double time_used,
+                                            bool is_final)
+{
+    return (progress_info_t){
+        .current_input_samples = current_input_samples,
+        .total_input_samples = total_input_samples,
+        .sample_rate = sample_rate,
+        .num_channels = num_channels,
+        .current_frame = current_frame,
+        .total_frames = total_frames,
+        .total_bytes_written = total_bytes_written,
+        .time_elapsed_sec = time_used,
+        .speed_factor = calc_speed(current_input_samples, sample_rate, time_used),
+        .eta_sec = is_final ? 0.0 : calc_eta(current_input_samples, total_input_samples, time_used),
+        .is_final = is_final
+    };
+}
+
+static void finalize_log(log_message_callback_t log_cb, void *user_data,
+                          int level, const char *fmt, ...)
+{
+    char msg[512];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
+
+    if (log_cb)
+        log_cb(level, msg, user_data);
+    else
+        fputs(msg, stderr);
+}
+
+/* Unlike finalize_log(), silent (not stderr) when log_cb is NULL: these
+   call sites should only ever log through a caller-supplied callback, and
+   run_encoding_session()'s callback-less public wrapper relies on that
+   silence. */
+static void log_msgf(log_message_callback_t log_cb, void *user_data,
+                      int level, const char *fmt, ...)
+{
+    if (!log_cb)
+        return;
+
+    char msg[256];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
+    log_cb(level, msg, user_data);
+}
+
+static bool finalize_mp4(faac_encoder *hEncoder, const encode_options_t *opts,
+                          log_message_callback_t log_cb, void *user_data)
+{
+    char *allocated_tags[MP4TAG_COUNT + 1] = { 0 };
+    int num_allocated = 0;
+
+    faac_library_info libinfo = { .struct_size = sizeof(libinfo) };
+    faac_get_library_info(&libinfo);
+
+    const uint8_t *asc_data = NULL;
+    uint32_t asc_size = 0;
+    if (hEncoder)
+    {
+        faac_encoder_asc(hEncoder, &asc_data, &asc_size);
+        mp4_set_decoder_config((unsigned char *)asc_data, asc_size);
+    }
+    uint32_t creation_time = 0;
+    if (opts->creation_time_str)
+    {
+        if (!strcmp(opts->creation_time_str, "auto"))
+        {
+            if (opts->input_filename && strcmp(opts->input_filename, "-") != 0)
+            {
+                time_t mtime;
+#ifdef _WIN32
+                bool ok = win32_mtime_utf8(opts->input_filename, &mtime) == 0;
+#else
+                struct stat st;
+                bool ok = stat(opts->input_filename, &st) == 0;
+                mtime = st.st_mtime;
+#endif
+                if (ok)
+                {
+                    creation_time = (uint32_t)mtime;
+                }
+                else if (opts->verbose)
+                {
+                    finalize_log(log_cb, user_data, 0, "couldn't stat() input file %s, defaulting to 0\n", opts->input_filename);
+                }
+            }
+            else if (opts->verbose)
+            {
+                finalize_log(log_cb, user_data, 0, "cannot use --creation-time auto with stdin, defaulting to 0\n");
+            }
+        }
+        else if (!strcmp(opts->creation_time_str, "now"))
+        {
+            creation_time = (uint32_t)time(NULL);
+        }
+        else
+        {
+            char *endptr;
+            errno = 0;
+            creation_time = (uint32_t)strtoul(opts->creation_time_str, &endptr, 10);
+            if (errno != 0 || *endptr != '\0')
+            {
+                if (opts->verbose)
+                    finalize_log(log_cb, user_data, 0, "invalid creation time %s, defaulting to 0\n", opts->creation_time_str);
+                creation_time = 0;
+            }
+        }
+        mp4_set_creation_time(creation_time);
+    }
+    else
+    {
+        const char *sde = getenv("SOURCE_DATE_EPOCH");
+        if (sde)
+        {
+            char *endptr;
+            errno = 0;
+            creation_time = (uint32_t)strtoul(sde, &endptr, 10);
+            if (errno != 0 || *endptr != '\0')
+            {
+                if (opts->verbose)
+                    finalize_log(log_cb, user_data, 0, "invalid SOURCE_DATE_EPOCH %s, ignoring\n", sde);
+                creation_time = 0;
+            }
+        }
+        mp4_set_creation_time(creation_time);
+    }
+
+    if (opts->art_data && opts->art_size > 0)
+    {
+        mp4_set_cover(opts->art_data, (int)opts->art_size);
+    }
+
+    mp4_metadata_t metadata = opts->metadata;
+
+    if (libinfo.version)
+    {
+        size_t ver_len = strlen(libinfo.version) + 6;
+        char *version_string = malloc(ver_len);
+        if (version_string)
+        {
+            snprintf(version_string, ver_len, "FAAC %s", libinfo.version);
+            metadata.encoder = version_string;
+            allocated_tags[num_allocated++] = version_string;
+        }
+    }
+
+#define SETTAG(id, x) \
+    do { \
+        if (x) { \
+            char *utf8_val = utf8_ensure(x); \
+            mp4_set_tag(id, utf8_val); \
+            if (utf8_val && num_allocated < (int)(sizeof(allocated_tags) / sizeof(allocated_tags[0]))) \
+                allocated_tags[num_allocated++] = utf8_val; \
+            else if (utf8_val) \
+                free(utf8_val); \
+        } \
+    } while (0)
+
+    SETTAG(MP4TAG_ARTIST, metadata.artist);
+    SETTAG(MP4TAG_ARTISTSORT, metadata.artist_sort);
+    SETTAG(MP4TAG_COMPOSER, metadata.composer);
+    SETTAG(MP4TAG_COMPOSERSORT, metadata.composer_sort);
+    SETTAG(MP4TAG_TITLE, metadata.title);
+    SETTAG(MP4TAG_ALBUM, metadata.album);
+    SETTAG(MP4TAG_ALBUMARTIST, metadata.album_artist);
+    SETTAG(MP4TAG_ALBUMARTISTSORT, metadata.album_artist_sort);
+    SETTAG(MP4TAG_ALBUMSORT, metadata.album_sort);
+    SETTAG(MP4TAG_YEAR, metadata.year);
+    SETTAG(MP4TAG_COMMENT, metadata.comment);
+#undef SETTAG
+
+    if (metadata.encoder) mp4_set_encoder(metadata.encoder);
+    if (metadata.language) mp4_set_language(metadata.language);
+    if (metadata.track) mp4_set_track(metadata.track, metadata.ntracks);
+    if (metadata.disc) mp4_set_disc(metadata.disc, metadata.ndiscs);
+    if (metadata.compilation) mp4_set_compilation(metadata.compilation);
+    if (metadata.genre_id) mp4_set_genre(metadata.genre_id);
+
+    for (uint32_t i = 0; i < opts->custom_tag_count; i++)
+    {
+        if (opts->custom_tags[i].name && opts->custom_tags[i].value)
+        {
+            char *utf8_val = utf8_ensure(opts->custom_tags[i].value);
+            if (utf8_val)
+            {
+                mp4_add_custom_tag(opts->custom_tags[i].name, utf8_val);
+                free(utf8_val);
+            }
+        }
+    }
+
+    bool ok = mp4_finish() == 0;
+    if (!ok)
+    {
+        finalize_log(log_cb, user_data, 1, "mp4_finish() failed: output file may be incomplete\n");
+    }
+
+    for (int i = 0; i < num_allocated; i++)
+    {
+        free(allocated_tags[i]);
+    }
+
+    return ok;
+}
+
+int run_encoding_session(const encode_options_t *opts,
+                          progress_callback_t progress_cb,
+                          void *user_data)
+{
+    encode_callbacks_t cbs;
+    memset(&cbs, 0, sizeof(cbs));
+    cbs.progress_cb = progress_cb;
+    cbs.user_data = user_data;
+    return run_encoding_session_ext(opts, &cbs);
+}
+
+int run_encoding_session_ext(const encode_options_t *opts,
+                              const encode_callbacks_t *callbacks)
+{
+    if (!opts || !opts->input_filename)
+        return 1;
+
+    progress_callback_t progress_cb = callbacks ? callbacks->progress_cb : NULL;
+    session_start_callback_t session_start_cb = callbacks ? callbacks->session_start_cb : NULL;
+    summary_callback_t summary_cb = callbacks ? (callbacks->summary_cb ? callbacks->summary_cb : callbacks->mp4_summary_cb) : NULL;
+    log_message_callback_t log_cb = callbacks ? callbacks->log_cb : NULL;
+    void *user_data = callbacks ? callbacks->user_data : NULL;
+
+    pcmfile_t *infile = NULL;
+    faac_encoder *hEncoder = NULL;
+    FILE *outfile = NULL;
+
+    float *pcmbuf = NULL;
+    unsigned char *bitbuf = NULL;
+    int *chanmap = NULL;
+
+    int ret = 0;
+    bool mp4_is_open = false;
+
+/* Relies on the ret/log_cb/user_data locals above; scoped to this function
+   with the #undef at its end. */
+#define FAIL(...) \
+    do { \
+        log_msgf(log_cb, user_data, 1, __VA_ARGS__); \
+        ret = 1; \
+        goto cleanup; \
+    } while (0)
+
+    if (opts->raw_pcm_input)
+    {
+        infile = wav_open_read(opts->input_filename, 1);
+        if (infile)
+        {
+            infile->bigendian = opts->raw_endian;
+            infile->channels = opts->raw_channels > 0 ? opts->raw_channels : 2;
+            infile->samplebytes = opts->raw_bits / 8;
+            infile->samplerate = opts->raw_rate;
+            infile->samples /= (infile->channels * infile->samplebytes);
+        }
+    }
+    else
+    {
+        infile = wav_open_read(opts->input_filename, 0);
+    }
+
+    if (!infile)
+        FAIL("Couldn't open input file %s\n", opts->input_filename);
+
+    uint32_t sample_rate = infile->samplerate;
+    uint16_t num_channels = (uint16_t)infile->channels;
+
+    faac_library_info libinfo = { .struct_size = sizeof(libinfo) };
+    faac_get_library_info(&libinfo);
+    if (num_channels > libinfo.max_channels)
+        FAIL("Input file %s has %u channels, but this build supports at most %u.\n",
+             opts->input_filename, num_channels, libinfo.max_channels);
+
+    faac_params params;
+    faac_params_init(&params, sizeof(params));
+    params.sample_rate = sample_rate;
+    params.num_channels = num_channels;
+    params.mpeg_version = opts->mpeg_version;
+    params.object_type = opts->object_type;
+    params.joint_mode = opts->joint_mode;
+    params.use_tns = opts->use_tns;
+    params.use_lfe = (opts->use_lfe != -1) ? (opts->use_lfe != 0) : (num_channels >= 6);
+    params.short_control = opts->shortctl;
+    if (opts->pns_level >= 0)
+        params.pns_level = opts->pns_level;
+
+    if (opts->quant_quality > 0 && opts->bit_rate == 0)
+    {
+        params.quant_quality = opts->quant_quality;
+        params.bit_rate = 0;
+    }
+    else if (opts->bit_rate > 0)
+    {
+        params.bit_rate = opts->bit_rate / (num_channels ? num_channels : 1);
+        params.quant_quality = 0;
+    }
+
+    if (opts->max_bit_rate > 0)
+        params.max_bit_rate = opts->max_bit_rate;
+
+    if (log_cb)
+    {
+        if (opts->shortctl == FAAC_SHORTCTL_NOSHORT)
+            log_cb(1, "disabling short blocks\n", user_data);
+        else if (opts->shortctl == FAAC_SHORTCTL_NOLONG)
+            log_cb(1, "disabling long blocks\n", user_data);
+
+        if (opts->pns_level > 0 && opts->mpeg_version == FAAC_MPEG2)
+            log_cb(1, "PNS not allowed in MPEG-2 mode, disabling PNS\n", user_data);
+    }
+
+    params.bandwidth = opts->bandwidth;
+    params.output_format = opts->container_mp4 ? FAAC_STREAM_RAW : opts->stream_format;
+    params.input_format = FAAC_INPUT_FLOAT;
+
+    if (faac_encoder_open(&params, &hEncoder) != FAAC_OK)
+        FAIL("Couldn't open encoder instance for %s\n", opts->input_filename);
+
+    faac_encoder_info info = { .struct_size = sizeof(info) };
+    faac_encoder_get_info(hEncoder, &info);
+
+    unsigned long samples_per_frame = (unsigned long)info.frame_samples * num_channels;
+    unsigned long max_output_bytes = info.max_output_bytes;
+    uint16_t frame_size = (uint16_t)(samples_per_frame / num_channels);
+
+    pcmbuf = malloc(samples_per_frame * sizeof(float));
+    bitbuf = malloc(max_output_bytes * sizeof(unsigned char));
+
+    if (!pcmbuf || !bitbuf)
+        FAIL("Out of memory!\n");
+
+    chanmap = mk_chan_map(num_channels, opts->center_channel, opts->lfe_channel);
+    if (chanmap && log_cb)
+    {
+        char msg[256];
+        snprintf(msg, sizeof(msg), "Remapping input channels: Center=%u, LFE=%u\n",
+                opts->center_channel, opts->lfe_channel);
+        log_cb(1, msg, user_data);
+    }
+
+    if (opts->container_mp4)
+    {
+        if (opts->output_filename && !strcmp(opts->output_filename, "-"))
+            FAIL("Cannot encode MP4 to stdout\n");
+
+        if (mp4_open(opts->output_filename, opts->overwrite) != 0)
+            FAIL("Couldn't create MP4 output file %s\n", opts->output_filename);
+        mp4_is_open = true;
+        mp4_set_format(sample_rate, num_channels, infile->samplebytes * 8);
+    }
+    else if (opts->output_filename)
+    {
+        if (!strcmp(opts->output_filename, "-"))
+        {
+            outfile = stdout;
+#ifdef _WIN32
+            _setmode(_fileno(stdout), _O_BINARY);
+#endif
+        }
+        else
+        {
+#ifdef _WIN32
+            outfile = win32_fopen_utf8(opts->output_filename, "wb");
+#else
+            outfile = fopen(opts->output_filename, "wb");
+#endif
+            if (!outfile)
+                FAIL("Couldn't create output file %s\n", opts->output_filename);
+        }
+    }
+
+    uint64_t total_input_samples = (infile->samples > 0) ? (uint64_t)infile->samples : 0;
+    uint64_t tf_calc = (total_input_samples > 0 && frame_size > 0) ?
+        (((total_input_samples + frame_size - 1) / frame_size) + 1) : 0;
+    uint32_t total_frames = (tf_calc > UINT32_MAX) ? UINT32_MAX : (uint32_t)tf_calc;
+
+    if (session_start_cb)
+    {
+        encode_session_info_t sess_info = {
+            .input_filename = opts->input_filename,
+            .output_filename = opts->output_filename,
+            .sample_rate = sample_rate,
+            .num_channels = num_channels,
+            .total_input_samples = total_input_samples,
+            .frame_size = frame_size,
+
+            .container_mp4 = opts->container_mp4,
+            .stream_format = opts->stream_format,
+            .mpeg_version = opts->mpeg_version,
+            .object_type = info.object_type,
+            .joint_mode = params.joint_mode,
+            .use_tns = params.use_tns,
+            .pns_level = (int8_t)info.pns_level,
+            .bandwidth = info.bandwidth,
+            .quant_quality = (uint16_t)info.quant_quality,
+            .bit_rate = info.bit_rate,
+
+            .remapping_channels = (chanmap != NULL),
+            .center_channel = opts->center_channel,
+            .lfe_channel = opts->lfe_channel,
+            .shortctl = opts->shortctl
+        };
+        session_start_cb(&sess_info, user_data);
+    }
+
+    uint32_t current_frame = 0;
+    uint64_t total_bytes_written = 0;
+    uint64_t current_input_samples = 0;
+    uint64_t encoded_samples = 0;
+    uint16_t max_frame_bytes = 0;
+    int samples_read = 0;
+
+    double start_time = get_wall_time_sec();
+
+    bool input_eof = false;
+
+    for (;;)
+    {
+        int bytes_written = 0;
+
+        if (!input_eof)
+        {
+            if (!opts->ignore_wav_length)
+            {
+                if (current_input_samples < total_input_samples || total_input_samples == 0)
+                {
+                    samples_read = (int)wav_read_float32(infile, pcmbuf, samples_per_frame, chanmap);
+                }
+                else
+                {
+                    samples_read = 0;
+                }
+
+                if (total_input_samples > 0 &&
+                    current_input_samples + (samples_read / num_channels) > total_input_samples)
+                {
+                    samples_read = (int)((total_input_samples - current_input_samples) * num_channels);
+                }
+            }
+            else
+            {
+                samples_read = (int)wav_read_float32(infile, pcmbuf, samples_per_frame, chanmap);
+            }
+
+            if (samples_read == 0)
+                input_eof = true;
+            else
+                current_input_samples += (samples_read / num_channels);
+        }
+
+        uint32_t nbytes = 0;
+        faac_status st = faac_encoder_encode(hEncoder,
+                                             input_eof ? NULL : pcmbuf,
+                                             input_eof ? 0 : (uint32_t)samples_read,
+                                             bitbuf,
+                                             (uint32_t)max_output_bytes,
+                                             &nbytes);
+        bytes_written = (st == FAAC_OK) ? (int)nbytes : -1;
+
+        if (bytes_written > 0)
+        {
+            current_frame++;
+            total_bytes_written += bytes_written;
+            if ((uint16_t)bytes_written > max_frame_bytes)
+                max_frame_bytes = (uint16_t)bytes_written;
+        }
+
+        if (input_eof && bytes_written <= 0)
+            break;
+
+        if (bytes_written < 0)
+            FAIL("faac_encoder_encode() failed: %s\n", faac_strerror(st));
+
+        if (bytes_written > 0)
+        {
+            uint64_t frame_samples = current_input_samples - encoded_samples;
+            if (frame_samples > frame_size)
+                frame_samples = frame_size;
+
+            if (opts->container_mp4)
+            {
+                if (mp4_write_frame(bitbuf, (uint32_t)bytes_written, (uint32_t)frame_samples) != 0)
+                    FAIL("mp4_write_frame() failed\n");
+            }
+            else
+            {
+                if (!write_output_bytes(outfile, bitbuf, (size_t)bytes_written))
+                    FAIL("Output write failed\n");
+            }
+
+            encoded_samples += frame_samples;
+        }
+
+        if (progress_cb)
+        {
+            double time_used = get_wall_time_sec() - start_time;
+            progress_info_t prog = build_progress_info(current_input_samples, total_input_samples,
+                                                         sample_rate, num_channels, current_frame,
+                                                         total_frames, total_bytes_written, time_used,
+                                                         false);
+
+            if (!progress_cb(&prog, user_data))
+            {
+                ret = ENCODE_CANCELLED;
+                goto cleanup;
+            }
+        }
+    }
+
+    /* The in-loop progress_cb above can't know which call is last until
+       after it returns, so it can't set is_final itself. */
+    if (progress_cb)
+    {
+        double time_used = get_wall_time_sec() - start_time;
+        progress_info_t prog = build_progress_info(current_input_samples, total_input_samples,
+                                                     sample_rate, num_channels, current_frame,
+                                                     total_frames, total_bytes_written, time_used,
+                                                     true);
+        progress_cb(&prog, user_data);
+    }
+
+    if (opts->container_mp4 && mp4_is_open)
+    {
+        if (!finalize_mp4(hEncoder, opts, log_cb, user_data))
+        {
+            ret = 1;
+            goto cleanup;
+        }
+        if (summary_cb)
+        {
+            uint32_t max_kbps = (mp4_max_bitrate() + 500) / 1000;
+            uint32_t avg_kbps = (mp4_avg_bitrate() + 500) / 1000;
+            encode_summary_t summary = {
+                .frame_count = mp4_frame_count(),
+                .sample_count = mp4_sample_count(),
+                .max_bitrate = max_kbps,
+                .avg_bitrate = avg_kbps,
+                .max_frame_size = mp4_max_frame_size(),
+                .is_mp4 = true
+            };
+            summary_cb(&summary, user_data);
+        }
+    }
+    else if (summary_cb)
+    {
+        double total_sec = (double)current_input_samples / (double)(sample_rate ? sample_rate : 1);
+        uint32_t avg_bitrate = (total_sec > 0.0) ? (uint32_t)(((double)total_bytes_written * 8.0 / 1000.0) / total_sec) : 0;
+        encode_summary_t summary = {
+            .frame_count = current_frame,
+            .sample_count = current_input_samples,
+            .max_bitrate = 0,
+            .avg_bitrate = avg_bitrate,
+            .max_frame_size = max_frame_bytes,
+            .is_mp4 = false
+        };
+        summary_cb(&summary, user_data);
+    }
+
+cleanup:
+    if (pcmbuf) free(pcmbuf);
+    if (bitbuf) free(bitbuf);
+    if (chanmap) free(chanmap);
+
+    if (opts->container_mp4 && mp4_is_open)
+    {
+        mp4_close();
+        mp4_is_open = false;
+    }
+
+    if (outfile && outfile != stdout)
+        fclose(outfile);
+
+    if (hEncoder)
+        faac_encoder_close(&hEncoder);
+
+    if (infile)
+        wav_close(infile);
+
+#undef FAIL
+    return ret;
+}

--- a/frontend/encode_engine.h
+++ b/frontend/encode_engine.h
@@ -1,0 +1,187 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2001 Menno Bakker
+ * Copyright (C) 2002-2017 Krzysztof Nikiel
+ * Copyright (C) 2004 Dan Villiom P. Christiansen
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#ifndef ENCODE_ENGINE_H
+#define ENCODE_ENGINE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <faac.h>
+#include "progress.h"
+#include "mp4write.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Metadata structure for MP4 tags */
+typedef struct {
+    const char *artist;
+    const char *artist_sort;
+    const char *title;
+    const char *album;
+    const char *album_sort;
+    const char *album_artist;
+    const char *album_artist_sort;
+    const char *composer;
+    const char *composer_sort;
+    const char *year;
+    const char *comment;
+    const char *encoder;
+    const char *language;
+    uint16_t genre_id;
+    uint16_t track;
+    uint16_t ntracks;
+    uint16_t disc;
+    uint16_t ndiscs;
+    bool compilation;
+} mp4_metadata_t;
+
+typedef struct {
+    char *name;
+    char *value;
+} custom_tag_t;
+
+typedef struct {
+    const char *input_filename;
+    const char *output_filename;
+
+    bool container_mp4;
+    bool raw_pcm_input;
+    uint16_t raw_channels;
+    uint8_t raw_bits;
+    uint32_t raw_rate;
+    bool raw_endian;
+
+    uint16_t center_channel;
+    uint16_t lfe_channel;
+
+    enum faac_mpeg_version mpeg_version;
+    enum faac_object_type object_type;
+    enum faac_joint_mode joint_mode;
+    enum faac_stream_format stream_format;
+    enum faac_shortctl_mode shortctl;
+
+    bool use_tns;
+    int8_t use_lfe; /* -1 for auto (ch >= 6), 0 = false, 1 = true */
+    int8_t pns_level; /* -1 to leave default */
+
+    uint16_t quant_quality;
+    uint32_t bit_rate; /* total bitrate in bps (whole stream) */
+    uint32_t max_bit_rate; /* bps whole stream cap */
+    uint32_t bandwidth; /* cutoff frequency in Hz */
+
+    bool ignore_wav_length;
+    bool overwrite;
+
+    mp4_metadata_t metadata;
+    const char *creation_time_str;
+    const uint8_t *art_data;
+    uint64_t art_size;
+
+    custom_tag_t *custom_tags;
+    uint16_t custom_tag_count;
+    uint16_t custom_tag_cap;
+
+    uint8_t verbose;
+} encode_options_t;
+
+bool add_custom_tag_to_options(encode_options_t *opts, const char *name, const char *value);
+void free_encode_options(encode_options_t *opts);
+
+/* Canonical defaults, shared by both the CLI and GUI frontends. */
+#define DEFAULT_QUANT_QUALITY 100
+#define DEFAULT_ABR_KBPS      128
+
+void init_encode_options(encode_options_t *opts);
+
+/* Parse a quality-or-bitrate text field (as typed into the CLI's -q/-b or
+   the GUI's rate edit box) into opts->quant_quality/opts->bit_rate,
+   falling back to DEFAULT_QUANT_QUALITY/DEFAULT_ABR_KBPS on invalid/empty
+   input rather than silently producing 0. is_bitrate_mode selects which
+   field is being set and whether the value is in kbps (bitrate) or a raw
+   quality percentage. */
+void parse_quality_or_bitrate(const char *text, bool is_bitrate_mode,
+                               encode_options_t *opts);
+
+#define ENCODE_SUCCESS   0
+#define ENCODE_ERROR     1
+#define ENCODE_CANCELLED 2
+
+typedef struct {
+    const char *input_filename;
+    const char *output_filename;
+    uint32_t sample_rate;
+    uint16_t num_channels;
+    uint64_t total_input_samples;
+    uint16_t frame_size;
+
+    bool container_mp4;
+    enum faac_stream_format stream_format;
+    enum faac_mpeg_version mpeg_version;
+    enum faac_object_type object_type;
+    enum faac_joint_mode joint_mode;
+    bool use_tns;
+    int8_t pns_level;
+    uint32_t bandwidth;
+    uint16_t quant_quality;
+    uint32_t bit_rate; /* bps per channel */
+
+    bool remapping_channels;
+    uint16_t center_channel;
+    uint16_t lfe_channel;
+    enum faac_shortctl_mode shortctl;
+} encode_session_info_t;
+
+typedef struct {
+    uint32_t frame_count;
+    uint64_t sample_count;
+    uint32_t max_bitrate;
+    uint32_t avg_bitrate;
+    uint16_t max_frame_size;
+    bool is_mp4;
+} encode_summary_t;
+
+typedef encode_summary_t encode_mp4_summary_t;
+
+typedef void (*session_start_callback_t)(const encode_session_info_t *info, void *user_data);
+typedef void (*summary_callback_t)(const encode_summary_t *summary, void *user_data);
+typedef summary_callback_t mp4_summary_callback_t;
+typedef void (*log_message_callback_t)(int level, const char *message, void *user_data);
+
+typedef struct {
+    progress_callback_t progress_cb;
+    session_start_callback_t session_start_cb;
+    summary_callback_t summary_cb;
+    mp4_summary_callback_t mp4_summary_cb; /* alias for backward compatibility */
+    log_message_callback_t log_cb;
+    void *user_data;
+} encode_callbacks_t;
+
+int run_encoding_session(const encode_options_t *opts,
+                          progress_callback_t progress_cb,
+                          void *user_data);
+
+int run_encoding_session_ext(const encode_options_t *opts,
+                              const encode_callbacks_t *callbacks);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ENCODE_ENGINE_H */

--- a/frontend/faacgui.exe.manifest
+++ b/frontend/faacgui.exe.manifest
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/frontend/faacgui.rc
+++ b/frontend/faacgui.rc
@@ -49,6 +49,13 @@ END
 
 /////////////////////////////////////////////////////////////////////////////
 //
+// Manifest
+//
+
+1 24 "faacgui.exe.manifest"
+
+/////////////////////////////////////////////////////////////////////////////
+//
 // Dialog
 //
 
@@ -62,9 +69,9 @@ BEGIN
                     WS_EX_STATICEDGE
     PUSHBUTTON      "...",IDC_SELECT_OUTPUTFILE,225,33,19,14,WS_DISABLED,
                     WS_EX_STATICEDGE
-    COMBOBOX        IDC_JOINTMODE,14,126,71,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Joint Stereo",IDC_STATIC,14,117,56,8
-    LTEXT           "Quantizer\nquality", IDC_STATIC, 98, 73, 44, 18
+    COMBOBOX        IDC_JOINTMODE,14,130,71,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Stereo Mode",IDC_STATIC,14,121,56,8
+    LTEXT           "Quantizer\nquality", IDC_QUALITYLABEL, 98, 73, 37, 18
     EDITTEXT        IDC_QUALITY, 138, 76, 30, 12, ES_AUTOHSCROLL
     CONTROL         "", IDC_STATIC, "static", SS_SUNKEN, 98, 94, 70, 30
     CONTROL         "Set bandwidth", IDC_BWCTL, "Button", BS_AUTOCHECKBOX
@@ -84,21 +91,22 @@ BEGIN
                     250,1
     LTEXT           "-",IDC_INPUTPARAMS,32,66,55,8
     LTEXT           "In:",IDC_STATIC,14,66,12,8
-    CONTROL         "Progress1",IDC_PROGRESS,"msctls_progress32",WS_BORDER,7,
-                    145,250,10
+    CONTROL         "Progress1",IDC_PROGRESS,"msctls_progress32",WS_BORDER | 0x01,7,
+                    145,250,10 /* 0x01 = PBS_SMOOTH */
     GROUPBOX        "Output Format",IDC_STATIC,93,62,164,77
-    CONTROL         "Use RAW output",IDC_USERAW,"Button",BS_AUTOCHECKBOX |
-                    BS_LEFTTEXT | WS_TABSTOP,14,93,71,10
+    LTEXT           "PNS (0-10)",IDC_STATIC,14,95,44,8
+    EDITTEXT        IDC_PNS,60,93,20,12,ES_AUTOHSCROLL
     CONTROL         "Use TNS",IDC_USETNS,"Button",BS_AUTOCHECKBOX |
                     BS_LEFTTEXT | WS_TABSTOP,14,82,71,10
-    COMBOBOX        IDC_MPEGVERSION,183,82,67,63,CBS_DROPDOWNLIST |
+    COMBOBOX        IDC_RATEMODE,183,82,67,63,CBS_DROPDOWNLIST |
                     WS_VSCROLL | WS_TABSTOP
     COMBOBOX        IDC_OBJECTTYPE,183,109,67,59,CBS_DROPDOWNLIST |
                     WS_VSCROLL | WS_TABSTOP
-    LTEXT           "MPEG Version",IDC_STATIC,183,73,56,8
+    LTEXT           "Rate Mode",IDC_STATIC,183,73,56,8
     LTEXT           "AAC Object Type",IDC_STATIC,183,100,56,8
-    CONTROL         "Use LFE channel",IDC_USELFE,"Button",BS_AUTOCHECKBOX |
-                    BS_LEFTTEXT | WS_DISABLED | WS_TABSTOP,14,104,71,10
+    LTEXT           "Blocks",IDC_STATIC,14,109,26,8
+    COMBOBOX        IDC_SHORTCTL,42,107,43,50,CBS_DROPDOWNLIST |
+                    WS_VSCROLL | WS_TABSTOP
 END
 
 
@@ -126,10 +134,6 @@ END
 // Dialog Info
 //
 
-IDD_MAINDIALOG DLGINIT
-BEGIN
-    IDC_MPEGVERSION, 0x403, 1, 0, "\000", 0
-END
 
 #endif    // English (U.S.) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2001 Menno Bakker
  * Copyright (C) 2002-2017 Krzysztof Nikiel
  * Copyright (C) 2004 Dan Villiom P. Christiansen
+ * Copyright (C) 2026 Nils Schimmelmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -15,36 +16,25 @@
  * Lesser General Public License for more details.
  */
 
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
 #ifdef _WIN32
 #include <windows.h>
-#include <fcntl.h>
 #else
 #include <signal.h>
+#include <locale.h>
 #endif
 
-/* the BSD derivatives don't define __unix__ */
 #if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__bsdi__)
 #define __unix__
 #endif
 
-#ifdef __unix__
-#include <sys/resource.h>
-#include <unistd.h>
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
 #include <string.h>
-#include <time.h>
-#include <sys/stat.h>
-#include <errno.h>
-#include <locale.h>
+#include <inttypes.h>
 
 #ifdef HAVE_GETOPT_H
 # include <getopt.h>
@@ -53,21 +43,17 @@
 # include "getopt.c"
 #endif
 
-#include "mp4write.h"
-#include "charset.h"
+#include <faac.h>
 #include "output.h"
+#include "charset.h"
+#include "encode_engine.h"
 
 #ifdef _WIN32
 # undef stderr
 # define stderr stdout
 #endif
 
-#include "input.h"
-
-#include <faac.h>
-
-#define FALSE 0
-#define TRUE 1
+#define MAX_COVER_ART_SIZE ((size_t)32 * 1024 * 1024)
 
 enum flags
 {
@@ -98,6 +84,11 @@ enum flags
     OPT_PNS,
     OBJTYPE_FLAG,
     CAP_RATE_FLAG,
+    OPT_TNS_ENABLE,
+    OPT_TNS_DISABLE,
+    OPT_OVERWRITE,
+    OPT_COMPILATION,
+    OPT_IGNORE_LENGTH,
     LANG_FLAG
 };
 
@@ -118,8 +109,7 @@ static help_t help_qual[] = {
     },
     {"-b <bitrate>\tSet average bitrate to x kbps. (ABR)\n",
     "\t\tSet average bitrate (ABR) to approximately <bitrate> kbps.\n"
-    "\t\tmax. ~529 (stereo, 44.1kHz) to ~576 (stereo, 48kHz), the ISO\n"
-    "\t\t6144 bits/channel/frame limit\n"},
+    "\t\tmax. ~500 (stereo)\n"},
     {"-c <freq>\tSet the bandwidth in Hz.\n",
     "\t\tThe actual frequency is adjusted to maximize upper spectral band\n"
     "\t\tusage.\n"},
@@ -251,24 +241,9 @@ char *license =
     "Lesser General Public License for more details.\n"
     "\n";
 
-#ifndef min
-#define min(a,b) ( (a) < (b) ? (a) : (b) )
-#endif
-
-/* globals */
-char *progName;
 #ifndef _WIN32
 volatile int running = 1;
-#endif
-
-enum container_format
-{
-    NO_CONTAINER,
-    MP4_CONTAINER,
-};
-
-#ifndef _WIN32
-void signal_handler(int signal)
+static void signal_handler(int signal)
 {
     (void)signal;
     running = 0;
@@ -335,12 +310,152 @@ static void help(int mode)
 }
 
 
+static bool cli_progress_callback(const progress_info_t *info, void *user_data)
+{
+    encode_options_t *opts = (encode_options_t *)user_data;
+    if (opts && opts->verbose == 0)
+    {
+#ifndef _WIN32
+        return running != 0;
+#else
+        return true;
+#endif
+    }
 
-#define fprintf if(verbose)fprintf
+    /* Cancellation (running != 0) is checked below on every call regardless
+       of this throttle: the caller invokes progress_cb every frame, but
+       redrawing the status line that often just spams the terminal. */
+    static progress_throttle_t s_throttle = { .last_fired_sec = -1.0 };
+    if (info->is_final || progress_throttle_tick(&s_throttle, info, 0.033))
+    {
+        if (info->total_frames > 0)
+        {
+            int percent = (int)(info->current_frame * 100 / info->total_frames);
+            double played_sec = (double)info->current_input_samples / (double)(info->sample_rate ? info->sample_rate : 1);
+            double bitrate_kbps = played_sec > 0.0 ? ((double)info->total_bytes_written * 8.0 / 1000.0) / played_sec : 0.0;
+            fprintf(stderr, "\r%7u/%-7u (%3d%%) |  %5.1f  | %6.1f/%-6.1f | %7.2fx | %.1f ",
+                    info->current_frame, info->total_frames, percent,
+                    bitrate_kbps,
+                    info->time_elapsed_sec, info->time_elapsed_sec + info->eta_sec,
+                    info->speed_factor, info->eta_sec);
+        }
+        else
+        {
+            fprintf(stderr, "\r %7u | %7.1f | %7.2fx ",
+                    info->current_frame, info->time_elapsed_sec, info->speed_factor);
+        }
+        fflush(stderr);
+    }
+#ifndef _WIN32
+    return running != 0;
+#else
+    return true;
+#endif
+}
+
+static void cli_log_callback(int level, const char *message, void *user_data)
+{
+    encode_options_t *opts = (encode_options_t *)user_data;
+    if (opts && (int)opts->verbose >= level)
+    {
+        fprintf(stderr, "%s", message);
+    }
+}
+
+static void cli_session_start_callback(const encode_session_info_t *info, void *user_data)
+{
+    encode_options_t *opts = (encode_options_t *)user_data;
+    if (!opts || opts->verbose < 1)
+        return;
+
+    if (info->bit_rate)
+    {
+        fprintf(stderr, "Initial quantization quality: %u\n", info->quant_quality);
+        fprintf(stderr, "Average bitrate: %u kbps/channel\n", (info->bit_rate + 500) / 1000);
+    }
+    else
+    {
+        fprintf(stderr, "Quantization quality: %u\n", info->quant_quality);
+    }
+    fprintf(stderr, "Bandwidth: %u Hz\n", info->bandwidth);
+    if (info->pns_level > 0)
+        fprintf(stderr, "PNS level: %d\n", info->pns_level);
+
+    const char *jm_str = "";
+    switch (info->joint_mode)
+    {
+    case FAAC_JOINT_MS: jm_str = " + M/S"; break;
+    case FAAC_JOINT_IS: jm_str = " + IS"; break;
+    case FAAC_JOINT_MIXED: jm_str = " + Mixed"; break;
+    default: break;
+    }
+
+    fprintf(stderr, "Object type: %s (MPEG-%d)%s%s%s\n",
+            (info->object_type == FAAC_OBJ_HE_AAC_V1) ? "HE-AAC v1" : "Low Complexity",
+            (info->mpeg_version == FAAC_MPEG4) ? 4 : 2,
+            info->use_tns ? " + TNS" : "",
+            jm_str,
+            (info->pns_level > 0) ? " + PNS" : "");
+
+    const char *fmt_str = "Unknown";
+    if (info->container_mp4)
+    {
+        fmt_str = "MPEG-4 File Format (MP4)";
+    }
+    else
+    {
+        switch (info->stream_format)
+        {
+        case FAAC_STREAM_RAW: fmt_str = "Headerless AAC (RAW)"; break;
+        case FAAC_STREAM_ADTS: fmt_str = "Transport Stream (ADTS)"; break;
+        default: break;
+        }
+    }
+    fprintf(stderr, "Container format: %s\n", fmt_str);
+
+    fprintf(stderr, "Encoding %s to %s\n", info->input_filename, info->output_filename);
+    if (info->total_input_samples != 0)
+    {
+        fprintf(stderr, "         frame         | bitrate | elapsed/estim | play/CPU | ETA\n");
+    }
+    else
+    {
+        fprintf(stderr, "  frame  | elapsed | play/CPU\n");
+    }
+}
+
+static void cli_summary_callback(const encode_summary_t *summary, void *user_data)
+{
+    encode_options_t *opts = (encode_options_t *)user_data;
+    if (!opts || opts->verbose < 2)
+        return;
+
+    fprintf(stderr, "\n");
+    fprintf(stderr, "%u frames\n", summary->frame_count);
+    fprintf(stderr, "%" PRIu64 " output samples\n", summary->sample_count);
+    if (summary->is_mp4)
+    {
+        fprintf(stderr, "max bitrate: %u\n", summary->max_bitrate);
+        fprintf(stderr, "avg bitrate: %u\n", summary->avg_bitrate);
+        fprintf(stderr, "max frame size: %u\n", summary->max_frame_size);
+    }
+    else
+    {
+        fprintf(stderr, "avg bitrate: %u kbps\n", summary->avg_bitrate);
+        fprintf(stderr, "max frame size: %u bytes\n", summary->max_frame_size);
+    }
+}
 
 int main(int argc, char *argv[])
 {
-    int frames, currentFrame;
+    encode_options_t opts;
+    init_encode_options(&opts);
+
+    char *aacFileName = NULL;
+    bool aacFileNameGiven = false;
+    bool has_custom_tags = false;
+    const char *dieMessage = NULL;
+    int ret = 0;
 
 #ifndef _WIN32
     signal(SIGINT, signal_handler);
@@ -349,6 +464,13 @@ int main(int argc, char *argv[])
        nl_langinfo() instead of always seeing the default "C" locale. */
     setlocale(LC_CTYPE, "");
 #endif
+
+    faac_library_info libinfo = { .struct_size = sizeof(libinfo) };
+    if (faac_get_library_info(&libinfo) != FAAC_OK)
+    {
+        fprintf(stderr, "Wrong libfaac version!\n");
+        return 1;
+    }
 
 #ifdef _WIN32
     int wargc = 0;
@@ -390,99 +512,14 @@ int main(int argc, char *argv[])
         LocalFree(wargv);
     }
 #endif
-    faac_encoder *hEncoder = NULL;
-    pcmfile_t *infile = NULL;
 
-    unsigned long samplesInput, maxBytesOutput, totalBytesWritten = 0;
-
-    faac_params params;
-    faac_status fstatus;
-    enum faac_mpeg_version mpegVersion = FAAC_MPEG4;
-    enum faac_object_type objectType = FAAC_OBJ_AUTO;
-    int jointmode = -1;
-    int pnslevel = -1;
-    static int useTns = 0;
-    enum container_format container = NO_CONTAINER;
-    enum faac_stream_format stream = FAAC_STREAM_ADTS;
-    int cutOff = -1;
-    int bitRate = 0;
-    unsigned long quantqual = 0;
-    unsigned int capRate = 0;
-    int chanC = 3;
-    int chanLF = 4;
-
-    char *audioFileName = NULL;
-    char *aacFileName = NULL;
-    int aacFileNameGiven = 0;
-
-    float *pcmbuf;
-    int *chanmap = NULL;
-
-    unsigned char *bitbuf;
-    int samplesRead = 0;
-    const char *dieMessage = NULL;
-
-    int rawChans = 0;           // disabled by default
-    int rawBits = 16;
-    int rawRate = 44100;
-    int rawEndian = 1;
-
-    int shortctl = FAAC_SHORTCTL_NORMAL;
-
-    FILE *outfile = NULL;
-
-    unsigned int ntracks = 0, trackno = 0;
-    unsigned int ndiscs = 0, discno = 0;
-    static int compilation = 0;
-    const char *artist = NULL, *artistsort = NULL, *title = NULL,
-        *album = NULL, *albumartist = NULL,
-        *albumartistsort = NULL, *albumsort = NULL,
-        *year = NULL, *comment = NULL, *composer = NULL,
-        *composersort = NULL, *language = NULL, *tagname = 0, *tagval = 0,
-        *creation_time_str = NULL;
-    int genre = 0;
-    uint8_t *artData = NULL;
-    uint64_t artSize = 0;
-    uint64_t encoded_samples = 0;
-    unsigned int frameSize;
-    uint64_t input_samples = 0;
-    const char *faac_id_string;
-    const char *faac_copyright_string;
-    static int ignorelen = 0;
-    int verbose = 1;
-    static int overwrite = 0;
-
-#ifndef _WIN32
-    // install signal handler
-    signal(SIGINT, signal_handler);
-    signal(SIGTERM, signal_handler);
-#endif
-
-    // get faac version
-    faac_library_info libinfo = { .struct_size = sizeof(libinfo) };
-    faac_get_library_info(&libinfo);
-    faac_id_string = libinfo.version;
-    faac_copyright_string = libinfo.copyright;
-    if (!strcmp(faac_id_string, PACKAGE_VERSION))
-    {
-        fprintf(stderr, "Freeware Advanced Audio Coder\nFAAC %s\n\n",
-                faac_id_string);
-    }
-    else
-    {
-        fprintf(stderr, __FILE__ "(%d): wrong libfaac version "
-                "(expected %s, found %s)\n", __LINE__,
-                PACKAGE_VERSION, faac_id_string);
-        return 1;
-    }
-
-    /* begin process command line */
-    progName = argv[0];
     if (argc < 2)
     {
         help('?');
-        return 1;
+        ret = 1;
+        goto cleanup;
     }
+
     while (1)
     {
         static struct option long_options[] = {
@@ -501,8 +538,8 @@ int main(int argc, char *argv[])
             {"pcmsamplebits", 1, 0, 'B'},
             {"pcmchannels", 1, 0, 'C'},
             {"shortctl", 1, 0, SHORTCTL_FLAG},
-            {"tns", 0, &useTns, 1},
-            {"no-tns", 0, &useTns, 0},
+            {"tns", 0, 0, OPT_TNS_ENABLE},
+            {"no-tns", 0, 0, OPT_TNS_DISABLE},
             {"mpeg-version", 1, 0, MPEGVERS_FLAG},
             {"object-type", 1, 0, OBJTYPE_FLAG},
             {"license", 0, 0, 'L'},
@@ -522,288 +559,248 @@ int main(int argc, char *argv[])
             {"comment", 1, 0, COMMENT_FLAG},
             {"composer", 1, 0, WRITER_FLAG},
             {"composersort", 1, 0, WRITER_SORT_FLAG},
-            {"compilation", 0, &compilation, 1},
+            {"compilation", 0, 0, OPT_COMPILATION},
             {"pcmswapbytes", 0, 0, 'X'},
-            {"ignorelength", 0, &ignorelen, 1},
+            {"ignorelength", 0, 0, OPT_IGNORE_LENGTH},
             {"tag", 1, 0, TAG_FLAG},
-            {"overwrite", 0, &overwrite, 1},
+            {"overwrite", 0, 0, OPT_OVERWRITE},
             {"creation-time", 1, 0, CREATION_TIME_FLAG},
             {"lang", 1, 0, LANG_FLAG},
             {"language", 1, 0, LANG_FLAG},
             {"cap-rate", 1, 0, CAP_RATE_FLAG},
             {0, 0, 0, 0}
         };
-        int c = -1;
-        int option_index = 0;
 
-        c = getopt_long(argc, argv, "Hhb:m:o:rnc:q:PR:B:C:I:Xwv:",
-                        long_options, &option_index);
+        int option_index = 0;
+        int c = getopt_long(argc, argv, "Hhb:m:o:rnc:q:PR:B:C:I:Xwv:L",
+                            long_options, &option_index);
 
         if (c == -1)
             break;
 
-        if (!c)
-            continue;
-
         switch (c)
         {
+        case OPT_TNS_ENABLE: opts.use_tns = true; break;
+        case OPT_TNS_DISABLE: opts.use_tns = false; break;
+        case OPT_OVERWRITE: opts.overwrite = true; break;
+        case OPT_COMPILATION: opts.metadata.compilation = true; break;
+        case OPT_IGNORE_LENGTH: opts.ignore_wav_length = true; break;
+        case 'L':
+            if (libinfo.copyright)
+                fprintf(stderr, "%s", libinfo.copyright);
+            fprintf(stderr, "%s", license);
+            ret = 0;
+            goto cleanup;
+        case 'X':
+            opts.raw_endian = false;
+            break;
         case 'o':
-            {
-                int l = strlen(optarg);
-                aacFileName = malloc(l + 1);
-                if (!aacFileName)
-                {
-                    fprintf(stderr, "out of memory\n");
-                    return 1;
-                }
-                memcpy(aacFileName, optarg, l);
-                aacFileName[l] = '\0';
-                aacFileNameGiven = 1;
-            }
+            aacFileName = strdup(optarg);
+            aacFileNameGiven = true;
             break;
         case 'r':
-            {
-                stream = FAAC_STREAM_RAW;
-                break;
-            }
+            opts.stream_format = FAAC_STREAM_RAW;
+            break;
         case 'c':
-            {
-                unsigned int i;
-                if (sscanf(optarg, "%u", &i) > 0)
-                {
-                    cutOff = i;
-                }
-                break;
-            }
+            opts.bandwidth = atoi(optarg);
+            break;
         case 'b':
-            {
-                unsigned int i;
-                if (sscanf(optarg, "%u", &i) > 0)
-                {
-                    bitRate = 1000 * i;
-                }
-                break;
-            }
+            parse_quality_or_bitrate(optarg, true, &opts);
+            break;
         case 'q':
-            {
-                unsigned int i;
-                if (sscanf(optarg, "%u", &i) > 0)
-                {
-                    if (i > 0)
-                        quantqual = i;
-                }
-                break;
-            }
+            parse_quality_or_bitrate(optarg, false, &opts);
+            break;
         case 'I':
-            sscanf(optarg, "%d,%d", &chanC, &chanLF);
+            if (sscanf(optarg, "%hu,%hu", &opts.center_channel, &opts.lfe_channel) < 1)
+                dieMessage = "Wrong channel config.\n";
             break;
         case 'P':
-            rawChans = 2;       // enable raw input
+            opts.raw_pcm_input = true;
             break;
         case 'R':
-            {
-                unsigned int i;
-                if (sscanf(optarg, "%u", &i) > 0)
-                {
-                    rawRate = i;
-                    rawChans = (rawChans > 0) ? rawChans : 2;
-                }
-                break;
-            }
+            opts.raw_rate = atoi(optarg);
+            opts.raw_pcm_input = true;
+            break;
         case 'B':
             {
-                unsigned int i;
-                if (sscanf(optarg, "%u", &i) > 0)
-                {
-                    if (i > 32)
-                        i = 32;
-                    if (i < 8)
-                        i = 8;
-                    rawBits = i;
-                    rawChans = (rawChans > 0) ? rawChans : 2;
-                }
-                break;
+                int bits = atoi(optarg);
+                if (bits > 32)
+                    bits = 32;
+                if (bits < 8)
+                    bits = 8;
+                opts.raw_bits = (uint8_t)bits;
             }
+            opts.raw_pcm_input = true;
+            break;
         case 'C':
-            {
-                unsigned int i;
-                if (sscanf(optarg, "%u", &i) > 0)
-                    rawChans = i;
-                break;
-            }
+            opts.raw_channels = (uint16_t)atoi(optarg);
+            opts.raw_pcm_input = true;
+            break;
         case 'w':
-            container = MP4_CONTAINER;
+            opts.container_mp4 = true;
             break;
         case ARTIST_FLAG:
-            artist = optarg;
+            opts.metadata.artist = optarg;
             break;
         case ARTIST_SORT_FLAG:
-            artistsort = optarg;
+            opts.metadata.artist_sort = optarg;
             break;
         case WRITER_FLAG:
-            composer = optarg;
+            opts.metadata.composer = optarg;
             break;
         case WRITER_SORT_FLAG:
-            composersort = optarg;
+            opts.metadata.composer_sort = optarg;
             break;
         case TITLE_FLAG:
-            title = optarg;
+            opts.metadata.title = optarg;
             break;
         case ALBUM_FLAG:
-            album = optarg;
+            opts.metadata.album = optarg;
             break;
         case ALBUM_ARTIST_FLAG:
-            albumartist = optarg;
+            opts.metadata.album_artist = optarg;
             break;
         case ALBUM_ARTIST_SORT_FLAG:
-            albumartistsort = optarg;
+            opts.metadata.album_artist_sort = optarg;
             break;
         case ALBUM_SORT_FLAG:
-            albumsort = optarg;
+            opts.metadata.album_sort = optarg;
             break;
         case TRACK_FLAG:
-            if (sscanf(optarg, "%u/%u", &trackno, &ntracks) < 1)
+            if (sscanf(optarg, "%hu/%hu", &opts.metadata.track, &opts.metadata.ntracks) < 1)
                 dieMessage = "Wrong track number.\n";
             break;
         case DISC_FLAG:
-            if (sscanf(optarg, "%u/%u", &discno, &ndiscs) < 1)
+            if (sscanf(optarg, "%hu/%hu", &opts.metadata.disc, &opts.metadata.ndiscs) < 1)
                 dieMessage = "Wrong disc number.\n";
             break;
         case GENRE_FLAG:
-            genre = atoi(optarg);
-            if ((genre < 0) || (genre > 255))
-                dieMessage = "Genre number out of range.\n";
-            genre++;
+            {
+                int g = atoi(optarg);
+                if (g < 0 || g > 255)
+                    dieMessage = "Genre number out of range.\n";
+                else
+                    opts.metadata.genre_id = (uint16_t)(g + 1);
+            }
             break;
         case YEAR_FLAG:
-            year = optarg;
+            opts.metadata.year = optarg;
             break;
         case COMMENT_FLAG:
-            comment = optarg;
+            opts.metadata.comment = optarg;
+            break;
+        case MPEGVERS_FLAG:
+            switch (atoi(optarg))
+            {
+            case 2: opts.mpeg_version = FAAC_MPEG2; break;
+            case 4: opts.mpeg_version = FAAC_MPEG4; break;
+            default: dieMessage = "Unrecognised MPEG version!\n"; break;
+            }
+            break;
+        case OBJTYPE_FLAG:
+            if (!strcmp(optarg, "lc"))
+                opts.object_type = FAAC_OBJ_LOW;
+            else if (!strcmp(optarg, "he-aac-v1"))
+                opts.object_type = FAAC_OBJ_HE_AAC_V1;
+            else if (!strcmp(optarg, "auto"))
+                opts.object_type = FAAC_OBJ_AUTO;
+            else
+                dieMessage = "Unrecognised object type (use lc, he-aac-v1, or auto)!\n";
+            break;
+        case SHORTCTL_FLAG:
+            opts.shortctl = (enum faac_shortctl_mode)atoi(optarg);
+            break;
+        case OPT_JOINT:
+            opts.joint_mode = (enum faac_joint_mode)atoi(optarg);
+            break;
+        case OPT_PNS:
+            opts.pns_level = (int8_t)atoi(optarg);
             break;
         case TAG_FLAG:
-            tagname = optarg;
-            if (!(tagval = strchr(optarg, ',')))
-                dieMessage = "Missing tag value.\n";
-            else
-                *(char *)tagval++ = 0;
-            if (!dieMessage)
             {
-                char *utf8_tagval = utf8_ensure(tagval);
-                if (utf8_tagval)
+                char *tagname = optarg;
+                char *tagval = strchr(optarg, ',');
+                if (!tagval)
                 {
-                    if (mp4_add_custom_tag(tagname, utf8_tagval))
-                        dieMessage = "Couldn't add tag (out of memory).\n";
-                    free(utf8_tagval);
+                    dieMessage = "Missing tag value.\n";
                 }
                 else
                 {
-                    dieMessage = "Couldn't add tag (out of memory).\n";
+                    *tagval++ = '\0';
+                    if (*tagval == '\0')
+                        dieMessage = "Tag value cannot be empty.\n";
                 }
+                if (!dieMessage)
+                {
+                    if (!add_custom_tag_to_options(&opts, tagname, tagval))
+                        dieMessage = "Couldn't add tag (out of memory).\n";
+                }
+                has_custom_tags = true;
             }
-            break;
-        case CREATION_TIME_FLAG:
-            creation_time_str = optarg;
-            break;
-        case LANG_FLAG:
-            language = optarg;
             break;
         case COVER_ART_FLAG:
             {
 #ifdef _WIN32
-                FILE *artFile = win32_fopen_utf8(optarg, "rb");
+                FILE *f = win32_fopen_utf8(optarg, "rb");
 #else
-                FILE *artFile = fopen(optarg, "rb");
+                FILE *f = fopen(optarg, "rb");
 #endif
-
-                if (artFile)
+                if (f)
                 {
-                    uint64_t r;
+                    fseek(f, 0, SEEK_END);
+                    long sz = ftell(f);
+                    fseek(f, 0, SEEK_SET);
+                    clearerr(f);
 
-                    fseek(artFile, 0, SEEK_END);
-                    artSize = ftell(artFile);
-
-                    artData = malloc(artSize);
-                    if (!artData)
+                    if (sz <= 0 || (size_t)sz > MAX_COVER_ART_SIZE)
                     {
-                        fprintf(stderr, "out of memory\n");
-                        fclose(artFile);
-                        return 1;
+                        dieMessage = "Invalid cover art file size!\n";
                     }
-
-                    fseek(artFile, 0, SEEK_SET);
-                    clearerr(artFile);
-
-                    r = fread(artData, artSize, 1, artFile);
-
-                    if (r != 1)
+                    else
                     {
-                        dieMessage = "Error reading cover art file!\n";
-                        free(artData);
-                        artData = NULL;
+                        opts.art_size = (uint64_t)sz;
+                        opts.art_data = malloc((size_t)opts.art_size);
+                        if (opts.art_data)
+                        {
+                            if (fread((void *)opts.art_data, 1, (size_t)opts.art_size, f) != (size_t)opts.art_size)
+                            {
+                                dieMessage = "Error reading cover art file!\n";
+                                free((void *)opts.art_data);
+                                opts.art_data = NULL;
+                                opts.art_size = 0;
+                            }
+                            else if (opts.art_size < 12 || !check_image_header((const char *)opts.art_data))
+                            {
+                                dieMessage = "Unsupported cover image file format!\n";
+                                free((void *)opts.art_data);
+                                opts.art_data = NULL;
+                                opts.art_size = 0;
+                            }
+                        }
+                        else
+                        {
+                            dieMessage = "Out of memory reading cover art file!\n";
+                        }
                     }
-                    else if (artSize < 12
-                             || !check_image_header((const char *) artData))
-                    {
-                        /* the above expression checks the image signature */
-                        dieMessage = "Unsupported cover image file format!\n";
-                        free(artData);
-                        artData = NULL;
-                    }
-
-                    fclose(artFile);
+                    fclose(f);
                 }
                 else
                 {
                     dieMessage = "Error opening cover art file!\n";
                 }
-
-                break;
-            }
-        case SHORTCTL_FLAG:
-            shortctl = atoi(optarg);
-            break;
-        case MPEGVERS_FLAG:
-            switch (atoi(optarg))
-            {
-            case 2:
-                mpegVersion = FAAC_MPEG2;
-                break;
-            case 4:
-                mpegVersion = FAAC_MPEG4;
-                break;
-            default:
-                dieMessage = "Unrecognised MPEG version!\n";
             }
             break;
-        case OBJTYPE_FLAG:
-            if (!strcmp(optarg, "lc"))
-                objectType = FAAC_OBJ_LOW;
-            else if (!strcmp(optarg, "he-aac-v1"))
-                objectType = FAAC_OBJ_HE_AAC_V1;
-            else if (!strcmp(optarg, "auto"))
-                objectType = FAAC_OBJ_AUTO;
-            else
-                dieMessage = "Unrecognised object type (use lc, he-aac-v1, or auto)!\n";
+        case CREATION_TIME_FLAG:
+            opts.creation_time_str = optarg;
+            break;
+        case LANG_FLAG:
+            opts.metadata.language = optarg;
             break;
         case CAP_RATE_FLAG:
-            {
-                unsigned int i;
-                if (sscanf(optarg, "%u", &i) > 0)
-                {
-                    capRate = i;
-                }
-                break;
-            }
-        case 'L':
-            fprintf(stderr, "%s", faac_copyright_string);
-            dieMessage = license;
-            break;
-        case 'X':
-            rawEndian = 0;
+            opts.max_bit_rate = atoi(optarg) * 1000;
             break;
         case 'v':
-            verbose = atoi(optarg);
+            opts.verbose = (uint8_t)atoi(optarg);
             break;
         case HELP_QUAL:
         case HELP_IO:
@@ -812,599 +809,87 @@ int main(int argc, char *argv[])
         case 'H':
         case 'h':
             help(c);
-            return 1;
-            break;
-        case OPT_JOINT:
-            jointmode = atoi(optarg);
-            break;
-        case OPT_PNS:
-            pnslevel = atoi(optarg);
-            break;
+            ret = 1;
+            goto cleanup;
         case '?':
         default:
             help('?');
-            return 1;
-            break;
+            ret = 1;
+            goto cleanup;
         }
     }
 
-    /* check that we have at least one non-option arguments */
-    if (!dieMessage && (argc - optind) > 1 && aacFileNameGiven)
-        dieMessage =
-            "Cannot encode several input files to one output file.\n";
-
-    if (argc - optind < 1 || dieMessage)
+    if (optind < argc)
     {
-        fprintf(stderr, dieMessage, progName, progName, progName, progName);
-        return 1;
+        opts.input_filename = argv[optind];
+        if ((argc - optind) > 1 && aacFileNameGiven)
+            dieMessage = "Cannot encode several input files to one output file.\n";
+    }
+    else
+    {
+        dieMessage = "No input file specified.\n";
     }
 
-    while (argc - optind > 0)
+    if (dieMessage)
     {
-        /* get the input file name */
-        audioFileName = argv[optind++];
+        fprintf(stderr, "%s", dieMessage);
+        ret = 1;
+        goto cleanup;
     }
 
-    /* generate the output file name, if necessary */
     if (!aacFileNameGiven)
     {
-        aacFileName = get_output_filename(audioFileName, container == MP4_CONTAINER);
-        if (!aacFileName)
-        {
-            fprintf(stderr, "out of memory\n");
-            return 1;
-        }
+        aacFileName = get_output_filename(opts.input_filename, opts.container_mp4);
     }
-    else
+    else if (is_mp4_filename(aacFileName))
     {
-        if (is_mp4_filename(aacFileName))
-            container = MP4_CONTAINER;
+        opts.container_mp4 = true;
     }
 
-    /* open the audio input file */
-    if (rawChans > 0)           // use raw input
+    if (opts.container_mp4)
     {
-        infile = wav_open_read(audioFileName, 1);
-        if (infile)
-        {
-            infile->bigendian = rawEndian;
-            infile->channels = rawChans;
-            infile->samplebytes = rawBits / 8;
-            infile->samplerate = rawRate;
-            infile->samples /= (infile->channels * infile->samplebytes);
-        }
-    }
-    else                        // header input
-        infile = wav_open_read(audioFileName, 0);
-
-    if (infile == NULL)
-    {
-        fprintf(stderr, "Couldn't open input file %s\n", audioFileName);
-        return 1;
+        opts.mpeg_version = FAAC_MPEG4;
     }
 
-    if (container != MP4_CONTAINER && (ntracks || trackno || artist ||
-                                       artistsort || title ||
-                                       album || albumartist ||
-                                       albumartistsort ||
-                                       albumsort || year || artData ||
-                                       genre || comment || discno || ndiscs ||
-                                       composer || composersort ||
-                                       compilation || language))
+    bool has_metadata = opts.metadata.artist || opts.metadata.artist_sort ||
+                        opts.metadata.title || opts.metadata.album ||
+                        opts.metadata.album_sort || opts.metadata.album_artist ||
+                        opts.metadata.album_artist_sort || opts.metadata.composer ||
+                        opts.metadata.composer_sort || opts.metadata.year ||
+                        opts.metadata.comment || opts.metadata.genre_id ||
+                        opts.metadata.track || opts.metadata.disc ||
+                        opts.metadata.compilation || opts.metadata.language ||
+                        opts.art_data || opts.custom_tag_count > 0 || has_custom_tags;
+
+    if (!opts.container_mp4 && has_metadata)
     {
         fprintf(stderr, "Metadata requires MP4 output!\n");
-        return 1;
+        ret = 1;
+        goto cleanup;
     }
 
-    if (container == MP4_CONTAINER)
+    if (opts.verbose > 0 && libinfo.version)
     {
-        mpegVersion = FAAC_MPEG4;
-        stream = FAAC_STREAM_RAW;
+        fprintf(stderr, "Freeware Advanced Audio Coder\nFAAC %s\n\n", libinfo.version);
     }
 
-    if (cutOff <= 0)
-    {
-        if (cutOff < 0)         // default
-            cutOff = 0;
-        else                    // disabled
-            cutOff = infile->samplerate / 2;
-    }
-    if ((uint32_t)cutOff > (infile->samplerate / 2))
-        cutOff = infile->samplerate / 2;
+    opts.output_filename = aacFileName;
 
-    if (shortctl == FAAC_SHORTCTL_NOSHORT) {
-        fprintf(stderr, "disabling short blocks\n");
-    } else if (shortctl == FAAC_SHORTCTL_NOLONG) {
-        fprintf(stderr, "disabling long blocks\n");
-    }
+    encode_callbacks_t cbs = {
+        .progress_cb = cli_progress_callback,
+        .session_start_cb = cli_session_start_callback,
+        .summary_cb = cli_summary_callback,
+        .log_cb = cli_log_callback,
+        .user_data = &opts
+    };
 
-    if (pnslevel > 0 && mpegVersion == FAAC_MPEG2)
-    {
-        fprintf(stderr, "PNS not allowed in MPEG-2 mode, disabling PNS\n");
-        pnslevel = 0;
-    }
+    ret = run_encoding_session_ext(&opts, &cbs);
+    if (opts.verbose && opts.verbose < 2)
+        fprintf(stderr, "\n");
 
-    /* put the options into the parameter struct and open the encoder */
-    faac_params_init(&params, sizeof(params));
-    params.sample_rate   = infile->samplerate;
-    params.num_channels  = infile->channels;
-    params.mpeg_version  = mpegVersion;
-    params.object_type   = objectType;
-    params.joint_mode    = (jointmode >= 0) ? (enum faac_joint_mode)jointmode
-                                            : params.joint_mode;
-    params.use_lfe       = (infile->channels >= 6);
-    params.use_tns       = useTns ? true : false;
-    params.short_control = (enum faac_shortctl_mode)shortctl;
-    if (pnslevel >= 0)
-        params.pns_level = pnslevel;
-    if (quantqual > 0)
-    {
-        params.quant_quality = quantqual;
-        params.bit_rate = 0;
-    }
-    if (bitRate)
-        params.bit_rate = bitRate / infile->channels;
-    /* max_bit_rate is already whole-stream, unlike bit_rate above. */
-    if (capRate)
-        params.max_bit_rate = capRate * 1000;
-    params.bandwidth     = cutOff;
-    params.output_format = stream;
-    params.input_format  = FAAC_INPUT_FLOAT;
-
-    /* Reject too many channels with a specific message, rather than the generic
-     * "invalid argument" that faac_encoder_open would otherwise return. */
-    {
-        faac_library_info libinfo = { .struct_size = sizeof(libinfo) };
-        faac_get_library_info(&libinfo);
-        if ((unsigned)infile->channels > libinfo.max_channels)
-        {
-            fprintf(stderr, "Input file %s has %u channels, but this build of "
-                    "libfaac supports at most %u.\n",
-                    audioFileName, (unsigned)infile->channels, libinfo.max_channels);
-            wav_close(infile);
-            return 1;
-        }
-    }
-
-    fstatus = faac_encoder_open(&params, &hEncoder);
-    if (fstatus != FAAC_OK)
-    {
-        fprintf(stderr, "Couldn't open encoder instance for input file %s: %s\n",
-                audioFileName, faac_strerror(fstatus));
-        wav_close(infile);
-        return 1;
-    }
-
-    /* buffer sizes and resolved settings come from the now-configured encoder */
-    faac_encoder_info info;
-    info.struct_size = sizeof(info);
-    faac_encoder_get_info(hEncoder, &info);
-    samplesInput   = (unsigned long)info.frame_samples * infile->channels;
-    maxBytesOutput = info.max_output_bytes;
-    frameSize = samplesInput / infile->channels;
-    pcmbuf = (float *) malloc(samplesInput * sizeof(float));
-    bitbuf = (unsigned char *) malloc(maxBytesOutput * sizeof(unsigned char));
-    if (!pcmbuf || !bitbuf)
-    {
-        fprintf(stderr, "out of memory\n");
-        return 1;
-    }
-    chanmap = mk_chan_map(infile->channels, chanC, chanLF);
-    if (chanmap)
-    {
-        fprintf(stderr, "Remapping input channels: Center=%d, LFE=%d\n",
-                chanC, chanLF);
-    }
-
-    /* AUTO may have resolved to LC or HE-AAC; read back the decision. */
-    objectType = info.object_type;
-
-    /* initialize MP4 creation */
-    if (container == MP4_CONTAINER)
-    {
-        if (!strcmp(aacFileName, "-"))
-        {
-            fprintf(stderr, "cannot encode MP4 to stdout\n");
-            return 1;
-        }
-
-        if (mp4_open(aacFileName, overwrite))
-        {
-            fprintf(stderr, "Couldn't create output file %s\n", aacFileName);
-            return 1;
-        }
-
-        mp4_set_format(infile->samplerate, infile->channels, infile->samplebytes * 8);
-    }
-    else
-    {
-        /* open the aac output file */
-        if (!strcmp(aacFileName, "-"))
-        {
-            outfile = stdout;
-        }
-        else
-        {
-#ifdef _WIN32
-            outfile = win32_fopen_utf8(aacFileName, "wb");
-#else
-            outfile = fopen(aacFileName, "wb");
-#endif
-        }
-        if (!outfile)
-        {
-            fprintf(stderr, "Couldn't create output file %s\n", aacFileName);
-            return 1;
-        }
-    }
-
-    /* report the effective settings the encoder resolved */
-    cutOff = info.bandwidth;
-    quantqual = info.quant_quality;
-    bitRate = info.bit_rate;
-    int resolvedPns = info.pns_level;
-    if (bitRate)
-    {
-        fprintf(stderr, "Initial quantization quality: %ld\n", quantqual);
-        fprintf(stderr, "Average bitrate: %d kbps/channel\n",
-                (bitRate + 500) / 1000);
-    }
-    else
-        fprintf(stderr, "Quantization quality: %ld\n", quantqual);
-    fprintf(stderr, "Bandwidth: %d Hz\n", cutOff);
-    if (resolvedPns > 0)
-        fprintf(stderr, "PNS level: %d\n", resolvedPns);
-    fprintf(stderr, "Object type: %s",
-            (objectType == FAAC_OBJ_HE_AAC_V1) ? "HE-AAC v1" : "Low Complexity");
-    fprintf(stderr, " (MPEG-%d)", (mpegVersion == FAAC_MPEG4) ? 4 : 2);
-    if (params.use_tns)
-        fprintf(stderr, " + TNS");
-
-    switch(params.joint_mode) {
-    case FAAC_JOINT_MS:
-        fprintf(stderr, " + M/S");
-        break;
-    case FAAC_JOINT_IS:
-        fprintf(stderr, " + IS");
-        break;
-    case FAAC_JOINT_MIXED:
-        fprintf(stderr, " + Mixed");
-        break;
-    default:
-        break;
-    }
-    if (resolvedPns > 0)
-        fprintf(stderr, " + PNS");
-    fprintf(stderr, "\n");
-
-    fprintf(stderr, "Container format: ");
-    switch (container)
-    {
-    case NO_CONTAINER:
-        switch (stream)
-        {
-        case FAAC_STREAM_RAW:
-            fprintf(stderr, "Headerless AAC (RAW)\n");
-            break;
-        case FAAC_STREAM_ADTS:
-            fprintf(stderr, "Transport Stream (ADTS)\n");
-            break;
-        default:
-            break;
-        }
-        break;
-    case MP4_CONTAINER:
-        fprintf(stderr, "MPEG-4 File Format (MP4)\n");
-        break;
-    }
-
-    int showcnt = 0;
-#ifdef _WIN32
-    long begin = GetTickCount();
-#endif
-    if (infile->samples)
-        frames = ((infile->samples + frameSize - 1) / frameSize) + 1;
-    else
-        frames = 0;
-    currentFrame = 0;
-
-    fprintf(stderr, "Encoding %s to %s\n", audioFileName, aacFileName);
-    if (frames != 0)
-    {
-        fprintf(stderr, "         frame         | bitrate | elapsed/estim | "
-                "play/CPU | ETA\n");
-    }
-    else
-    {
-        fprintf(stderr, "  frame  | elapsed | play/CPU\n");
-    }
-
-    /* encoding loop */
-#ifdef _WIN32
-    for (;;)
-#else
-    while (running)
-#endif
-    {
-        int bytesWritten;
-
-        if (!ignorelen)
-        {
-            if (input_samples < (uint64_t)infile->samples || infile->samples == 0)
-                samplesRead =
-                    wav_read_float32(infile, pcmbuf, samplesInput, chanmap);
-            else
-                samplesRead = 0;
-
-            if (input_samples + (samplesRead / infile->channels) >
-                (uint64_t)infile->samples && infile->samples != 0)
-                samplesRead =
-                    (infile->samples - input_samples) * infile->channels;
-        }
-        else
-            samplesRead =
-                wav_read_float32(infile, pcmbuf, samplesInput, chanmap);
-
-        input_samples += samplesRead / infile->channels;
-
-        /* call the actual encoding routine */
-        {
-            uint32_t nbytes = 0;
-            fstatus = faac_encoder_encode(hEncoder, pcmbuf, (uint32_t)samplesRead,
-                                          bitbuf, (uint32_t)maxBytesOutput, &nbytes);
-            bytesWritten = (fstatus == FAAC_OK) ? (int)nbytes : -1;
-        }
-
-        if (bytesWritten)
-        {
-            currentFrame++;
-            showcnt--;
-            totalBytesWritten += bytesWritten;
-        }
-
-        if ((showcnt <= 0) || !bytesWritten)
-        {
-            double timeused;
-#ifdef __unix__
-            struct rusage usage;
-#endif
-#ifdef _WIN32
-            char percent[MAX_PATH + 20];
-            timeused = (GetTickCount() - begin) * 1e-3;
-#else
-#ifdef __unix__
-            if (getrusage(RUSAGE_SELF, &usage) == 0)
-            {
-                timeused = (double) usage.ru_utime.tv_sec +
-                    (double) usage.ru_utime.tv_usec * 1e-6;
-            }
-            else
-                timeused = 0;
-#else
-            timeused = (double) clock() * (1.0 / CLOCKS_PER_SEC);
-#endif
-#endif
-            if (currentFrame && (timeused > 0.1))
-            {
-                showcnt += 50;
-
-                if (frames != 0)
-                {
-                    fprintf(stderr,
-                            "\r%7d/%-7d (%3d%%) |  %5.1f  | %6.1f/%-6.1f | %7.2fx | %.1f ",
-                            currentFrame, frames, currentFrame * 100 / frames,
-                            ((double) totalBytesWritten * 8.0 / 1000.0) /
-                            ((double) infile->samples / infile->samplerate *
-                             currentFrame / frames), timeused,
-                            timeused * frames / currentFrame,
-                            ((double)frameSize * currentFrame / infile->samplerate) /
-                            timeused,
-                            timeused * (frames -
-                                        currentFrame) / currentFrame);
-                }
-                else
-                {
-                    fprintf(stderr,
-                            "\r %7d | %7.1f | %7.2fx ",
-                            currentFrame,
-                            timeused,
-                            ((double)frameSize * currentFrame / infile->samplerate) /
-                            timeused);
-                }
-
-                fflush(stderr);
-#ifdef _WIN32
-                if (frames != 0)
-                {
-                    snprintf(percent, sizeof(percent), "%.2f%% encoding %s",
-                            100.0 * currentFrame / frames, audioFileName);
-                    SetConsoleTitle(percent);
-                }
-#endif
-            }
-        }
-
-        /* all done, bail out */
-        if (!samplesRead && !bytesWritten)
-            break;
-
-        if (bytesWritten < 0)
-        {
-            fprintf(stderr, "faac_encoder_encode() failed: %s\n",
-                    faac_strerror(fstatus));
-            break;
-        }
-
-        if (bytesWritten > 0)
-        {
-            uint64_t frame_samples = input_samples - encoded_samples;
-            if (frame_samples > frameSize)
-                frame_samples = frameSize;
-
-            if (container == MP4_CONTAINER) {
-                if (mp4_write_frame(bitbuf, (uint32_t)bytesWritten, (uint32_t)frame_samples))
-                {
-                    fprintf(stderr, "mp4_write_frame() failed\n");
-                    break;
-                }
-            } else
-                fwrite(bitbuf, 1, bytesWritten, outfile);
-
-            encoded_samples += frame_samples;
-        }
-    }
-    fprintf(stderr, "\n");
-
-    if (container == MP4_CONTAINER)
-    {
-        char *version_string = malloc(strlen(faac_id_string) + 6);
-        if (!version_string)
-        {
-            fprintf(stderr, "out of memory\n");
-            return 1;
-        }
-        const uint8_t *ascData = NULL;
-        uint32_t ascSize = 0;
-
-        faac_encoder_asc(hEncoder, &ascData, &ascSize);
-        mp4_set_decoder_config((unsigned char *)ascData, ascSize);
-        snprintf(version_string, strlen(faac_id_string) + 6, "FAAC %s", faac_id_string);
-
-        mp4_set_encoder(version_string);
-
-        char *allocated_tags[MP4TAG_COUNT] = { 0 };
-        int num_allocated = 0;
-
-#define SETTAG(id, x) \
-    if (x) { \
-        char *utf8_val = utf8_ensure(x); \
-        if (utf8_val && num_allocated < MP4TAG_COUNT) { \
-            mp4_set_tag(id, utf8_val); \
-            allocated_tags[num_allocated++] = utf8_val; \
-        } \
-    }
-        SETTAG(MP4TAG_ARTIST, artist);
-        SETTAG(MP4TAG_ARTISTSORT, artistsort);
-        SETTAG(MP4TAG_COMPOSER, composer);
-        SETTAG(MP4TAG_COMPOSERSORT, composersort);
-        SETTAG(MP4TAG_TITLE, title);
-        SETTAG(MP4TAG_ALBUM, album);
-        SETTAG(MP4TAG_ALBUMARTIST, albumartist);
-        SETTAG(MP4TAG_ALBUMARTISTSORT, albumartistsort);
-        SETTAG(MP4TAG_ALBUMSORT, albumsort);
-        SETTAG(MP4TAG_YEAR, year);
-        SETTAG(MP4TAG_COMMENT, comment);
-#undef SETTAG
-        if (trackno) mp4_set_track((uint16_t)trackno, (uint16_t)ntracks);
-        if (discno) mp4_set_disc((uint16_t)discno, (uint16_t)ndiscs);
-        if (compilation) mp4_set_compilation(true);
-        if (genre) mp4_set_genre((uint16_t)genre);
-        if (language) mp4_set_language(language);
-        if (artData && artSize)
-            mp4_set_cover(artData, (uint32_t)artSize);
-
-        {
-            uint32_t final_creation_time = 0;
-            if (creation_time_str)
-            {
-                if (!strcmp(creation_time_str, "auto"))
-                {
-                    if (strcmp(audioFileName, "-") == 0)
-                    {
-                        fprintf(stderr, "cannot use --creation-time auto with stdin, defaulting to 0\n");
-                    }
-                    else
-                    {
-#ifdef _WIN32
-                        time_t mtime = 0;
-                        if (win32_mtime_utf8(audioFileName, &mtime) == 0)
-                        {
-                            final_creation_time = (uint32_t)mtime;
-                        }
-#else
-                        struct stat st;
-                        if (stat(audioFileName, &st) == 0)
-                        {
-                            final_creation_time = (uint32_t)st.st_mtime;
-                        }
-#endif
-                        else
-                        {
-                            fprintf(stderr, "couldn't stat() input file %s, defaulting to 0\n", audioFileName);
-                        }
-                    }
-                }
-                else if (!strcmp(creation_time_str, "now"))
-                {
-                    final_creation_time = (uint32_t)time(NULL);
-                }
-                else
-                {
-                    char *endptr;
-                    errno = 0;
-                    final_creation_time = (uint32_t)strtoul(creation_time_str, &endptr, 10);
-                    if (errno != 0 || *endptr != '\0')
-                    {
-                        fprintf(stderr, "invalid creation time %s, defaulting to 0\n", creation_time_str);
-                        final_creation_time = 0;
-                    }
-                }
-            }
-            else
-            {
-                const char *sde = getenv("SOURCE_DATE_EPOCH");
-                if (sde)
-                {
-                    char *endptr;
-                    errno = 0;
-                    final_creation_time = (uint32_t)strtoul(sde, &endptr, 10);
-                    if (errno != 0 || *endptr != '\0')
-                    {
-                        fprintf(stderr, "invalid SOURCE_DATE_EPOCH %s, ignoring\n", sde);
-                        final_creation_time = 0;
-                    }
-                }
-            }
-            mp4_set_creation_time(final_creation_time);
-        }
-
-        if (mp4_finish())
-            fprintf(stderr, "mp4_finish() failed: output file may be incomplete\n");
-        mp4_close();
-
-        for (int i = 0; i < num_allocated; i++)
-            free(allocated_tags[i]);
-
-        free(version_string);
-
-        if (verbose >= 2)
-        {
-            fprintf(stderr, "%u frames\n", mp4_frame_count());
-            fprintf(stderr, "%llu output samples\n", (unsigned long long)mp4_sample_count());
-            fprintf(stderr, "max bitrate: %u\n", mp4_max_bitrate());
-            fprintf(stderr, "avg bitrate: %u\n", mp4_avg_bitrate());
-            fprintf(stderr, "max frame size: %u\n", mp4_max_frame_size());
-        }
-    }
-    else
-    {
-        fclose(outfile);
-    }
-
-    faac_encoder_close(&hEncoder);
-
-    wav_close(infile);
-
-    if (artData)
-        free(artData);
-    if (pcmbuf)
-        free(pcmbuf);
-    if (bitbuf)
-        free(bitbuf);
-    if (aacFileNameGiven)
-        free(aacFileName);
-    if (chanmap)
-        free(chanmap);
+cleanup:
+    if (aacFileName) free(aacFileName);
+    free_encode_options(&opts);
 
 #ifdef _WIN32
     if (allocated_argv)
@@ -1418,5 +903,5 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    return 0;
+    return ret;
 }

--- a/frontend/maingui.c
+++ b/frontend/maingui.c
@@ -1,6 +1,7 @@
 /*
  * FAAC - Freeware Advanced Audio Coder
  * Copyright (C) 2001 Menno Bakker
+ * Copyright (C) 2026 Nils Schimmelmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -17,19 +18,77 @@
 #include <commdlg.h>
 #include <commctrl.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <inttypes.h>
 
 #include "input.h"
-
 #include <faac.h>
 #include "resource.h"
+#include "output.h"
 #include "charset.h"
+#include "encode_engine.h"
 
+#define WM_USER_PROGRESS    (WM_USER + 101)
+#define WM_USER_SESS_START  (WM_USER + 102)
+#define WM_USER_LOG         (WM_USER + 103)
+#define WM_USER_SUMMARY     (WM_USER + 104)
+#define WM_USER_ENCODE_DONE (WM_USER + 105)
+
+#define GUI_PROGRESS_RANGE       1024
+#define GUI_PROGRESS_THROTTLE_MS 33
 
 static HINSTANCE hInstance;
+static HWND hwndTip;
 
-static WCHAR inputFilename[_MAX_PATH], outputFilename[_MAX_PATH];
+/* Wide-char at the Win32 edge (dialog controls, file dialogs, drag-drop);
+   converted to UTF-8 via win32_utf16_to_utf8() right before crossing into
+   the UTF-8-only libfrontend layer (encode_options_t, wav_open_read(),
+   get_output_filename()). Filenames outside the current ANSI code page
+   can't round-trip through the narrow Win32 APIs, hence wide at the edge. */
+static WCHAR inputFilename[_MAX_PATH];
+static WCHAR outputFilename[_MAX_PATH];
 
 static BOOL Encoding = FALSE;
+
+typedef struct {
+    HWND hWnd;
+    WCHAR inputFilename[_MAX_PATH];
+    WCHAR outputFilename[_MAX_PATH];
+} encode_thread_param_t;
+
+enum RateMode {
+    RATEMODE_VBR = 0,
+    RATEMODE_ABR = 1
+};
+
+static progress_info_t g_gui_progress;
+static encode_session_info_t g_gui_sess_info;
+static encode_summary_t g_gui_summary;
+static char g_gui_log_msg[256];
+static progress_throttle_t g_gui_throttle;
+static bool g_gui_progress_posted = false;
+static CRITICAL_SECTION g_cs_progress;
+
+static void SetProgressBarPos(HWND hDlg, int control_id, int pos, int max_pos)
+{
+    HWND hProgress = GetDlgItem(hDlg, control_id);
+    if (!hProgress) return;
+
+    if (pos < max_pos)
+    {
+        SendMessage(hProgress, PBM_SETPOS, (WPARAM)(pos + 1), 0);
+        SendMessage(hProgress, PBM_SETPOS, (WPARAM)pos, 0);
+    }
+    else
+    {
+        SendMessage(hProgress, PBM_SETRANGE32, 0, (LPARAM)(max_pos + 1));
+        SendMessage(hProgress, PBM_SETPOS, (WPARAM)(max_pos + 1), 0);
+        SendMessage(hProgress, PBM_SETPOS, (WPARAM)max_pos, 0);
+        SendMessage(hProgress, PBM_SETRANGE32, 0, (LPARAM)max_pos);
+    }
+}
 
 static BOOL SelectFileName(HWND hParent, WCHAR *filename, BOOL forReading)
 {
@@ -60,13 +119,16 @@ static BOOL SelectFileName(HWND hParent, WCHAR *filename, BOOL forReading)
         ofn.lpstrTitle = L"Select Source File";
 
         return GetOpenFileNameW(&ofn);
-    } else {
+    }
+    else
+    {
         static const WCHAR filters[] =
+            L"MPEG-4 Audio (*.m4a)\0*.m4a\0"
             L"AAC Files (*.aac)\0*.aac\0"
             L"All Files (*.*)\0*.*\0\0";
 
         ofn.lpstrFilter = filters;
-        ofn.lpstrDefExt = L"aac";
+        ofn.lpstrDefExt = L"m4a";
         ofn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY;
         ofn.lpstrTitle = L"Select Output File";
 
@@ -74,261 +136,407 @@ static BOOL SelectFileName(HWND hParent, WCHAR *filename, BOOL forReading)
     }
 }
 
+static void AddTip(HWND hDlg, int ctrlId, const char *text)
+{
+    TOOLINFO ti = { .cbSize = sizeof(ti) };
+    ti.uFlags = TTF_SUBCLASS | TTF_IDISHWND;
+    ti.hwnd = hDlg;
+    ti.uId = (UINT_PTR)GetDlgItem(hDlg, ctrlId);
+    ti.lpszText = (LPSTR)text;
+    SendMessage(hwndTip, TTM_ADDTOOL, 0, (LPARAM)&ti);
+}
+
+static LRESULT GetComboData(HWND hWnd, int control_id, LRESULT default_val)
+{
+    HWND hCtrl = GetDlgItem(hWnd, control_id);
+    LRESULT sel = SendMessage(hCtrl, CB_GETCURSEL, 0, 0);
+    LRESULT data = (sel != CB_ERR) ? SendMessage(hCtrl, CB_GETITEMDATA, (WPARAM)sel, 0) : CB_ERR;
+    return (data != CB_ERR) ? data : default_val;
+}
+
+/* Sets the quality/bitrate label + edit box for the given rate mode, shared
+   by WM_INITDIALOG's initial state and the IDC_RATEMODE CBN_SELCHANGE
+   handler so the two don't drift out of sync. */
+static void ApplyRateModeUI(HWND hWnd, int mode)
+{
+    char text[16];
+
+    if (mode == RATEMODE_VBR)
+    {
+        SetDlgItemText(hWnd, IDC_QUALITYLABEL, "Quantizer\nquality");
+        snprintf(text, sizeof(text), "%d", DEFAULT_QUANT_QUALITY);
+    }
+    else
+    {
+        SetDlgItemText(hWnd, IDC_QUALITYLABEL, "Bitrate\n(kbps)");
+        snprintf(text, sizeof(text), "%d", DEFAULT_ABR_KBPS);
+    }
+    SetDlgItemText(hWnd, IDC_QUALITY, text);
+}
+
 static void AwakeDialogControls(HWND hWnd)
 {
     char szTemp[64];
     pcmfile_t *infile = NULL;
-    unsigned int sampleRate, numChannels;
-    WCHAR *pExt;
-
     char *utf8_input = win32_utf16_to_utf8(inputFilename);
-    if (!utf8_input)
+
+    if (!utf8_input || (infile = wav_open_read(utf8_input, 0)) == NULL)
+    {
+        free(utf8_input);
         return;
+    }
 
-    infile = wav_open_read(utf8_input, 0);
-    free(utf8_input);
-
-    if (!infile)
-        return;
-
-    /* determine input file parameters */
-    sampleRate = infile->samplerate;
-    numChannels = infile->channels;
+    unsigned int sampleRate = infile->samplerate;
+    unsigned int numChannels = infile->channels;
 
     wav_close(infile);
 
     SetDlgItemTextW(hWnd, IDC_INPUTFILENAME, inputFilename);
 
-    wcsncpy(outputFilename, inputFilename, (sizeof(outputFilename) / sizeof(WCHAR)) - 5);
-    outputFilename[(sizeof(outputFilename) / sizeof(WCHAR)) - 5] = L'\0';
-
-    pExt = wcsrchr(outputFilename, L'.');
-
-    if (pExt == NULL) wcscat(outputFilename, L".aac");
-    else wcscpy(pExt, L".aac");
+    char *utf8_output = get_output_filename(utf8_input, 1 /* GUI always defaults to MP4 */);
+    free(utf8_input);
+    if (utf8_output)
+    {
+        int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8_output, -1, NULL, 0);
+        if (wlen > 0 && wlen <= _MAX_PATH)
+            MultiByteToWideChar(CP_UTF8, 0, utf8_output, -1, outputFilename, wlen);
+        free(utf8_output);
+    }
 
     EnableWindow(GetDlgItem(hWnd, IDC_OUTPUTFILENAME), TRUE);
     EnableWindow(GetDlgItem(hWnd, IDC_SELECT_OUTPUTFILE), TRUE);
 
     SetDlgItemTextW(hWnd, IDC_OUTPUTFILENAME, outputFilename);
 
-    wsprintf(szTemp, "%iHz %ich", sampleRate, numChannels);
+    snprintf(szTemp, sizeof(szTemp), "%uHz %uch", sampleRate, numChannels);
     SetDlgItemText(hWnd, IDC_INPUTPARAMS, szTemp);
 
     EnableWindow(GetDlgItem(hWnd, IDOK), TRUE);
 }
 
+static bool GuiProgressCallback(const progress_info_t *info, void *user_data)
+{
+    HWND hWnd = (HWND)user_data;
+
+    if (!Encoding)
+        return false;
+
+    EnterCriticalSection(&g_cs_progress);
+    /* Throttle updates to ~30 Hz (33ms) to avoid message queue spamming. */
+    bool should_update = info->is_final ||
+                         progress_throttle_tick(&g_gui_throttle, info,
+                                                 GUI_PROGRESS_THROTTLE_MS / 1000.0);
+    bool do_post = false;
+    if (should_update)
+    {
+        g_gui_progress = *info;
+        if (!g_gui_progress_posted || info->is_final)
+        {
+            g_gui_progress_posted = true;
+            do_post = true;
+        }
+    }
+    LeaveCriticalSection(&g_cs_progress);
+
+    if (do_post)
+    {
+        PostMessage(hWnd, WM_USER_PROGRESS, 0, 0);
+    }
+
+    return true;
+}
+
+static void GuiSessionStartCallback(const encode_session_info_t *info, void *user_data)
+{
+    HWND hWnd = (HWND)user_data;
+    if (!info)
+        return;
+
+    EnterCriticalSection(&g_cs_progress);
+    g_gui_sess_info = *info;
+    LeaveCriticalSection(&g_cs_progress);
+
+    PostMessage(hWnd, WM_USER_SESS_START, 0, 0);
+}
+
+static void GuiLogCallback(int level, const char *message, void *user_data)
+{
+    HWND hWnd = (HWND)user_data;
+    (void)level;
+    if (!message)
+        return;
+
+    EnterCriticalSection(&g_cs_progress);
+    snprintf(g_gui_log_msg, sizeof(g_gui_log_msg), "%s", message);
+    LeaveCriticalSection(&g_cs_progress);
+
+    PostMessage(hWnd, WM_USER_LOG, 0, 0);
+}
+
+static void GuiSummaryCallback(const encode_summary_t *summary, void *user_data)
+{
+    HWND hWnd = (HWND)user_data;
+    if (!summary)
+        return;
+
+    EnterCriticalSection(&g_cs_progress);
+    g_gui_summary = *summary;
+    LeaveCriticalSection(&g_cs_progress);
+
+    PostMessage(hWnd, WM_USER_SUMMARY, 0, 0);
+}
+
 static DWORD WINAPI EncodeFile(LPVOID pParam)
 {
-    HWND hWnd = (HWND) pParam;
-    pcmfile_t *infile = NULL;
+    encode_thread_param_t *param = (encode_thread_param_t *)pParam;
+    if (!param)
+        return 1;
 
-    GetDlgItemTextW(hWnd, IDC_INPUTFILENAME, inputFilename, sizeof(inputFilename) / sizeof(WCHAR));
-    GetDlgItemTextW(hWnd, IDC_OUTPUTFILENAME, outputFilename, sizeof(outputFilename) / sizeof(WCHAR));
+    HWND hWnd = param->hWnd;
 
-    char *utf8_input = win32_utf16_to_utf8(inputFilename);
-    if (utf8_input)
+    EnterCriticalSection(&g_cs_progress);
+    progress_throttle_reset(&g_gui_throttle);
+    LeaveCriticalSection(&g_cs_progress);
+
+    char *utf8_input = win32_utf16_to_utf8(param->inputFilename);
+    char *utf8_output = win32_utf16_to_utf8(param->outputFilename);
+    free(param);
+
+    encode_options_t opts;
+    init_encode_options(&opts);
+
+    opts.input_filename = utf8_input;
+    opts.output_filename = utf8_output;
+    opts.container_mp4 = utf8_output && is_mp4_filename(utf8_output);
+    opts.overwrite = true;
+
+    opts.object_type = (enum faac_object_type)GetComboData(hWnd, IDC_OBJECTTYPE, FAAC_OBJ_AUTO);
+
     {
-        infile = wav_open_read(utf8_input, 0);
-        free(utf8_input);
+        LRESULT mode = SendMessage(GetDlgItem(hWnd, IDC_JOINTMODE), CB_GETCURSEL, 0, 0);
+        opts.joint_mode = (mode == CB_ERR) ? FAAC_JOINT_MIXED : (enum faac_joint_mode)mode;
     }
 
-    /* open the input file */
-    if (infile != NULL)
+    opts.shortctl = (enum faac_shortctl_mode)GetComboData(hWnd, IDC_SHORTCTL, FAAC_SHORTCTL_NORMAL);
+
+    opts.use_tns = IsDlgButtonChecked(hWnd, IDC_USETNS) == BST_CHECKED;
+    opts.stream_format = opts.container_mp4 ? FAAC_STREAM_RAW : FAAC_STREAM_ADTS;
+
+    char szTemp[256];
+    GetDlgItemText(hWnd, IDC_QUALITY, szTemp, sizeof(szTemp));
+
     {
-        /* determine input file parameters */
-        unsigned int sampleRate = infile->samplerate;
-        unsigned int numChannels = infile->channels;
-
-        unsigned long inputSamples;
-        unsigned long maxOutputBytes;
-
-        /* set up parameters and open the encoder */
-        faac_params params;
-        faac_encoder *hEncoder = NULL;
-	char szTemp[256];
-
-        faac_params_init(&params, sizeof(params));
-        params.sample_rate  = sampleRate;
-        params.num_channels = numChannels;
-        params.input_format = FAAC_INPUT_FLOAT;   /* wav_read_float32 -> scaled float */
-        {
-            HWND hOT = GetDlgItem(hWnd, IDC_OBJECTTYPE);
-            LRESULT sel  = SendMessage(hOT, CB_GETCURSEL, 0, 0);
-            LRESULT data = (sel != CB_ERR) ? SendMessage(hOT, CB_GETITEMDATA, (WPARAM)sel, 0) : CB_ERR;
-            params.object_type = (data != CB_ERR) ? (enum faac_object_type)data : FAAC_OBJ_AUTO;
-        }
-        {
-            LRESULT mode = SendMessage(GetDlgItem(hWnd, IDC_JOINTMODE), CB_GETCURSEL, 0, 0);
-            params.joint_mode = (mode == CB_ERR) ? FAAC_JOINT_MIXED : (enum faac_joint_mode)mode;
-        }
-        params.use_tns = IsDlgButtonChecked(hWnd, IDC_USETNS) == BST_CHECKED;
-        params.use_lfe = IsDlgButtonChecked(hWnd, IDC_USELFE) == BST_CHECKED;
-        params.output_format = IsDlgButtonChecked(hWnd, IDC_USERAW) == BST_CHECKED
-                             ? FAAC_STREAM_RAW : FAAC_STREAM_ADTS;
-        params.mpeg_version = (enum faac_mpeg_version)
-            SendMessage(GetDlgItem(hWnd, IDC_MPEGVERSION), CB_GETCURSEL, 0, 0);
-
-        GetDlgItemText(hWnd, IDC_QUALITY, szTemp, sizeof(szTemp));
-	params.quant_quality = atoi(szTemp);
-	params.bit_rate = 0;  /* quality-driven; no bitrate control in this dialog */
-	if (IsDlgButtonChecked(hWnd, IDC_BWCTL) == BST_CHECKED)
-	{
-            GetDlgItemText(hWnd, IDC_BANDWIDTH, szTemp, sizeof(szTemp));
-            params.bandwidth = atoi(szTemp);
-	}
-
-        if (faac_encoder_open(&params, &hEncoder) == FAAC_OK)
-        {
-            HANDLE hOutfile;
-
-            faac_encoder_info info;
-            info.struct_size = sizeof(info);
-            faac_encoder_get_info(hEncoder, &info);
-
-            inputSamples   = (unsigned long)info.frame_samples * numChannels;
-            maxOutputBytes = info.max_output_bytes;
-
-	    sprintf(szTemp, "%u", info.quant_quality);
-	    SetDlgItemText(hWnd, IDC_QUALITY, szTemp);
-
-	    sprintf(szTemp, "%u", info.bandwidth);
-	    SetDlgItemText(hWnd, IDC_BANDWIDTH, szTemp);
-
-            /* open the output file */
-            hOutfile = CreateFileW(outputFilename, GENERIC_WRITE, 0, NULL,
-                CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-
-            if (hOutfile != INVALID_HANDLE_VALUE)
-            {
-                UINT startTime = GetTickCount(), lastUpdated = 50;
-                DWORD totalBytesRead = 0;
-
-                unsigned int bytesInput = 0;
-                DWORD numberOfBytesWritten = 0;
-                float *pcmbuf;
-                unsigned char *bitbuf;
-                char HeaderText[50];
-                char Percentage[5];
-
-                pcmbuf = (float*)LocalAlloc(0, inputSamples*sizeof(float));
-                bitbuf = (unsigned char*)LocalAlloc(0, maxOutputBytes*sizeof(unsigned char));
-
-                SendDlgItemMessage(hWnd, IDC_PROGRESS, PBM_SETRANGE, 0, MAKELPARAM(0, 1024));
-                SendDlgItemMessage(hWnd, IDC_PROGRESS, PBM_SETPOS, 0, 0);
-
-                for ( ;; )
-                {
-                    int bytesWritten;
-                    UINT timeElapsed, timeEncoded;
-
-                    bytesInput = wav_read_float32(infile, pcmbuf, inputSamples, NULL) * sizeof(float);
-
-                    SendDlgItemMessage (hWnd, IDC_PROGRESS, PBM_SETPOS, (unsigned long)((float)totalBytesRead * 1024.0f / (infile->samples*sizeof(int)*numChannels)), 0);
-
-                    /* Percentage for Dialog Output */
-                    _itoa((int)((float)totalBytesRead * 100.0f / (infile->samples*sizeof(int)*numChannels)),Percentage,10);
-                    lstrcpy(HeaderText,"FAAC GUI: ");
-                    lstrcat(HeaderText,Percentage);
-                    lstrcat(HeaderText,"%");
-                    SendMessage(hWnd,WM_SETTEXT,0,(LPARAM)HeaderText);
-
-                    totalBytesRead += bytesInput;
-
-                    timeElapsed = (GetTickCount () - startTime) / 10;
-                    timeEncoded = 100.0 * totalBytesRead / (sampleRate * numChannels * sizeof (int));
-
-                    if (timeElapsed > (lastUpdated + 20))
-                    {
-                        float factor;
-			unsigned timeLeft;
-
-                        lastUpdated = timeElapsed;
-
-                        factor = (float) timeEncoded / (float) (timeElapsed ? timeElapsed : 1);
-			timeLeft = 10.0 * infile->samples / sampleRate / factor - 0.1 * timeElapsed;
-
-			sprintf(szTemp, "Playing time: %2.2i:%04.1f\tEncoding time: %2.2i:%04.1f\n"
-				"Play/enc factor: %.2f\tEstimated time left: %2.2i:%04.1f",
-				timeEncoded / 6000, 0.01 * (timeEncoded % 6000),
-				timeElapsed / 6000, 0.01 * (timeElapsed % 6000),
-				factor,
-				timeLeft / 600, 0.1 * (timeLeft % 600)
-			       );
-
-                        SetDlgItemText(hWnd, IDC_TIME, szTemp);
-                    }
-
-                    /* call the actual encoding routine */
-                    {
-                        uint32_t nbytes = 0;
-                        faac_status st = faac_encoder_encode(hEncoder,
-                            pcmbuf,
-                            (uint32_t)(bytesInput/sizeof(float)),
-                            bitbuf,
-                            (uint32_t)maxOutputBytes,
-                            &nbytes);
-                        bytesWritten = (st == FAAC_OK) ? (int)nbytes : -1;
-                    }
-
-                    /* Stop Pressed */
-                    if ( !Encoding )
-                        break;
-
-                    /* all done, bail out */
-                    if (!bytesInput && !bytesWritten)
-                        break;
-
-                    if (bytesWritten < 0)
-                    {
-                        MessageBox (hWnd, "faac_encoder_encode failed!", "Error", MB_OK | MB_ICONSTOP);
-                        break;
-                    }
-
-                    WriteFile(hOutfile, bitbuf, bytesWritten, &numberOfBytesWritten, NULL);
-
-                    }
-
-                CloseHandle(hOutfile);
-                if (pcmbuf) LocalFree(pcmbuf);
-                if (bitbuf) LocalFree(bitbuf);
-            }
-
-            faac_encoder_close(&hEncoder);
-        }
-
-        wav_close(infile);
-        MessageBeep(1);
-
-        SendDlgItemMessage(hWnd, IDC_PROGRESS, PBM_SETPOS, 0, 0);
-    } else {
-        MessageBox(hWnd, "Couldn't open input file!", "Error", MB_OK | MB_ICONSTOP);
+        LRESULT mode = GetComboData(hWnd, IDC_RATEMODE, RATEMODE_VBR);
+        parse_quality_or_bitrate(szTemp, mode == RATEMODE_ABR, &opts);
     }
 
-    SendMessage(hWnd,WM_SETTEXT,0,(LPARAM)"FAAC GUI");
-    Encoding = FALSE;
-    SetDlgItemText(hWnd, IDOK, "Encode");
+    GetDlgItemText(hWnd, IDC_PNS, szTemp, sizeof(szTemp));
+    if (szTemp[0] != '\0')
+    {
+        int pns = atoi(szTemp);
+        opts.pns_level = (pns < 0) ? 0 : ((pns > 10) ? 10 : (int8_t)pns);
+    }
+    else
+    {
+        opts.pns_level = -1;
+    }
+
+    if (IsDlgButtonChecked(hWnd, IDC_BWCTL) == BST_CHECKED)
+    {
+        GetDlgItemText(hWnd, IDC_BANDWIDTH, szTemp, sizeof(szTemp));
+        int bw = atoi(szTemp);
+        opts.bandwidth = (bw > 0) ? (uint32_t)bw : 0;
+    }
+
+    encode_callbacks_t cbs = {
+        .progress_cb = GuiProgressCallback,
+        .session_start_cb = GuiSessionStartCallback,
+        .summary_cb = GuiSummaryCallback,
+        .log_cb = GuiLogCallback,
+        .user_data = hWnd
+    };
+
+    EnterCriticalSection(&g_cs_progress);
+    g_gui_log_msg[0] = '\0';
+    LeaveCriticalSection(&g_cs_progress);
+
+    int status = (utf8_input && utf8_output)
+        ? run_encoding_session_ext(&opts, &cbs)
+        : ENCODE_ERROR;
+
+    free(utf8_input);
+    free(utf8_output);
+    free_encode_options(&opts);
+
+    PostMessage(hWnd, WM_USER_ENCODE_DONE, (WPARAM)status, 0);
     return 0;
 }
 
-static BOOL WINAPI DialogProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+static INT_PTR CALLBACK DialogProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
+    (void)lParam;
     switch (msg)
     {
+    case WM_USER_PROGRESS:
+        {
+            progress_info_t info;
+            EnterCriticalSection(&g_cs_progress);
+            info = g_gui_progress;
+            g_gui_progress_posted = false;
+            LeaveCriticalSection(&g_cs_progress);
+
+            if (info.total_input_samples > 0)
+            {
+                double ratio = (double)info.current_input_samples / (double)info.total_input_samples;
+                if (ratio > 1.0) ratio = 1.0;
+                if (ratio < 0.0) ratio = 0.0;
+
+                int pos = (int)(ratio * (double)GUI_PROGRESS_RANGE);
+                SetProgressBarPos(hWnd, IDC_PROGRESS, pos, GUI_PROGRESS_RANGE);
+
+                char HeaderText[64];
+                int percent = (int)(ratio * 100.0);
+                snprintf(HeaderText, sizeof(HeaderText), "FAAC GUI: %d%%", percent);
+                SetWindowText(hWnd, HeaderText);
+            }
+
+            char szTemp[256];
+            double playingTime = (double)info.current_input_samples / (double)(info.sample_rate ? info.sample_rate : 1);
+            snprintf(szTemp, sizeof(szTemp),
+                "Playing time: %02d:%04.1f\tEncoding time: %02d:%04.1f\n"
+                "Play/enc factor: %.2f\tEstimated time left: %02d:%04.1f",
+                (int)playingTime / 60, (float)((int)(playingTime * 10.0) % 600) / 10.0f,
+                (int)(info.time_elapsed_sec / 60.0), (float)((int)(info.time_elapsed_sec * 10.0) % 600) / 10.0f,
+                (float)info.speed_factor,
+                (int)info.eta_sec / 60, (float)((int)(info.eta_sec * 10.0) % 600) / 10.0f);
+
+            SetDlgItemText(hWnd, IDC_TIME, szTemp);
+            return TRUE;
+        }
+
+    case WM_USER_SESS_START:
+        {
+            encode_session_info_t info;
+            EnterCriticalSection(&g_cs_progress);
+            info = g_gui_sess_info;
+            LeaveCriticalSection(&g_cs_progress);
+
+            char szParams[128];
+            const char *aot = (info.object_type == FAAC_OBJ_HE_AAC_V1) ? "HE-AAC v1" : "Low Complexity";
+            snprintf(szParams, sizeof(szParams), "%uHz %uch | %s | Cutoff: %uHz",
+                     info.sample_rate, info.num_channels, aot, info.bandwidth);
+            SetDlgItemText(hWnd, IDC_INPUTPARAMS, szParams);
+            return TRUE;
+        }
+
+    case WM_USER_LOG:
+        {
+            char log_msg[256];
+            EnterCriticalSection(&g_cs_progress);
+            snprintf(log_msg, sizeof(log_msg), "%s", g_gui_log_msg);
+            LeaveCriticalSection(&g_cs_progress);
+
+            if (log_msg[0] != '\0')
+            {
+                size_t len = strlen(log_msg);
+                if (len > 0 && log_msg[len - 1] == '\n')
+                    log_msg[len - 1] = '\0';
+                wchar_t *wmsg = win32_utf8_to_utf16(log_msg);
+                SetDlgItemTextW(hWnd, IDC_TIME, wmsg ? wmsg : L"");
+                free(wmsg);
+            }
+            return TRUE;
+        }
+
+    case WM_USER_SUMMARY:
+        {
+            encode_summary_t sum;
+            EnterCriticalSection(&g_cs_progress);
+            sum = g_gui_summary;
+            LeaveCriticalSection(&g_cs_progress);
+
+            char szSummary[256];
+            snprintf(szSummary, sizeof(szSummary),
+                     "Encoded %u frames (%" PRIu64 " samples) | Avg bitrate: %u kbps | Max frame size: %u bytes",
+                     sum.frame_count, sum.sample_count, sum.avg_bitrate, sum.max_frame_size);
+            SetDlgItemText(hWnd, IDC_TIME, szSummary);
+            return TRUE;
+        }
+
+    case WM_USER_ENCODE_DONE:
+        {
+            int status = (int)wParam;
+
+            if (status == ENCODE_ERROR)
+            {
+                char err[300] = "Encoding failed!";
+                EnterCriticalSection(&g_cs_progress);
+                if (g_gui_log_msg[0] != '\0')
+                {
+                    snprintf(err, sizeof(err), "Encoding failed:\n%s", g_gui_log_msg);
+                }
+                LeaveCriticalSection(&g_cs_progress);
+
+                wchar_t *werr = win32_utf8_to_utf16(err);
+                if (werr)
+                {
+                    SetDlgItemTextW(hWnd, IDC_TIME, werr);
+                    MessageBoxW(hWnd, werr, L"Error", MB_OK | MB_ICONSTOP);
+                    free(werr);
+                }
+                else
+                {
+                    SetDlgItemText(hWnd, IDC_TIME, err);
+                    MessageBox(hWnd, err, "Error", MB_OK | MB_ICONSTOP);
+                }
+                SendDlgItemMessage(hWnd, IDC_PROGRESS, PBM_SETPOS, 0, 0);
+            }
+            else if (status == ENCODE_SUCCESS)
+            {
+                SetProgressBarPos(hWnd, IDC_PROGRESS, GUI_PROGRESS_RANGE, GUI_PROGRESS_RANGE);
+                SetWindowText(hWnd, "FAAC GUI: 100%");
+                MessageBeep(MB_OK);
+            }
+            else /* ENCODE_CANCELLED */
+            {
+                SendDlgItemMessage(hWnd, IDC_PROGRESS, PBM_SETPOS, 0, 0);
+                SetWindowText(hWnd, "FAAC GUI");
+            }
+
+            Encoding = FALSE;
+            EnableWindow(GetDlgItem(hWnd, IDOK), TRUE);
+            SetDlgItemText(hWnd, IDOK, "Encode");
+            return TRUE;
+        }
+
     case WM_INITDIALOG:
-      {
-	faac_library_info libinfo = { .struct_size = sizeof(libinfo) };
-	char txt[100];
-	faac_get_library_info(&libinfo);
-	sprintf(txt, "libfaac version %s", libinfo.version ? libinfo.version : "?");
-	SetDlgItemText(hWnd, IDC_COMPILEDATE, txt);
-      }
+        {
+            faac_library_info libinfo = { .struct_size = sizeof(libinfo) };
+            if (faac_get_library_info(&libinfo) == FAAC_OK)
+            {
+                char txt[128];
+                snprintf(txt, sizeof(txt), "libfaac version %s", libinfo.version ? libinfo.version : "?");
+                SetDlgItemText(hWnd, IDC_COMPILEDATE, txt);
+            }
+            else
+            {
+                MessageBox(hWnd, "Wrong libfaac version!", "FAAC", MB_OK | MB_ICONERROR);
+                PostMessage(hWnd, WM_CLOSE, 0, 0);
+            }
+        }
 
-        inputFilename[0] = 0x00;
+        inputFilename[0] = L'\0';
+        outputFilename[0] = L'\0';
 
-        SendMessage(GetDlgItem(hWnd, IDC_MPEGVERSION), CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)"MPEG4");
-        SendMessage(GetDlgItem(hWnd, IDC_MPEGVERSION), CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)"MPEG2");
-        SendMessage(GetDlgItem(hWnd, IDC_MPEGVERSION), CB_SETCURSEL, 0, 0);
+        {
+            HWND hRM = GetDlgItem(hWnd, IDC_RATEMODE);
+            LRESULT idx;
+            idx = SendMessage(hRM, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)"VBR (Quality)");
+            SendMessage(hRM, CB_SETITEMDATA, idx, (LPARAM)RATEMODE_VBR);
+            idx = SendMessage(hRM, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)"ABR (Bitrate)");
+            SendMessage(hRM, CB_SETITEMDATA, idx, (LPARAM)RATEMODE_ABR);
+            SendMessage(hRM, CB_SETCURSEL, 0, 0);
+        }
 
         {
             HWND hOT = GetDlgItem(hWnd, IDC_OBJECTTYPE);
@@ -348,102 +556,160 @@ static BOOL WINAPI DialogProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         SendMessage(GetDlgItem(hWnd, IDC_JOINTMODE), CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)"Mixed");
         SendMessage(GetDlgItem(hWnd, IDC_JOINTMODE), CB_SETCURSEL, 3, 0);
 
-        CheckDlgButton(hWnd, IDC_USELFE, FALSE);
-        CheckDlgButton(hWnd, IDC_USERAW, FALSE);
+        {
+            HWND hSC = GetDlgItem(hWnd, IDC_SHORTCTL);
+            LRESULT idx;
+            idx = SendMessage(hSC, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)"Normal");
+            SendMessage(hSC, CB_SETITEMDATA, idx, (LPARAM)FAAC_SHORTCTL_NORMAL);
+            idx = SendMessage(hSC, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)"No Short");
+            SendMessage(hSC, CB_SETITEMDATA, idx, (LPARAM)FAAC_SHORTCTL_NOSHORT);
+            idx = SendMessage(hSC, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)"No Long");
+            SendMessage(hSC, CB_SETITEMDATA, idx, (LPARAM)FAAC_SHORTCTL_NOLONG);
+            SendMessage(hSC, CB_SETCURSEL, 0, 0);
+        }
+
         CheckDlgButton(hWnd, IDC_USETNS, FALSE);
-        SetDlgItemText(hWnd, IDC_QUALITY, "100");
+        ApplyRateModeUI(hWnd, RATEMODE_VBR);
+        SetDlgItemText(hWnd, IDC_PNS, "4"); /* library default, libfaac/faac.c */
         SetDlgItemText(hWnd, IDC_BANDWIDTH, "0");
+
+        hwndTip = CreateWindowEx(WS_EX_TOPMOST, TOOLTIPS_CLASS, NULL,
+            WS_POPUP | TTS_ALWAYSTIP | TTS_NOPREFIX | TTS_BALLOON,
+            CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+            hWnd, NULL, hInstance, NULL);
+        if (hwndTip)
+        {
+            SetWindowPos(hwndTip, HWND_TOPMOST, 0, 0, 0, 0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+            SendMessage(hwndTip, TTM_SETMAXTIPWIDTH, 0, 300); /* enables \n line breaks */
+
+            AddTip(hWnd, IDC_QUALITY,
+                "Percent (VBR) or kbps/channel (ABR), depending on Rate Mode.");
+            AddTip(hWnd, IDC_BWCTL,
+                "Cap the encoded bandwidth to a specific frequency instead of\n"
+                "letting the encoder choose it automatically.");
+            AddTip(hWnd, IDC_BANDWIDTH, "Cutoff frequency in Hz.");
+            AddTip(hWnd, IDC_RATEMODE,
+                "VBR (Quality) targets a quality level; ABR (Bitrate) targets\n"
+                "an average bitrate.");
+            AddTip(hWnd, IDC_OBJECTTYPE,
+                "Auto picks LC or HE-AAC v1 based on bitrate; force one to\n"
+                "override that choice.");
+            AddTip(hWnd, IDC_USETNS, "Temporal Noise Shaping: reduces pre-echo on transients.");
+            AddTip(hWnd, IDC_PNS, "Perceptual Noise Substitution level, 0-10; 0 disables it.");
+            AddTip(hWnd, IDC_SHORTCTL,
+                "Normal switches block length automatically; No Short/No Long\n"
+                "force one block type throughout the encode.");
+            AddTip(hWnd, IDC_JOINTMODE,
+                "None: independent channels. M/S and IS: fixed stereo coding.\n"
+                "Mixed: chooses dynamically per band (default).");
+        }
 
         DragAcceptFiles(hWnd, TRUE);
         return TRUE;
 
     case WM_DROPFILES:
-
-        if (DragQueryFileW((HDROP) wParam, 0, inputFilename, _MAX_PATH - 1))
+        if (!Encoding && DragQueryFileW((HDROP)wParam, 0, inputFilename, _MAX_PATH - 1))
             AwakeDialogControls(hWnd);
 
-        DragFinish((HDROP) wParam);
+        DragFinish((HDROP)wParam);
         return FALSE;
 
     case WM_COMMAND:
-
-        switch (wParam)
+        switch (LOWORD(wParam))
         {
         case IDOK:
-
-            if ( !Encoding )
+            if (!Encoding)
             {
-                DWORD retval;
-                CreateThread(NULL,0,EncodeFile,hWnd,0,&retval);
-                Encoding = TRUE;
-                SetDlgItemText(hWnd, IDOK, "Stop");
+                encode_thread_param_t *param = (encode_thread_param_t *)malloc(sizeof(encode_thread_param_t));
+                if (param)
+                {
+                    param->hWnd = hWnd;
+                    GetDlgItemTextW(hWnd, IDC_INPUTFILENAME, param->inputFilename, _MAX_PATH);
+                    GetDlgItemTextW(hWnd, IDC_OUTPUTFILENAME, param->outputFilename, _MAX_PATH);
+
+                    SendDlgItemMessage(hWnd, IDC_PROGRESS, PBM_SETRANGE, 0, MAKELPARAM(0, GUI_PROGRESS_RANGE));
+                    SendDlgItemMessage(hWnd, IDC_PROGRESS, PBM_SETPOS, 0, 0);
+
+                    Encoding = TRUE;
+                    SetDlgItemText(hWnd, IDOK, "Stop");
+
+                    DWORD retval;
+                    HANDLE hThread = CreateThread(NULL, 0, EncodeFile, param, 0, &retval);
+                    if (hThread)
+                    {
+                        CloseHandle(hThread);
+                    }
+                    else
+                    {
+                        Encoding = FALSE;
+                        SetDlgItemText(hWnd, IDOK, "Encode");
+                        free(param);
+                    }
+                }
             }
             else
             {
+                /* User clicked Stop: signal worker thread to cancel, then disable button until thread finishes */
                 Encoding = FALSE;
-                SetDlgItemText(hWnd, IDOK, "Encode");
+                EnableWindow(GetDlgItem(hWnd, IDOK), FALSE);
+                SetDlgItemText(hWnd, IDOK, "Stopping...");
             }
             return TRUE;
 
         case IDCANCEL:
-
             EndDialog(hWnd, TRUE);
             return TRUE;
 
         case IDC_SELECT_INPUTFILE:
-
-            if (SelectFileName(hWnd, inputFilename, TRUE))
+            if (!Encoding && SelectFileName(hWnd, inputFilename, TRUE))
                 AwakeDialogControls(hWnd);
-
             break;
 
         case IDC_SELECT_OUTPUTFILE:
-
-            if (SelectFileName(hWnd, outputFilename, FALSE))
+            if (!Encoding && SelectFileName(hWnd, outputFilename, FALSE))
             {
                 SetDlgItemTextW(hWnd, IDC_OUTPUTFILENAME, outputFilename);
             }
+            break;
 
+        case IDC_BWCTL:
+            switch (IsDlgButtonChecked(hWnd, IDC_BWCTL))
+            {
+            case BST_CHECKED:
+                EnableWindow(GetDlgItem(hWnd, IDC_BANDWIDTH), TRUE);
+                break;
+            case BST_UNCHECKED:
+                EnableWindow(GetDlgItem(hWnd, IDC_BANDWIDTH), FALSE);
+                break;
+            }
             break;
-	case IDC_BWCTL:
-	  switch (IsDlgButtonChecked(hWnd, IDC_BWCTL))
-	  {
-	  case BST_CHECKED:
-	    EnableWindow(GetDlgItem(hWnd, IDC_BANDWIDTH), TRUE);
-	    //SetDlgItemText(hWnd, IDC_BANDWIDTH, "0");
-            break;
-	  case BST_UNCHECKED:
-	    EnableWindow(GetDlgItem(hWnd, IDC_BANDWIDTH), FALSE);
-	    //SetDlgItemText(hWnd, IDC_BANDWIDTH, "");
-            break;
-	  }
-	  break;
 
-        case MAKEWPARAM(IDC_OBJECTTYPE, CBN_SELCHANGE):
-        {
-            HWND hOT  = GetDlgItem(hWnd, IDC_OBJECTTYPE);
-            HWND hMPG = GetDlgItem(hWnd, IDC_MPEGVERSION);
-            LRESULT sel  = SendMessage(hOT, CB_GETCURSEL, 0, 0);
-            LRESULT data = (sel != CB_ERR) ? SendMessage(hOT, CB_GETITEMDATA, (WPARAM)sel, 0) : CB_ERR;
-            if (data == (LRESULT)FAAC_OBJ_HE_AAC_V1) {
-                SendMessage(hMPG, CB_SETCURSEL, 0, 0);
-                EnableWindow(hMPG, FALSE);
-            } else {
-                EnableWindow(hMPG, TRUE);
+        case IDC_RATEMODE:
+            if (HIWORD(wParam) == CBN_SELCHANGE)
+            {
+                LRESULT mode = GetComboData(hWnd, IDC_RATEMODE, RATEMODE_VBR);
+                ApplyRateModeUI(hWnd, (int)mode);
             }
             break;
         }
-        }
-
         break;
     }
 
     return FALSE;
 }
 
-int WINAPI WinMain (HINSTANCE hInst, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
+int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
-    hInstance = hInst;
+    (void)hPrevInstance;
+    (void)lpCmdLine;
+    (void)nCmdShow;
 
-    return DialogBox(hInstance, MAKEINTRESOURCE (IDD_MAINDIALOG), NULL, (DLGPROC) DialogProc);
+    hInstance = hInst;
+    INITCOMMONCONTROLSEX icc = { sizeof(icc), ICC_BAR_CLASSES | ICC_WIN95_CLASSES };
+    InitCommonControlsEx(&icc);
+    InitializeCriticalSection(&g_cs_progress);
+    int res = (int)DialogBox(hInstance, MAKEINTRESOURCE(IDD_MAINDIALOG), NULL, DialogProc);
+    DeleteCriticalSection(&g_cs_progress);
+    return res;
 }

--- a/frontend/meson.build
+++ b/frontend/meson.build
@@ -1,30 +1,36 @@
+# Only charset.c uses iconv, so keep detection scoped here, not project-wide.
 libiconv = cc.find_library('iconv', required: false)
 has_iconv = cc.has_header('iconv.h') and cc.has_function('iconv_open', dependencies: [libiconv])
 
-faac_c_args = []
-if has_iconv
-    faac_c_args += '-DHAVE_ICONV'
-endif
+libfrontend = static_library('frontend',
+    ['input.c', 'mp4write.c', 'charset.c', 'output.c', 'encode_engine.c', 'progress.c',
+     'input.h', 'mp4write.h', 'charset.h', 'progress.h', 'output.h', 'encode_engine.h'],
+    include_directories: ['..', '../include'],
+    link_with: libfaac,
+    c_args: has_iconv ? ['-DHAVE_ICONV'] : [],
+    dependencies: [libiconv]
+)
 
 libshell32 = cc.find_library('shell32', required: target_machine.system() == 'windows')
 
 faac = executable('faac',
-    ['main.c', 'input.c', 'mp4write.c', 'output.c', 'charset.c',
-     'input.h', 'mp4write.h', 'output.h', 'charset.h'],
+    ['main.c'],
     include_directories: ['..', '../include'],
-    c_args: faac_c_args,
-    link_with: libfaac,
-    dependencies: [libshell32, libiconv],
+    link_with: [libfaac, libfrontend],
+    dependencies: [libshell32],
     install: true
 )
 
 if target_machine.system() == 'windows'
     windows = import('windows')
-    resource_src = windows.compile_resources('faacgui.rc', 'icon.rc')
+    resource_src = windows.compile_resources('faacgui.rc', 'icon.rc',
+        depend_files: 'faacgui.exe.manifest')
+    libcomctl32 = cc.find_library('comctl32', required: true)
     faacgui = executable('faacgui',
-        ['input.c', 'input.h', 'maingui.c', 'charset.c', 'charset.h', 'resource.h'] + resource_src,
+        ['maingui.c', 'resource.h'] + resource_src,
         include_directories: ['..', '../include'],
-        link_with: libfaac,
+        link_with: [libfaac, libfrontend],
+        dependencies: [libcomctl32],
         win_subsystem: 'windows',
         install: true
     )

--- a/frontend/progress.c
+++ b/frontend/progress.c
@@ -1,0 +1,38 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#include "progress.h"
+
+void progress_throttle_reset(progress_throttle_t *t)
+{
+    t->last_fired_sec = -1.0;
+    t->reached_end = false;
+}
+
+bool progress_throttle_tick(progress_throttle_t *t, const progress_info_t *info,
+                             double interval_sec)
+{
+    bool at_end = info->total_input_samples > 0 &&
+                  info->current_input_samples >= info->total_input_samples;
+    bool fire_edge = at_end && !t->reached_end;
+    if (at_end)
+        t->reached_end = true;
+
+    bool fire = fire_edge || t->last_fired_sec < 0.0 ||
+                (info->time_elapsed_sec - t->last_fired_sec) >= interval_sec;
+    if (fire)
+        t->last_fired_sec = info->time_elapsed_sec;
+    return fire;
+}

--- a/frontend/progress.h
+++ b/frontend/progress.h
@@ -1,0 +1,63 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#ifndef PROGRESS_H
+#define PROGRESS_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint64_t current_input_samples;
+    uint64_t total_input_samples;
+    uint32_t sample_rate;
+    uint16_t num_channels;
+    uint32_t current_frame;
+    uint32_t total_frames;
+    uint64_t total_bytes_written;
+    double time_elapsed_sec;
+    double speed_factor;
+    double eta_sec;
+    bool is_final; /* last call of the session; render unthrottled */
+} progress_info_t;
+
+/* Callback function type for reporting progress updates.
+   Return false from callback to signal user-cancelled encoding. */
+typedef bool (*progress_callback_t)(const progress_info_t *info, void *user_data);
+
+/* Shared rate-limiting for progress_callback_t implementations: encode_engine.c
+   calls progress_cb every frame so cancellation is checked promptly, but a
+   redraw that often is wasted work. Must fire on the end-of-input frame by
+   rising edge, not by level: current_input_samples stays pinned at the
+   total across every post-EOF flush frame, so a level check would re-fire
+   on each of those instead of once. */
+typedef struct {
+    double last_fired_sec;
+    bool reached_end;
+} progress_throttle_t;
+
+void progress_throttle_reset(progress_throttle_t *t);
+bool progress_throttle_tick(progress_throttle_t *t, const progress_info_t *info,
+                             double interval_sec);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PROGRESS_H */

--- a/frontend/resource.h
+++ b/frontend/resource.h
@@ -14,15 +14,15 @@
 #define IDC_TIME                        1008
 #define IDC_BANDWIDTH                   1009
 #define IDC_QUALITY                     1010
-#define IDC_USERAW                      1011
+#define IDC_PNS                         1011
 #define IDC_USETNS                      1012
-#define IDC_USELFE2                     1013
-#define IDC_USELFE                      1013
+#define IDC_SHORTCTL                    1013
 #define IDC_BWCTL                       1014
 
 #define IDC_COMPILEDATE                 1018
-#define IDC_MPEGVERSION                 1020
 #define IDC_OBJECTTYPE                  1021
+#define IDC_QUALITYLABEL                1022
+#define IDC_RATEMODE                    1023
 
 // Next default values for new objects
 // 
@@ -30,7 +30,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        104
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1022
+#define _APS_NEXT_CONTROL_VALUE         1024
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
Unify the CLI and Windows GUI around a shared frontend library, introducing MP4 container support to the GUI while fixing critical pipeline, memory, and validation issues.

* Shared Encoding Engine:
  - Extract input handling, encoder setup, MP4 output, metadata, logging, and progress tracking into a reusable frontend core
  - Implement callback API for thread-safe session reporting

* Features & GUI Upgrades:
  - Add native MP4 container output support to the Windows GUI
  - Expose VBR/ABR bitrates, PNS, and block control options in UI
  - Lock file list during encoding and improve progress reporting
  - Embed Windows common-controls manifest for modern UI styling

* Correctness & Bug Fixes:
  - Fix uninitialized WAV header reads on raw PCM inputs
  - Validate custom channel mappings (-I) and reject malformed/empty MP4 tags
  - Bound embedded artwork to 32 MiB max to prevent memory bloat
  - Ensure resource cleanup (buffers, encoders, temporary files) on error paths
  - Propagate CLI encoding errors properly instead of success
  - Handle GUI thread creation failures safely without locking UI

Fixes https://github.com/knik0/faac/issues/43 leveraging the 2.1 ABI contract

## GUI

<img width="411" height="368" alt="image" src="https://github.com/user-attachments/assets/0c496476-c6df-48e3-ac4f-12e5f52d724b" />

## Benchmark
https://github.com/nschimme/faac/actions/runs/32739244244

<img width="792" height="516" alt="image" src="https://github.com/user-attachments/assets/21be2298-1804-4f2d-83fe-5115c1a5fec8" />


