### PR TITLE
build: force-include config.h via build system instead of per-file guards

### DIFF
--- a/frontend/charset.c
+++ b/frontend/charset.c
@@ -13,10 +13,6 @@
  * Lesser General Public License for more details.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/frontend/input.c
+++ b/frontend/input.c
@@ -13,10 +13,6 @@
  * Lesser General Public License for more details.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -307,7 +303,6 @@ pcmfile_t *wav_open_read(const char *name, bool rawinput)
 
   return sndf;
 }
-
 
 int *mk_chan_map(uint16_t channels, uint16_t center, uint16_t lf)
 {

--- a/frontend/input.h
+++ b/frontend/input.h
@@ -16,10 +16,6 @@
 #ifndef _INPUT_H
 #define _INPUT_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -16,10 +16,6 @@
  * Lesser General Public License for more details.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -307,7 +303,6 @@ static void help(int mode)
         break;
     }
 }
-
 
 static bool cli_progress_callback(const progress_info_t *info, void *user_data)
 {

--- a/libfaac/cpu_compute.c
+++ b/libfaac/cpu_compute.c
@@ -13,10 +13,6 @@
  * Lesser General Public License for more details.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "cpu_compute.h"
 
 #if defined(SSE2_ARCH)

--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -22,10 +22,6 @@
  * ASC. The opaque faac_encoder* is the core's faacEncStruct*.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/libfaac/frame.h
+++ b/libfaac/frame.h
@@ -27,10 +27,6 @@
 #define FIFO_AHEAD1     2
 #define FIFO_AHEAD2     3
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "faac_internal.h"
 
 #ifdef __cplusplus

--- a/libfaac/quantize_sse.c
+++ b/libfaac/quantize_sse.c
@@ -13,10 +13,6 @@
  * Lesser General Public License for more details.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include <immintrin.h>
 #include <math.h>
 #include "quantize.h"

--- a/libfaac/resample.h
+++ b/libfaac/resample.h
@@ -20,10 +20,6 @@
 #ifndef RESAMPLE_H
 #define RESAMPLE_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "coder.h"
 
 #ifdef __cplusplus

--- a/libfaac/sbr.h
+++ b/libfaac/sbr.h
@@ -16,10 +16,6 @@
 #ifndef SBR_H
 #define SBR_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "coder.h"
 #include "fft.h"
 #include "sbr_analysis.h"

--- a/libfaac/sbr_analysis.c
+++ b/libfaac/sbr_analysis.c
@@ -19,10 +19,6 @@
 #include "util.h"
 #include <string.h>
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 /* Multi-pass signal analysis: transient detection, temporal grid selection,
  * and subband energy accumulation. hot keeps it vectorized under LTO despite
  * only being reached through the cold dispatcher; SbrQmfAnalysis is inlined

--- a/libfaac/sbr_analysis.h
+++ b/libfaac/sbr_analysis.h
@@ -16,11 +16,6 @@
 #ifndef SBR_ANALYSIS_H
 #define SBR_ANALYSIS_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,10 +26,6 @@ extern "C" {
 
 #ifndef SBR_MAX_ENVELOPES
 #define SBR_MAX_ENVELOPES 2
-#endif
-
-#ifndef MAX_CHANNELS
-#define MAX_CHANNELS 64
 #endif
 
 struct SBRInfo;

--- a/libfaac/stereo.h
+++ b/libfaac/stereo.h
@@ -16,10 +16,6 @@
 #ifndef STEREO_H
 #define STEREO_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "channels.h"
 #include "util.h"
 

--- a/meson.build
+++ b/meson.build
@@ -8,8 +8,6 @@ project('faac', 'c',
         'b_lto=true'
     ])
 
-add_global_arguments('-DHAVE_CONFIG_H', language: 'c')
-
 cc = meson.get_compiler('c')
 if cc.get_argument_syntax() == 'msvc'
     # _s variants buy nothing here and aren't portable; suppress instead.
@@ -46,6 +44,13 @@ configure_file(
     output: 'config.h',
     configuration: config_h
 )
+
+# Force config.h into every TU instead of relying on each file's own include.
+if cc.get_argument_syntax() == 'msvc'
+    add_project_arguments('/FI' + meson.current_build_dir() / 'config.h', language: 'c')
+else
+    add_project_arguments('-include', meson.current_build_dir() / 'config.h', language: 'c')
+endif
 
 
 subdir('docs')


### PR DESCRIPTION
Per-file '#ifdef HAVE_CONFIG_H' guards fail silently when omitted. Three files omitted their guards and quietly ran on incorrect fallback macros, causing dead SSE2 quantization paths (broken since merged), missing WORDS_BIGENDIAN definitions, and invalid MAX_CHANNELS limits.

Forcing config.h into every translation unit via '-include' (GCC/Clang) and '/FI' (MSVC) at the project level makes header omission structurally impossible and cleans up boilerplate across the source tree.

Changes:
- Use add_project_arguments() in meson.build to force-include config.h globally without leaking flags into subprojects.
- Remove redundant `#include "config.h"` guards and redundant fallback macros from libfaac and frontend headers/sources.

Verification:
- Bit-exact output verified against master (ADTS/MP4 across multiple bitrates).
- Confirmed QuantizeInit correctly dispatches to quantize_sse2 in x86_64 GCC build.
- Benchmark: https://github.com/nschimme/faac/actions/runs/33415570120