### PR TITLE
Fix AAC bitrate limits, low-bitrate tuning, and HE channel constraints

### DIFF
--- a/frontend/encode_engine.c
+++ b/frontend/encode_engine.c
@@ -522,8 +522,12 @@ int run_encoding_session_ext(const encode_options_t *opts,
     params.output_format = opts->container_mp4 ? FAAC_STREAM_RAW : opts->stream_format;
     params.input_format = FAAC_INPUT_FLOAT;
 
-    if (faac_encoder_open(&params, &hEncoder) != FAAC_OK)
-        FAIL("Couldn't open encoder instance for %s\n", opts->input_filename);
+    {
+        faac_status st = faac_encoder_open(&params, &hEncoder);
+        if (st != FAAC_OK)
+            FAIL("Couldn't open encoder instance for %s: %s\n",
+                 opts->input_filename, faac_strerror(st));
+    }
 
     faac_encoder_info info = { .struct_size = sizeof(info) };
     faac_encoder_get_info(hEncoder, &info);

--- a/frontend/mp4write.c
+++ b/frontend/mp4write.c
@@ -73,7 +73,9 @@ enum {
     /* DecoderConfigDescriptor fixed fields (ISO/IEC 14496-1) */
     MP4_OBJECT_TYPE_AUDIO_ISO_14496_3 = 0x40,
     MP4_STREAM_TYPE_AUDIO             = 0x15, /* streamType=5 (audio) << 2 | upStream=0 | reserved=1 */
-    MP4_DECODER_BUFFER_SIZE           = 6144, /* bufferSizeDB, arbitrary but generous for one AAC frame */
+    /* bufferSizeDB is in BYTES; 6144 is the per-channel BIT count of AAC's
+       decoder input buffer (ISO/IEC 14496-3 4.5.3.1). */
+    MP4_DECODER_BUFFER_BYTES_PER_CH   = 6144 / 8,
 
     MP4_TRACK_ID      = 1, /* single-track file: 'trak' and 'tkhd' both hardcode this */
     MP4_NEXT_TRACK_ID = 2, /* mvhd's hint for the next trak ID a future edit would use */
@@ -748,9 +750,10 @@ int mp4_finish(void) {
     put_u16(0); put_u8(0);
     put_descriptor(4, 13 + MP4_DESC_HDR + g_mp4.asc.size);
     put_u8(MP4_OBJECT_TYPE_AUDIO_ISO_14496_3); put_u8(MP4_STREAM_TYPE_AUDIO);
-    put_u8((uint8_t)(MP4_DECODER_BUFFER_SIZE >> 16));
-    put_u8((uint8_t)(MP4_DECODER_BUFFER_SIZE >> 8));
-    put_u8((uint8_t)(MP4_DECODER_BUFFER_SIZE & 0xff));
+    uint32_t bufferSizeDB = MP4_DECODER_BUFFER_BYTES_PER_CH * g_mp4.channels;
+    put_u8((uint8_t)(bufferSizeDB >> 16));
+    put_u8((uint8_t)(bufferSizeDB >> 8));
+    put_u8((uint8_t)(bufferSizeDB & 0xff));
     put_u32(g_mp4.bitrate.max); put_u32(g_mp4.bitrate.avg);
     put_descriptor(5, g_mp4.asc.size);
     put_data(g_mp4.asc.data, g_mp4.asc.size);

--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -175,6 +175,11 @@ static faac_status validate_params(const faac_params *p)
         return FAAC_ERR_INVALID_ARGUMENT;
     if (p->pns_level < 0 || p->pns_level > 10)
         return FAAC_ERR_INVALID_ARGUMENT;
+    /* AUTO resolves around this itself; this is for callers that named the
+     * profile. */
+    if (p->object_type == FAAC_OBJ_HE_AAC_V1
+        && p->num_channels > (uint32_t)SBR_MAX_CODED_CHANNELS)
+        return FAAC_ERR_UNSUPPORTED;
     if (p->channel_map) {
         uint32_t i;
         if (p->channel_map_count < p->num_channels)

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -32,7 +32,10 @@
 
 /* HE-AAC auto-mode thresholds; tuned via ViSQOL on a 49-clip corpus. */
 #define HE_MIN_SAMPLE_RATE    32000  /* Fs/2 < 16 kHz below this → core too narrow for SBR */
-#define HE_MIN_BITRATE_PER_CH 12000  /* below floor HE wins by an ever-widening margin */
+/* HE only wins harder as the rate falls: the further below Nyquist the LC core
+ * lands, the more spectrum SBR is rescuing. 8000 is HE-AAC's design floor and
+ * the lowest rate measured. */
+#define HE_MIN_BITRATE_PER_CH 8000
 #define HE_MAX_BITRATE_PER_CH 48000  /* above ceiling LC wins: SBR costs up to 1 MOS on transients */
 /* quantqual == totalBitrate/1280 (see faacEncApplyConfig); derived to stay in sync with HE_MAX_BITRATE_PER_CH. */
 #define HE_VBR_QUANTQUAL_MAX  (2 * HE_MAX_BITRATE_PER_CH / 1280)
@@ -206,14 +209,6 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
     /* Check for correct bitrate */
     if (!hEncoder->sampleRate || !hEncoder->numChannels)
         return 0;
-    /* Clamp against the full (pre-downsample) rate: for an already-resolved
-     * HE-AAC handle sampleRate is the halved core rate. */
-    {
-        unsigned long fullRate = SbrContextGetFullRate(hEncoder->sbrContext, hEncoder->sampleRate);
-        if (config->bitRate > (MaxBitrate(fullRate) / hEncoder->numChannels))
-            config->bitRate = MaxBitrate(fullRate) / hEncoder->numChannels;
-    }
-
     /* Resolve AUTO to LC or HE-AAC. HE-AAC wins for low rates, but only
      * at Fs >= 32 kHz so the Fs/2 core stays >= 16 kHz; below that the
      * narrow-band core + SBR reconstruction collapses. */
@@ -234,11 +229,19 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
         } else {
             rate_ok = (config->quantqual <= HE_VBR_QUANTQUAL_MAX);
         }
-        hEncoder->config.aacObjectType = (rate_ok && hEncoder->sampleRate >= HE_MIN_SAMPLE_RATE) ? HE_V1 : LOW;
+        /* One SBR payload per frame, bound to the element it follows, so it
+         * serves a single SCE or CPE. Past two channels the rest get no SBR,
+         * and with an LFE present it lands on ID_LFE, which decoders reject. */
+        int channels_ok = (hEncoder->numChannels <= SBR_MAX_CODED_CHANNELS);
+
+        hEncoder->config.aacObjectType =
+            (rate_ok && channels_ok && hEncoder->sampleRate >= HE_MIN_SAMPLE_RATE) ? HE_V1 : LOW;
         config->aacObjectType = hEncoder->config.aacObjectType;
     }
 
-    if (hEncoder->config.aacObjectType == HE_V1 && hEncoder->sampleRate < HE_MIN_SAMPLE_RATE)
+    if (hEncoder->config.aacObjectType == HE_V1
+        && (hEncoder->sampleRate < HE_MIN_SAMPLE_RATE
+            || hEncoder->numChannels > SBR_MAX_CODED_CHANNELS))
         return 0;
 
     /* HE-AAC: encode the core as AAC-LC; SBR rebuilds the top octave. The core
@@ -255,6 +258,12 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
 
         SbrContextResolveRate(hEncoder->sbrContext, &hEncoder->sampleRate, &hEncoder->sampleRateIdx, &hEncoder->srInfo);
     }
+
+    /* MaxBitrate() is already per channel, and its frame is FRAME_LEN samples
+     * at the core rate -- so the clamp has to follow the HE-AAC resolution
+     * above, which halves that rate. */
+    if (config->bitRate > MaxBitrate(hEncoder->sampleRate))
+        config->bitRate = MaxBitrate(hEncoder->sampleRate);
 
     /* Re-init TNS for new profile */
     TnsInit(hEncoder);
@@ -1066,7 +1075,7 @@ int faacEncEncode(faacEncHandle hpEncoder,
 
         /* Aim at the budget rather than stepping down by a fixed factor: rate
          * control can park quality anywhere up to MAXQUAL (5000), and a fixed
-         * halving needs ~9 passes to cross that to MINQUAL (10), more than any
+         * halving needs far more passes to cross that to MINQUAL than any
          * sane retry budget. Frame bits grow sub-linearly with quality, so
          * scaling by the bit ratio undershoots the budget and converges in a
          * pass or two. */

--- a/libfaac/quantize.h
+++ b/libfaac/quantize.h
@@ -31,11 +31,15 @@ typedef struct
  * quantization error for a uniform distribution (ISO 14496-3 §8.3.5). */
 #define MAGIC_NUMBER 0.4054f
 
+/* Quality is a masking-target multiplier in percent of DEFQUAL, so MINQUAL
+ * bounds how small a frame the rate control can ask for; at 10 it could not
+ * reach an 8 kbps/ch budget. Nothing assumes a floor -- below the target a band
+ * goes HCB_ZERO. */
 enum {
     DEFQUAL = 100,
     MAXQUAL = 5000,
     MAXQUALADTS = MAXQUAL,
-    MINQUAL = 10,
+    MINQUAL = 1,
 };
 
 void ResetCoderSections(CoderInfo *coderInfo);

--- a/libfaac/sbr.h
+++ b/libfaac/sbr.h
@@ -49,8 +49,9 @@
    window next, whereas envelopes must land on the coded frame itself. */
 #define SBR_FRAME_FIFO (LOOKAHEAD_DEPTH + 2)
 
-/* SBR codes exactly one element, an SCE or a CPE, so the payload never spans
-   more than two channels regardless of the core's channel count. */
+/* What THIS encoder's SBR covers, not a format limit: MPEG-4 carries
+   sbr_extension_data() in a fill element after each SCE and CPE, so HE-AAC v1
+   5.1 is legal. Lifting this means one payload per element, none for the LFE. */
 #define SBR_MAX_CODED_CHANNELS 2
 
 #ifdef __cplusplus

--- a/libfaac/util.c
+++ b/libfaac/util.c
@@ -45,12 +45,6 @@ unsigned int MaxBitrate(unsigned long sampleRate)
     return AAC_MAX_BITS_PER_CH * sampleRate / FRAME_LEN;
 }
 
-/* Returns the minimum bitrate per channel for that sampling frequency */
-unsigned int MinBitrate(void)
-{
-    return 8000;
-}
-
 /* Portable CLZ (returns 32 for x==0); lets escape() get a magnitude's bit-length
  * in O(1) instead of the old shift-until-fits loop. */
 int CountLeadingZeros(unsigned int x)

--- a/libfaac/util.h
+++ b/libfaac/util.h
@@ -57,7 +57,6 @@ static inline int clamp_int(int x, int lo, int hi)
 
 int GetSRIndex(unsigned int sampleRate);
 unsigned int MaxBitrate(unsigned long sampleRate);
-unsigned int MinBitrate(void);
 int CountLeadingZeros(unsigned int x);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR fixes several long-standing rate-control, spec-compliance, and container metadata bugs in `libfaac` and the `faac` CLI. These fixes resolve bitstream corruption in multichannel encodes, fix incorrect bitrate limits, and allow the rate controller to function accurately at low bitrates.

---

## Changes

### Critical Bug Fixes & Spec Compliance
* **Fix Multichannel HE-AAC Bitstream Corruption:** Restrict HE-AAC v1 to $\le 2$ channels (`SBR_MAX_CODED_CHANNELS`). Encoding 5.1 previously emitted SBR payloads bound to `ID_LFE`, generating invalid bitstreams that decoders (like `ffmpeg`) reject. Unsupported channel configurations now fail fast with `FAAC_ERR_UNSUPPORTED`.
* **Correct MP4 `esds` Buffer Sizing:** Fix an eightfold size calculation error in `mp4write.c`. `bufferSizeDB` was writing AAC's per-channel bit count (`6144`) directly into a byte field. Updated to properly scale by channel count (`768 * channels` bytes).

### Rate Control Clamping & Tuning
* **Fix `MaxBitrate` Ceiling Math:** Corrected the ceiling clamp to run *after* HE rate resolution (halved core rate) and removed redundant per-channel division that locked out half of the format's valid bitrate range.
* **Unblock Low-Bitrate Target Rates (8–12 kbps/ch):**
  * Lowered the quantizer floor (`MINQUAL`) from `10` to `1`. The old floor pinned up to ~80% of frames during low-bitrate encodes, causing streams to overshoot target bitrates by ~60%.
  * Lowered `HE_MIN_BITRATE_PER_CH` threshold from `12000` to `8000` bps/channel so `AUTO` correctly selects HE-AAC at lower bitrates where SBR outperforms LC.

###  Diagnostics & Cleanup
* **Improved CLI Error Messages:** `encode_engine.c` now logs the specific error message via `faac_strerror()` when encoder initialization fails rather than printing a generic failure message.
* **Dead Code Removal:** Removed unused `MinBitrate()` helper from `util.c`.

---

## Verification
* **Bitstream Validation:** Verified multichannel HE-AAC requests fail immediately with `FAAC_ERR_UNSUPPORTED` rather than writing invalid SBR structures.
* **Rate Target Accuracy:** Confirmed low-bitrate encodes (8–12 kbps/ch) land on budget instead of overshooting.
* **Container Headers:** Validated MP4 `esds` output atom structure for mono (768 bytes) and stereo (1536 bytes).

Benchmark: https://github.com/nschimme/faac/pull/457
