### PR TITLE
sbr: fix parameter resolution in VBR mode and transient normalization

### DIFF
--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -308,7 +308,8 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
 
     if (hEncoder->config.aacObjectType == HE_V1) {
         SBRContext *sCtx = hEncoder->sbrContext;
-        SbrContextUpdateConfig(sCtx, hEncoder->numChannels, hEncoder->config.bitRate * hEncoder->numChannels, &hEncoder->fft_tables);
+        unsigned long sbr_bitrate = hEncoder->config.bitRate ? (hEncoder->config.bitRate * hEncoder->numChannels) : ((unsigned long)hEncoder->config.quantqual * 1280);
+        SbrContextUpdateConfig(sCtx, hEncoder->numChannels, sbr_bitrate, &hEncoder->fft_tables);
         /* kx * Fs / (2*64): each QMF band is Fs/(2*SBR_QMF_BANDS_64) Hz wide.
          * Matching core bandwidth to the SBR crossover avoids a gap or overlap. */
         hEncoder->config.bandWidth = SbrContextGetXOverBandwidth(sCtx);

--- a/libfaac/sbr_analysis.c
+++ b/libfaac/sbr_analysis.c
@@ -70,7 +70,7 @@ void SbrAnalyze(SignalAnalysis *sa, float *fullPtrs[], int nch, int numSamples, 
         }
         sa->ch[ch].lastVal = val_in;
 
-        sa->ch[ch].transientStrength = smax * (float)sampled / (ssum + SBR_ENERGY_FLOOR);
+        sa->ch[ch].transientStrength = smax * (float)num_slots / (ssum + SBR_ENERGY_FLOOR);
         sa->ch[ch].transientSlot = smax_idx;
 
         /* Evaluate relative energy jumps to inform block switching. */


### PR DESCRIPTION
These are correctness fixes. Neutral performance.

When running in VBR quality mode (-q), hEncoder->config.bitRate is 0, causing SbrUpdate() to default to low amplitude and coarse frequency resolutions (bs_amp_res = 0, dk = 2). Derive an effective nominal stream bitrate from quantqual when bitRate is 0 so HE-AAC uses fine resolution parameters.

Also update SbrAnalyze() to normalize transientStrength using the total slot count (num_slots) rather than the decimated count (sampled), preventing transient strength scaling artifacts during decimation.