### PR TITLE
add optional encoding diagnostics option and polish CLI summary

### DIFF
--- a/frontend/encode_engine.c
+++ b/frontend/encode_engine.c
@@ -588,7 +588,7 @@ int run_encoding_session_ext(const encode_options_t *opts,
 
     uint64_t total_input_samples = (infile->samples > 0) ? (uint64_t)infile->samples : 0;
     uint64_t tf_calc = (total_input_samples > 0 && frame_size > 0) ?
-        (((total_input_samples + frame_size - 1) / frame_size) + 1) : 0;
+        ((total_input_samples + info.encoder_delay + frame_size - 1) / frame_size) : 0;
     uint32_t total_frames = (tf_calc > UINT32_MAX) ? UINT32_MAX : (uint32_t)tf_calc;
 
     if (session_start_cb)

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -424,20 +424,29 @@ static void cli_summary_callback(const encode_summary_t *summary, void *user_dat
     if (!opts || opts->verbose < 2)
         return;
 
-    fprintf(stderr, "\n");
-    fprintf(stderr, "%u frames\n", summary->frame_count);
-    fprintf(stderr, "%" PRIu64 " output samples\n", summary->sample_count);
+    fprintf(stderr, "\n--- Encode Summary ---\n");
+    fprintf(stderr, " Frames & Samples    : Frames = %u | Samples = %" PRIu64 "\n",
+            summary->frame_count, summary->sample_count);
     if (summary->is_mp4)
     {
-        fprintf(stderr, "max bitrate: %u\n", summary->max_bitrate);
-        fprintf(stderr, "avg bitrate: %u\n", summary->avg_bitrate);
-        fprintf(stderr, "max frame size: %u\n", summary->max_frame_size);
+        fprintf(stderr, " Bitrate & Frame Size: Avg = %u | Max = %u | Max Frame Size = %u\n",
+                summary->avg_bitrate, summary->max_bitrate, summary->max_frame_size);
     }
     else
     {
-        fprintf(stderr, "avg bitrate: %u kbps\n", summary->avg_bitrate);
-        fprintf(stderr, "max frame size: %u bytes\n", summary->max_frame_size);
+        fprintf(stderr, " Bitrate & Frame Size: Avg = %u kbps | Max Frame Size = %u bytes\n",
+                summary->avg_bitrate, summary->max_frame_size);
     }
+
+    long input_size = get_file_size(opts->input_filename);
+    long output_size = get_file_size(opts->output_filename);
+    if (input_size > 0 && output_size > 0)
+    {
+        fprintf(stderr, " File Size           : Input = %.2f MB | Output = %.2f MB | Ratio = %.1f:1\n",
+                input_size / (1024.0 * 1024.0), output_size / (1024.0 * 1024.0),
+                (double)input_size / (double)output_size);
+    }
+    fprintf(stderr, "----------------------\n");
 }
 
 int main(int argc, char *argv[])

--- a/frontend/output.c
+++ b/frontend/output.c
@@ -23,6 +23,7 @@
 
 #ifdef _WIN32
 #define strcasecmp _stricmp
+#include "charset.h"
 #else
 #include <strings.h>
 #endif
@@ -116,4 +117,23 @@ bool check_image_header(const char *buf)
         return true;               /* GIF */
 
     return false;
+}
+
+long get_file_size(const char *filename)
+{
+    if (!filename || !strcmp(filename, "-"))
+        return -1;
+
+#ifdef _WIN32
+    FILE *f = win32_fopen_utf8(filename, "rb");
+#else
+    FILE *f = fopen(filename, "rb");
+#endif
+    if (!f)
+        return -1;
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fclose(f);
+    return size;
 }

--- a/frontend/output.h
+++ b/frontend/output.h
@@ -40,6 +40,10 @@ bool detect_container_mp4(const char *filename);
    --cover-art data before it's embedded as an MP4 covr atom. */
 bool check_image_header(const char *buf);
 
+/* Byte size of a regular file, or -1 if it can't be determined (missing,
+   or "-" for stdin/stdout, which has no meaningful size). */
+long get_file_size(const char *filename);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -399,11 +399,19 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
     return 1;
 }
 
+#ifdef FAAC_STATS
+faacEncStats g_faacStats;
+#endif
+
 faacEncHandle faacEncOpen(unsigned long sampleRate,
                                   unsigned int numChannels,
                                   unsigned long *inputSamples,
                                   unsigned long *maxOutputBytes)
 {
+#ifdef FAAC_STATS
+    memset(&g_faacStats, 0, sizeof(faacEncStats));
+    g_faacStats.minReservoirRatio = 100.0f;
+#endif
     unsigned int channel;
     faacEncStruct* hEncoder;
 
@@ -564,6 +572,71 @@ int faacEncClose(faacEncHandle hpEncoder)
     unsigned int channel;
 
     if (!hEncoder) return 0;
+
+#ifdef FAAC_STATS
+    if (g_faacStats.totalFrames > 0)
+    {
+        double qavg = g_faacStats.totalQuality / g_faacStats.totalFrames;
+        double tr = 100.0 * g_faacStats.transientFrames / g_faacStats.totalFrames;
+        double tns = g_faacStats.longBlocks > 0 ? 100.0 * g_faacStats.longBlocksTNS / g_faacStats.longBlocks : 0.0;
+        double ms = g_faacStats.totalBands > 0 ? 100.0 * g_faacStats.msBands / g_faacStats.totalBands : 0.0;
+        double is = g_faacStats.totalBands > 0 ? 100.0 * g_faacStats.isBands / g_faacStats.totalBands : 0.0;
+        double pns = g_faacStats.totalBands > 0 ? 100.0 * g_faacStats.pnsBands / g_faacStats.totalBands : 0.0;
+        double att_avg = g_faacStats.attackCount > 0 ? g_faacStats.totalAttack / g_faacStats.attackCount : 0.0;
+        float att_max = g_faacStats.maxAttack;
+
+        fprintf(stderr, "\n--- Encoder Diagnostics ---\n");
+        fprintf(stderr, " Quality             : Qavg    = %6.2f\n", qavg);
+
+        if (g_faacStats.sbrFrames > 0)
+        {
+            double sbr_tr = 100.0 * g_faacStats.sbrTransientFrames / g_faacStats.sbrFrames;
+            fprintf(stderr, " Transients & Grid   : Core Tr = %5.1f%% (%u/%u) | SBR Grid = %5.1f%% Var | Attack = %.1fx avg, %.1fx max\n",
+                    tr, g_faacStats.transientFrames, g_faacStats.totalFrames, sbr_tr, att_avg, att_max);
+        }
+        else
+        {
+            fprintf(stderr, " Transients & Grid   : Core Tr = %5.1f%% (%u/%u) | Attack = %.1fx avg, %.1fx max\n",
+                    tr, g_faacStats.transientFrames, g_faacStats.totalFrames, att_avg, att_max);
+        }
+
+        double peak_retry_pct = 100.0 * g_faacStats.peakRetryFrames / g_faacStats.totalFrames;
+
+        if (g_faacStats.sbrFrames > 0)
+        {
+            double sbr_invf = g_faacStats.sbrInvfCount > 0 ? (double)g_faacStats.sbrInvfSum / g_faacStats.sbrInvfCount : 0.0;
+            fprintf(stderr, " Tool Allocation     : M/S     = %5.1f%% | I/S = %5.1f%% | PNS = %5.1f%% | TNS = %5.1f%% | INVF = %.2f\n",
+                    ms, is, pns, tns, sbr_invf);
+        }
+        else
+        {
+            fprintf(stderr, " Tool Allocation     : M/S     = %5.1f%% | I/S = %5.1f%% | PNS = %5.1f%% | TNS = %5.1f%%\n",
+                    ms, is, pns, tns);
+        }
+        if (g_faacStats.reservoirFrames > 0 || g_faacStats.peakRetryFrames > 0)
+        {
+            if (g_faacStats.reservoirFrames > 0 && g_faacStats.peakRetryFrames > 0)
+            {
+                double res_fill = g_faacStats.totalReservoirRatio / g_faacStats.reservoirFrames;
+                fprintf(stderr, " Rate Control & Cap  : Reservoir Fill = %5.1f%% (min %5.1f%%, max %5.1f%%) | Peak Limit Retries = %5.1f%% (%u/%u)\n",
+                        res_fill, g_faacStats.minReservoirRatio, g_faacStats.maxReservoirRatio,
+                        peak_retry_pct, g_faacStats.peakRetryFrames, g_faacStats.totalFrames);
+            }
+            else if (g_faacStats.reservoirFrames > 0)
+            {
+                double res_fill = g_faacStats.totalReservoirRatio / g_faacStats.reservoirFrames;
+                fprintf(stderr, " Rate Control & Cap  : Reservoir Fill = %5.1f%% (min %5.1f%%, max %5.1f%%)\n",
+                        res_fill, g_faacStats.minReservoirRatio, g_faacStats.maxReservoirRatio);
+            }
+            else
+            {
+                fprintf(stderr, " Rate Control & Cap  : Peak Limit Retries = %5.1f%% (%u/%u)\n",
+                        peak_retry_pct, g_faacStats.peakRetryFrames, g_faacStats.totalFrames);
+            }
+        }
+        fprintf(stderr, "---------------------------\n");
+    }
+#endif
 
     PsyEnd(hEncoder->psyInfo, hEncoder->numChannels);
     FilterBankEnd(hEncoder);
@@ -754,6 +827,14 @@ int faacEncEncode(faacEncHandle hpEncoder,
 
     BlockSwitch(hEncoder, coderInfo, hEncoder->psyInfo, numChannels);
 
+#ifdef FAAC_STATS
+    g_faacStats.totalFrames++;
+    if (coderInfo[0].block_type == ONLY_SHORT_WINDOW || coderInfo[0].block_type == LONG_SHORT_WINDOW)
+    {
+        g_faacStats.transientFrames++;
+    }
+#endif
+
     /* force block type */
     if (shortctl == SHORTCTL_NOSHORT)
     {
@@ -809,6 +890,19 @@ int faacEncEncode(faacEncHandle hpEncoder,
     for (channel = 0; channel < numChannels; channel++) {
         if (!hEncoder->isLfeChannel[channel] && useTns) {
             float attack = PsyGetAttack(&hEncoder->psyInfo[channel]);
+
+#ifdef FAAC_STATS
+            if (attack > 0.0f && isfinite(attack)) {
+                g_faacStats.totalAttack += attack;
+                if (attack > g_faacStats.maxAttack) {
+                    g_faacStats.maxAttack = attack;
+                }
+                g_faacStats.attackCount++;
+            }
+            if (coderInfo[channel].block_type != ONLY_SHORT_WINDOW) {
+                g_faacStats.longBlocks++;
+            }
+#endif
 
             /* No envelope available (HE-AAC skips PsyBufferUpdate) means no
                basis to reject on, so admit and let the LPC gates decide. */
@@ -948,6 +1042,14 @@ int faacEncEncode(faacEncHandle hpEncoder,
      * the rate controller below never runs to claw the quality back. */
     hEncoder->aacquantCfg.quality = baseQuality;
 
+#ifdef FAAC_STATS
+    if (attempt > 0)
+    {
+        g_faacStats.peakRetryFrames++;
+    }
+    g_faacStats.totalQuality += hEncoder->aacquantCfg.quality;
+#endif
+
     /* Adjust quality to get correct average bitrate */
     if (hEncoder->config.bitRate)
     {
@@ -1005,6 +1107,16 @@ int faacEncEncode(faacEncHandle hpEncoder,
             float fillRatio = (float)hEncoder->bitReservoir / (float)hEncoder->bitReservoirCap;
             if (fillRatio < 0.25f || fillRatio > 0.75f)
                 damping = 0.85f;
+
+#ifdef FAAC_STATS
+            {
+                float fillPct = fillRatio * 100.0f;
+                g_faacStats.totalReservoirRatio += fillPct;
+                if (fillPct < g_faacStats.minReservoirRatio) g_faacStats.minReservoirRatio = fillPct;
+                if (fillPct > g_faacStats.maxReservoirRatio) g_faacStats.maxReservoirRatio = fillPct;
+                g_faacStats.reservoirFrames++;
+            }
+#endif
 
             /* Additive reservoir proportional correction to eliminate long-term drift */
             float resErr = fillRatio - 0.5f;

--- a/libfaac/frame.h
+++ b/libfaac/frame.h
@@ -39,6 +39,7 @@ extern "C" {
 #include "fft.h"
 #include "quantize.h"
 #include "sbr.h"
+#include "stats.h"
 
 typedef struct faacEncStruct {
     /* number of channels in AAC file */

--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -21,6 +21,7 @@
 #include "quantize.h"
 #include "huff2.h"
 #include "cpu_compute.h"
+#include "stats.h"
 
 typedef int (*QuantizeFunc)(const float * __restrict xr, int * __restrict xi, int n, float sfacfix);
 
@@ -262,6 +263,10 @@ static void assign_band_codebooks(CoderInfo * __restrict ci, const float * __res
     {
         int band = ci->bandcnt;
 
+#ifdef FAAC_STATS
+        g_faacStats.totalBands++;
+#endif
+
         if (ci->book[band] != HCB_NONE)
         {
             ci->bandcnt++;
@@ -289,6 +294,9 @@ static void assign_band_codebooks(CoderInfo * __restrict ci, const float * __res
         if (target[sb] < pns_threshold)
         {
             ci->book[band] = HCB_PNS;
+#ifdef FAAC_STATS
+            g_faacStats.pnsBands++;
+#endif
             ci->sf[band] += lrintf(sf_enrg_avg);
             ci->bandcnt++;
             continue;

--- a/libfaac/sbr.c
+++ b/libfaac/sbr.c
@@ -26,6 +26,7 @@
 #include "bitstream.h"
 #include "sbr_internal.h"
 #include "faac_internal.h"
+#include "stats.h"
 
 /* SBR master frequency band table (ISO/IEC 14496-3:2005 §4.6.18.3.2). kx/k2 are
  * spec-mandatory: the decoder reconstructs them from the sample rate alone, so
@@ -513,6 +514,17 @@ void SbrEncode(SBRInfo *sbr, float *timeDomain[MAX_CHANNELS], int numChannels, i
 
     sbr_adopt_envelope_grid(sbr, sa, fd);
     sbr_quantize_envelopes(sbr, nch, sa->sampled, sa, fd);
+
+#ifdef FAAC_STATS
+    g_faacStats.sbrFrames++;
+    if (fd->frameClass != SBR_FRAME_CLASS_FIXFIX) {
+        g_faacStats.sbrTransientFrames++;
+    }
+    for (int ch = 0; ch < nch; ch++) {
+        g_faacStats.sbrInvfSum += fd->ch[ch].invfMode;
+        g_faacStats.sbrInvfCount++;
+    }
+#endif
 }
 
 /* SBR bitstream writer. Emits the SBR fill element payload into the bitstream.

--- a/libfaac/stats.h
+++ b/libfaac/stats.h
@@ -1,0 +1,63 @@
+/*
+ * FAAC - Freeware Advanced Audio Coder
+ * Copyright (C) 2026 Nils Schimmelmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#ifndef FAAC_STATS_H
+#define FAAC_STATS_H
+
+#ifdef FAAC_STATS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct faacEncStats {
+    unsigned int totalFrames;
+    unsigned int transientFrames;
+    double totalQuality;
+
+    unsigned long totalBands;
+    unsigned long msBands;
+    unsigned long isBands;
+    unsigned long pnsBands;
+
+    unsigned int longBlocks;
+    unsigned int longBlocksTNS;
+
+    unsigned int sbrFrames;
+    unsigned int sbrTransientFrames;
+    unsigned long sbrInvfSum;
+    unsigned long sbrInvfCount;
+
+    double totalAttack;
+    float maxAttack;
+    unsigned long attackCount;
+
+    unsigned int peakRetryFrames;
+
+    double totalReservoirRatio;
+    float minReservoirRatio;
+    float maxReservoirRatio;
+    unsigned int reservoirFrames;
+} faacEncStats;
+
+extern faacEncStats g_faacStats;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FAAC_STATS */
+
+#endif /* FAAC_STATS_H */

--- a/libfaac/stereo.c
+++ b/libfaac/stereo.c
@@ -20,6 +20,7 @@
 #include "huff2.h"
 #include "util.h"
 #include "faac_internal.h"
+#include "stats.h"
 
 /* Intensity stereo crossover scales with core bandwidth (3.5-7 kHz) to save low-band phase bits at low rates. */
 #define IS_BW_RATIO              0.35f
@@ -188,6 +189,9 @@ static inline int process_cpe(CoderInfo * restrict cl, CoderInfo * restrict cr,
                 cl->sf[*sfcnt]   = sf;
                 cr->sf[*sfcnt]   = -pan;
                 cr->book[*sfcnt] = hcb;
+#ifdef FAAC_STATS
+                g_faacStats.isBands += 2;
+#endif
                 float dom = (hcb == HCB_INTENSITY) ? es : ed;
                 apply_is(sl0, sr0, start, len, wstart, wend, hcb == HCB_INTENSITY, sqrtf(etot / dom));
                 if (mode != JOINT_IS) element->msInfo.ms_used[*sfcnt] = 0;
@@ -213,6 +217,9 @@ static inline int process_cpe(CoderInfo * restrict cl, CoderInfo * restrict cr,
             }
             if (ms) {
                 msused = 1;
+#ifdef FAAC_STATS
+                g_faacStats.msBands += 2;
+#endif
             } else {
                 /* Sparsity check: if one channel completely masks the other. */
                 if (el <= er * thrside_sq) {

--- a/libfaac/tns.c
+++ b/libfaac/tns.c
@@ -383,6 +383,10 @@ void TnsEncode(TnsInfo* tnsInfo, int numBands, enum WINDOW_TYPE blockType, int* 
                        &tnsInfo->windowData.tnsFilter[0]))
         return;
 
+#ifdef FAAC_STATS
+    g_faacStats.longBlocksTNS++;
+#endif
+
     /* Declared from b_start to the top of the spectrum rather than to b_stop,
      * over-declaring the region. */
     tnsInfo->windowData.tnsFilter[0].length = tnsInfo->tnsNumSwbLong - b_start;

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,8 @@ config_h.set('HAVE_SSE2', (cpu_family in ['x86', 'x86_64']) and config_h.get('HA
 
 config_h.set('FAAC_SBR_DECIMATION', get_option('sbr-decimation'))
 
+config_h.set('FAAC_STATS', get_option('stats'))
+
 config_h.set('MAX_CHANNELS', get_option('max-channels'))
 
 c_args = []

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,3 +24,10 @@ option('max-channels',
     min: 1,
     max: 8,
     value: 8)
+
+# End-of-encode diagnostics banner (Qavg, transient/tool-usage %, rate-control
+# health, etc), printed to stderr on faacEncClose().
+option('stats',
+    description: 'Enable optional end-of-encode statistics banner',
+    type: 'boolean',
+    value: false)


### PR DESCRIPTION
This PR introduces an optional end-of-encode diagnostic telemetry banner to `libfaac` (`-Dstats=true`), updates the `-v2` frontend summary to match the new aligned visual layout, and fixes an off-by-one total frame calculation for HE-AAC encodings.

## Key Changes
- **Encoder Telemetry (`libfaac`):**
  - Added `-Dstats` Meson build flag (`FAAC_STATS`) that defaults off.
  - Introduced `libfaac/stats.h` to track average quality (Qavg), transient block percentage, attack ratios, tool usage (M/S, I/S, PNS, TNS), SBR grid/invf stats, peak-limiter retries, and bit reservoir fill.
  - Instrumentation is completely isolated behind `#ifdef FAAC_STATS` passed directly via compiler flags to avoid header leakage and ensure zero binary footprint change when disabled.
- **Frontend Summary & File Metrics:**
  - Updated the CLI `-v2` verbose summary to a bordered, column-aligned format.
  - Added `get_file_size()` in `output.c` to display input/output file sizes and compression ratios (automatically omitted for `stdin`/`stdout`).
- **Fixes:**
  - Corrected total frame count calculation in `encode_engine.c` by factoring `info.encoder_delay` into ceiling division, resolving N+1/N display glitches at EOF for HE-AAC.

## Example Output
```text
nschimme@Nilss-MBP build % faac ff-16b-2c-44100hz.wav -b 64 --tns --overwrite -v2
Freeware Advanced Audio Coder
FAAC 2.1.0

Initial quantization quality: 454
Average bitrate: 32 kbps/channel
Bandwidth: 11025 Hz
PNS level: 4
Object type: HE-AAC v1 (MPEG-4) + TNS + Mixed + PNS
Container format: MPEG-4 File Format (MP4)
Encoding ff-16b-2c-44100hz.wav to ff-16b-2c-44100hz.m4a
         frame         | bitrate | elapsed/estim | play/CPU | ETA
   4031/4031    (100%) |   64.1  |    0.2/0.2    |  975.51x | 0.0
--- Encode Summary ---
 Frames & Samples    : Frames = 4031 | Samples = 4127744
 Bitrate & Frame Size: Avg = 64 | Max = 95 | Max Frame Size = 1227
 File Size           : Input = 31.47 MB | Output = 1.43 MB | Ratio = 22.0:1
----------------------

--- Encoder Diagnostics ---
 Quality             : Qavg    = 185.60
 Transients & Grid   : Core Tr =  99.3% (4003/4031) | SBR Grid =   6.8% Var | Attack = 0.0x avg, 0.0x max
 Tool Allocation     : M/S     =   0.0% | I/S =   6.9% | PNS =  22.1% | TNS =   1.6% | INVF = 3.00
 Rate Control & Cap  : Reservoir Fill =  42.1% (min   0.0%, max 100.0%)
---------------------------
```