### PR TITLE
implement native 24-bit packed PCM input handling

### DIFF
--- a/include/faac.h
+++ b/include/faac.h
@@ -135,7 +135,7 @@ enum faac_stream_format {
 enum faac_input_format {
     FAAC_INPUT_NULL  = 0,            /* invalid / unset                          */
     FAAC_INPUT_16BIT,                /* native-endian int16                      */
-    FAAC_INPUT_24BIT,                /* native-endian int24 in 24 bits (unimpl.) */
+    FAAC_INPUT_24BIT,                /* native-endian int24 in 24 bits           */
     FAAC_INPUT_32BIT,                /* native-endian int24 in 32 bits           */
     FAAC_INPUT_FLOAT,                /* 32-bit float                             */
     FAAC_INPUT_MAX = 0x7fffffff

--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -166,10 +166,8 @@ static faac_status validate_params(const faac_params *p)
         default: return FAAC_ERR_INVALID_ARGUMENT;
     }
     switch (p->input_format) {
-        case FAAC_INPUT_16BIT: case FAAC_INPUT_32BIT: case FAAC_INPUT_FLOAT:
+        case FAAC_INPUT_16BIT: case FAAC_INPUT_24BIT: case FAAC_INPUT_32BIT: case FAAC_INPUT_FLOAT:
             break;
-        case FAAC_INPUT_24BIT:
-            return FAAC_ERR_UNSUPPORTED;   /* 24-in-24 not implemented */
         default:
             return FAAC_ERR_INVALID_ARGUMENT;
     }

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -188,6 +188,7 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
     switch( hEncoder->config.inputFormat )
     {
         case INPUT_16BIT:
+        case INPUT_24BIT:
         case INPUT_32BIT:
         case INPUT_FLOAT:
             break;
@@ -481,6 +482,20 @@ static int appendInputFifo(faacEncStruct *hEncoder, int32_t *inputBuffer,
             case INPUT_16BIT: {
                 short *src = (short *)inputBuffer + hEncoder->config.channel_map[channel];
                 for (i = 0; i < spch; i++) { dst[i] = (float)*src; src += numChannels; }
+                break;
+            }
+            case INPUT_24BIT: {
+                const uint8_t *src_base = (const uint8_t *)inputBuffer;
+                for (i = 0; i < spch; i++) {
+                    const uint8_t *src = src_base + (i * numChannels + hEncoder->config.channel_map[channel]) * 3;
+#if defined(WORDS_BIGENDIAN) && WORDS_BIGENDIAN
+                    int32_t s = ((int32_t)src[0] << 16) | ((int32_t)src[1] << 8) | (int32_t)src[2];
+#else
+                    int32_t s = (int32_t)src[0] | ((int32_t)src[1] << 8) | ((int32_t)src[2] << 16);
+#endif
+                    if (s & 0x800000) s |= (int32_t)0xff000000;
+                    dst[i] = (1.0f / 256.0f) * (float)s;
+                }
                 break;
             }
             case INPUT_32BIT: {


### PR DESCRIPTION
This expands feature support for what we showcase in our ABI. This is behaviorally the same as what our frontend/ does.

Enable support for FAAC_INPUT_24BIT across validation routines and implement unpacking, sign-extension, and float conversion in frame processing.

- Update include/faac.h to remove the "(unimpl.)" status flag on FAAC_INPUT_24BIT
- Update validate_params() in libfaac/faac.c and faacEncApplyConfig() in libfaac/frame.c to accept FAAC_INPUT_24BIT without returning FAAC_ERR_UNSUPPORTED
- Implement byte-level unpacking for 3-byte native-endian signed PCM in appendInputFifo(), including bitwise sign extension to 32-bit signed int and scaling to match existing 24-in-32 fixed-point input scaling

## Benchmark

https://github.com/nschimme/faac/actions/runs/32753145839

<img width="801" height="494" alt="image" src="https://github.com/user-attachments/assets/7d4bf45b-53d8-428b-9cfb-53d09533d373" />
