### PR TITLE
tns: enable TNS by default and optimize runtime footprint

### DIFF
--- a/docs/faac.1
+++ b/docs/faac.1
@@ -83,6 +83,10 @@ Perceptual Noise Substitution level, 0 to 10;
 .B 0
 disables PNS.
 .TP
+.BR --no-tns
+Disable Temporal Noise Shaping, which reduces pre-echo on transients. On by
+default.
+.TP
 .BR -q\ <\fIquality\fP>
 Set encoding quality. Set default variable bitrate (VBR) quality level in percent.
 max. 5000, min. 10.
@@ -206,12 +210,6 @@ Supported image formats are GIF, JPEG, and PNG.
 .BR --comment\ <\fIstring\fP>
 Set comment
 .SH ADVANCED OPTIONS, ONLY FOR TESTING PURPOSES
-.TP
-.BR --tns
-Enable coding of TNS, temporal noise shaping.
-.TP
-.BR --no-tns
-Disable coding of TNS, temporal noise shaping.
 .TP
 .BR --mpeg-vers\ \fIX\fP
 Force AAC MPEG version, X can be 2 or 4

--- a/frontend/encode_engine.c
+++ b/frontend/encode_engine.c
@@ -53,7 +53,7 @@ void init_encode_options(encode_options_t *opts)
     opts->joint_mode = FAAC_JOINT_MIXED;
     opts->stream_format = FAAC_STREAM_ADTS;
     opts->shortctl = FAAC_SHORTCTL_NORMAL;
-    opts->use_tns = false;
+    opts->use_tns = true;
     opts->use_lfe = -1;
     opts->pns_level = -1;
     opts->quant_quality = 0;

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -80,7 +80,6 @@ enum flags
     OPT_PNS,
     OBJTYPE_FLAG,
     CAP_RATE_FLAG,
-    OPT_TNS_ENABLE,
     OPT_TNS_DISABLE,
     OPT_OVERWRITE,
     OPT_COMPILATION,
@@ -182,8 +181,7 @@ static help_t help_mp4[] = {
 };
 
 static help_t help_advanced[] = {
-    {"--tns  \tEnable coding of TNS, temporal noise shaping.\n", NULL},
-    {"--no-tns\tDisable coding of TNS, temporal noise shaping.\n", NULL},
+    {"--no-tns\tDisable coding of TNS, temporal noise shaping (default: on).\n", NULL},
     {"--joint 0\tDisable joint stereo coding.\n", NULL},
     {"--joint 1\tUse Mid/Side coding.\n", NULL},
     {"--joint 2\tUse Intensity Stereo coding.\n", NULL},
@@ -542,7 +540,6 @@ int main(int argc, char *argv[])
             {"pcmsamplebits", 1, 0, 'B'},
             {"pcmchannels", 1, 0, 'C'},
             {"shortctl", 1, 0, SHORTCTL_FLAG},
-            {"tns", 0, 0, OPT_TNS_ENABLE},
             {"no-tns", 0, 0, OPT_TNS_DISABLE},
             {"mpeg-version", 1, 0, MPEGVERS_FLAG},
             {"object-type", 1, 0, OBJTYPE_FLAG},
@@ -584,7 +581,6 @@ int main(int argc, char *argv[])
 
         switch (c)
         {
-        case OPT_TNS_ENABLE: opts.use_tns = true; break;
         case OPT_TNS_DISABLE: opts.use_tns = false; break;
         case OPT_OVERWRITE: opts.overwrite = true; break;
         case OPT_COMPILATION: opts.metadata.compilation = true; break;

--- a/frontend/maingui.c
+++ b/frontend/maingui.c
@@ -568,7 +568,7 @@ static INT_PTR CALLBACK DialogProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lP
             SendMessage(hSC, CB_SETCURSEL, 0, 0);
         }
 
-        CheckDlgButton(hWnd, IDC_USETNS, FALSE);
+        CheckDlgButton(hWnd, IDC_USETNS, TRUE); /* library default, libfaac/frame.c */
         ApplyRateModeUI(hWnd, RATEMODE_VBR);
         SetDlgItemText(hWnd, IDC_PNS, "4"); /* library default, libfaac/faac.c */
         SetDlgItemText(hWnd, IDC_BANDWIDTH, "0");

--- a/libfaac/blockswitch.h
+++ b/libfaac/blockswitch.h
@@ -48,7 +48,7 @@ typedef struct {
 	float sampleRate;
 
 	/* shared work buffers */
-	float *sharedWorkBuffLong;  /* Used for 2048-sample windows (filtbank, psy, tns, mdct) */
+	float *sharedWorkBuffLong;  /* Used for 2048-sample windows (filtbank, psy, mdct) */
 } GlobalPsyInfo;
 
 void PsyInit (GlobalPsyInfo *gpsyInfo, PsyInfo *psyInfo,

--- a/libfaac/channels.c
+++ b/libfaac/channels.c
@@ -20,8 +20,10 @@
 #include <string.h>
 #include <stdio.h>
 
-_Static_assert(TNS_MAX_FILTERS == (1 << LEN_TNS_NFILTL),
-               "coder.h's TnsWindowData.tnsFilter[] bound must match the LEN_TNS_NFILTL bitstream field width");
+_Static_assert(TNS_MAX_FILTERS <= (1 << LEN_TNS_NFILTL) - 1,
+               "TnsWindowData.tnsFilter[] holds more filters than numFilters can encode in LEN_TNS_NFILTL bits");
+_Static_assert(TNS_MAX_ORDER <= (1 << LEN_TNS_ORDERL) - 1,
+               "TnsFilterData order exceeds what LEN_TNS_ORDERL bits can encode");
 
 /**
  * Maps input channels to AAC elements (SCE, CPE, LFE), per ISO/IEC 14496-3's

--- a/libfaac/coder.h
+++ b/libfaac/coder.h
@@ -39,14 +39,16 @@ enum WINDOW_TYPE {
     SHORT_LONG_WINDOW
 };
 
-#define TNS_MAX_ORDER 12
+/* Array bounds, sized to what this encoder actually emits rather than to what
+ * the spec permits: one filter per long window at a fixed order (tns.c's
+ * TNS_LPC_ORDER), never the spec's 4 filters at order 20. Both are checked
+ * against the bitstream field widths by _Static_asserts in channels.c, which
+ * this header can't include without a cycle. */
+#define TNS_MAX_ORDER 8
+#define TNS_MAX_FILTERS 1
 #define DEF_TNS_COEFF_THRESH 0.1f
 #define DEF_TNS_COEFF_RES 4
 #define DEF_TNS_RES_OFFSET 3
-/* Bound on TnsWindowData.tnsFilter[]. Must stay in sync with the bitstream
- * field width LEN_TNS_NFILTL (channels.h) -- checked by a _Static_assert in
- * channels.c, since this header can't include channels.h without a cycle. */
-#define TNS_MAX_FILTERS 4
 
 typedef struct {
     int order;                           /* Filter order */
@@ -82,7 +84,10 @@ typedef struct CoderInfo {
     int book[MAX_SCFAC_BANDS];
     int bandcnt;
     int sfbn;
-    int sfb_offset[NSFB_LONG + 1];
+    /* Points at the encoder's prebuilt long or short table (frame.c); the
+     * contents depend only on the sample rate and the coded bandwidth, so
+     * there is one of each per encoder rather than one per channel. */
+    const int *sfb_offset;
 
     struct {
         int n;

--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -114,7 +114,7 @@ FAACAPI faac_status faac_params_init(faac_params *p, uint32_t caller_size)
     tmp.object_type   = FAAC_OBJ_LOW;
     tmp.joint_mode    = FAAC_JOINT_MIXED;
     tmp.use_lfe       = false;
-    tmp.use_tns       = false;
+    tmp.use_tns       = true;
     tmp.bit_rate      = 64000;          /* per channel; 0 would defer to quant_quality */
     tmp.bandwidth     = 0;              /* derive from bit_rate */
     tmp.quant_quality = 0;              /* derive from bit_rate */

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -371,7 +371,9 @@ int faacEncApplyConfig(faacEncStruct* hEncoder,
     CalcBW(&hEncoder->config.bandWidth,
               hEncoder->sampleRate,
               hEncoder->srInfo,
-              &hEncoder->aacquantCfg);
+              &hEncoder->aacquantCfg,
+              hEncoder->sfbOffsetShort,
+              hEncoder->sfbOffsetLong);
 
     // reset psymodel
     PsyEnd(hEncoder->psyInfo, hEncoder->numChannels);
@@ -439,7 +441,7 @@ faacEncHandle faacEncOpen(unsigned long sampleRate,
     hEncoder->config.jointmode = JOINT_MIXED;
     hEncoder->config.pnslevel = 4;
     hEncoder->config.useLfe = 1;
-    hEncoder->config.useTns = 0;
+    hEncoder->config.useTns = 1;
     hEncoder->config.bitRate = 64000;
     hEncoder->config.bandWidth = CalcBandwidth(hEncoder->config.bitRate, sampleRate);
     hEncoder->config.quantqual = 0;
@@ -709,8 +711,7 @@ int faacEncEncode(faacEncHandle hpEncoder,
 {
     faacEncStruct* hEncoder = (faacEncStruct*)hpEncoder;
     unsigned int channel;
-    int sb, frameBytes;
-    unsigned int offset;
+    int frameBytes;
     BitStream *bitStream;
 
     CoderInfo *coderInfo = hEncoder->coderInfo;
@@ -871,25 +872,13 @@ int faacEncEncode(faacEncHandle hpEncoder,
     for (channel = 0; channel < numChannels; channel++) {
         if (coderInfo[channel].block_type == ONLY_SHORT_WINDOW) {
             coderInfo[channel].sfbn = hEncoder->aacquantCfg.max_cbs;
-
-            offset = 0;
-            for (sb = 0; sb < coderInfo[channel].sfbn; sb++) {
-                coderInfo[channel].sfb_offset[sb] = offset;
-                offset += hEncoder->srInfo->cb_width_short[sb];
-            }
-            coderInfo[channel].sfb_offset[sb] = offset;
+            coderInfo[channel].sfb_offset = hEncoder->sfbOffsetShort;
         } else {
             coderInfo[channel].sfbn = hEncoder->aacquantCfg.max_cbl;
+            coderInfo[channel].sfb_offset = hEncoder->sfbOffsetLong;
 
             coderInfo[channel].groups.n = 1;
             coderInfo[channel].groups.len[0] = 1;
-
-            offset = 0;
-            for (sb = 0; sb < coderInfo[channel].sfbn; sb++) {
-                coderInfo[channel].sfb_offset[sb] = offset;
-                offset += hEncoder->srInfo->cb_width_long[sb];
-            }
-            coderInfo[channel].sfb_offset[sb] = offset;
         }
     }
 
@@ -937,7 +926,7 @@ int faacEncEncode(faacEncHandle hpEncoder,
 
     /* Perform TNS analysis and filtering */
     for (channel = 0; channel < numChannels; channel++) {
-        if (!hEncoder->isLfeChannel[channel] && useTns) {
+        if (!hEncoder->isLfeChannel[channel] && useTns && coderInfo[channel].block_type != ONLY_SHORT_WINDOW) {
             float attack = PsyGetAttack(&hEncoder->psyInfo[channel]);
 
 #ifdef FAAC_STATS
@@ -948,9 +937,7 @@ int faacEncEncode(faacEncHandle hpEncoder,
                 }
                 g_faacStats.attackCount++;
             }
-            if (coderInfo[channel].block_type != ONLY_SHORT_WINDOW) {
-                g_faacStats.longBlocks++;
-            }
+            g_faacStats.longBlocks++;
 #endif
 
             /* No envelope available (HE-AAC skips PsyBufferUpdate) means no
@@ -959,13 +946,10 @@ int faacEncEncode(faacEncHandle hpEncoder,
                 coderInfo[channel].tnsInfo.tnsDataPresent = 0;
                 continue;
             }
-            TnsEncode(&(coderInfo[channel].tnsInfo),
-                      coderInfo[channel].sfbn,
-                      coderInfo[channel].block_type,
-                      coderInfo[channel].sfb_offset,
-                      hEncoder->freqBuff[channel]);
+
+            TnsEncode(&coderInfo[channel], hEncoder->freqBuff[channel]);
         } else {
-            coderInfo[channel].tnsInfo.tnsDataPresent = 0;      /* TNS not used for LFE */
+            coderInfo[channel].tnsInfo.tnsDataPresent = 0;      /* TNS not used for LFE or short blocks */
         }
     }
 

--- a/libfaac/frame.h
+++ b/libfaac/frame.h
@@ -57,6 +57,9 @@ typedef struct faacEncStruct {
 
     /* Scalefactorband data */
     SR_INFO *srInfo;
+    /* Prefix sums of srInfo's cb_width tables, built once per config. */
+    int sfbOffsetLong[NSFB_LONG + 1];
+    int sfbOffsetShort[NSFB_SHORT + 1];
 
     /* sample buffers: FIFO_PAST (MDCT overlap), FIFO_CURR, FIFO_AHEAD1, FIFO_AHEAD2 */
     float *audioFIFO[MAX_CHANNELS][4];

--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -431,17 +431,29 @@ int BlocQuant(CoderInfo * __restrict coder, float * __restrict xr, AACQuantCfg *
     return 1;
 }
 
-void CalcBW(unsigned *bw, int rate, SR_INFO *sr, AACQuantCfg *aacquantCfg)
+/* sfbOffsetShort/Long are filled as a side effect of the same bandwidth walk
+ * that picks max_cbs/max_cbl -- a prefix sum over the same table, to the same
+ * bound, so there's nothing left for a caller to redo afterward. Only
+ * [0, max_cbs] and [0, max_cbl] are written; callers never index sfb_offset
+ * past their own sfbn, which is exactly max_cbs/max_cbl. */
+void CalcBW(unsigned *bw, int rate, SR_INFO *sr, AACQuantCfg *aacquantCfg,
+            int *sfbOffsetShort, int *sfbOffsetLong)
 {
     int i, l = 0, max = *bw * (BLOCK_LEN_SHORT << 1) / rate;
-    for (i = 0; i < sr->num_cb_short && l < max; i++)
+    for (i = 0; i < sr->num_cb_short && l < max; i++) {
+        sfbOffsetShort[i] = l;
         l += sr->cb_width_short[i];
+    }
+    sfbOffsetShort[i] = l;
     aacquantCfg->max_cbs = i;
     if (aacquantCfg->pnslevel) *bw = (float)l * rate / (BLOCK_LEN_SHORT << 1);
 
     l = 0, max = *bw * (BLOCK_LEN_LONG << 1) / rate;
-    for (i = 0; i < sr->num_cb_long && l < max; i++)
+    for (i = 0; i < sr->num_cb_long && l < max; i++) {
+        sfbOffsetLong[i] = l;
         l += sr->cb_width_long[i];
+    }
+    sfbOffsetLong[i] = l;
     aacquantCfg->max_cbl = i;
     aacquantCfg->max_l = l;
     *bw = (float)l * rate / (BLOCK_LEN_LONG << 1);

--- a/libfaac/quantize.h
+++ b/libfaac/quantize.h
@@ -40,7 +40,8 @@ enum {
 
 void ResetCoderSections(CoderInfo *coderInfo);
 int BlocQuant(CoderInfo *coderInfo, float *xr, AACQuantCfg *aacquantCfg);
-void CalcBW(unsigned *bw, int rate, SR_INFO *sr, AACQuantCfg *aacquantCfg);
+void CalcBW(unsigned *bw, int rate, SR_INFO *sr, AACQuantCfg *aacquantCfg,
+            int *sfbOffsetShort, int *sfbOffsetLong);
 void BlocGroup(CoderInfo *coderInfo, float *xr, CoderInfo *ci_r, float *xr_r, AACQuantCfg *cfg);
 void QuantizeInit(void);
 

--- a/libfaac/tns.c
+++ b/libfaac/tns.c
@@ -31,7 +31,9 @@ static const struct {
     {25, 46}, {26, 46}, {24, 42}, {28, 42}, {30, 42}, {31, 39}
 };
 
-#define TNS_LPC_ORDER       8     /* fixed filter order; spec allows up to TNS_MAX_ORDER but higher orders rarely paid for themselves here */
+#define TNS_LPC_ORDER       8     /* fixed filter order; the spec allows up to 20, but higher orders rarely paid for themselves here */
+_Static_assert(TNS_LPC_ORDER <= TNS_MAX_ORDER,
+               "coder.h's TNS array bound must cover the order tns.c actually fits");
 #define TNS_GAIN_LIMIT      1.4f  /* Levinson-Durbin prediction gain below this isn't worth the filter's bit cost */
 #define TNS_MEASURED_GAIN   1.4f  /* post-quantization re-check: same bar as TNS_GAIN_LIMIT, applied to the filter actually being transmitted */
 
@@ -177,34 +179,22 @@ static void finalize_filter(int order, const float * k, float * a)
     }
 }
 
-/* direction picks which end of the band the recursion runs from: TNS wants
- * the prediction to run towards the transient (so quantization noise piles
- * up where it'll be masked), and the transient can sit at either edge of
- * the analysis window. */
-static void filter_spec(int length, int order, int direction, const float * a, float * spec)
+static void filter_spec(int length, int order, const float * a, const float * src, float * dst)
 {
-    float hist[BLOCK_LEN_LONG];
     int i, j;
+    int limit = order < length ? order : length;
 
-    memcpy(hist, spec, length * sizeof(float));
-    if (direction) {
-        for (i = length - 1; i >= 0; i--) {
-            float acc = hist[i];
-            int jmax = min(order, length - 1 - i);
-
-            for (j = 1; j <= jmax; j++)
-                acc += a[j] * hist[i + j];
-            spec[i] = acc;
-        }
-    } else {
-        for (i = 0; i < length; i++) {
-            float acc = hist[i];
-            int jmax = min(order, i);
-
-            for (j = 1; j <= jmax; j++)
-                acc += a[j] * hist[i - j];
-            spec[i] = acc;
-        }
+    for (i = 0; i < limit; i++) {
+        float acc = src[i];
+        for (j = 1; j <= i; j++)
+            acc += a[j] * src[i - j];
+        dst[i] = acc;
+    }
+    for (; i < length; i++) {
+        float acc = src[i];
+        for (j = 1; j <= order; j++)
+            acc += a[j] * src[i - j];
+        dst[i] = acc;
     }
 }
 
@@ -225,13 +215,14 @@ void TnsInit(faacEncStruct* hEncoder)
 /* Fits one TNS filter over scalefactor bands [b_start, b_stop) and, if it
  * earns its place, whitens that range of `spec` in place and fills *filter.
  * Returns 1 when a filter was written, 0 otherwise. */
-static int tns_fit_range(int b_start, int b_stop, int *sfbOffsetTable,
+static int tns_fit_range(int b_start, int b_stop, const int *sfbOffsetTable,
                          float *spec, TnsFilterData *filter)
 {
     int i_start = sfbOffsetTable[b_start];
     int length = sfbOffsetTable[b_stop] - i_start;
-    float *band, energy;
+    float *band;
     float wspec[BLOCK_LEN_LONG];
+    float trial[BLOCK_LEN_LONG];
     float r[TNS_MAX_ORDER + 1] = {0};
     float k[TNS_MAX_ORDER + 1] = {0};
     float gain;
@@ -241,21 +232,18 @@ static int tns_fit_range(int b_start, int b_stop, int *sfbOffsetTable,
         return 0;
 
     band = spec + i_start;
-    energy = 0.0f;
-    for (i = 0; i < length; i++)
-        energy += band[i] * band[i];
-    if (energy < TNS_MIN_ENERGY)
-        return 0;
 
-    /* Per-band RMS-normalize before autocorrelation, floored at 1% of the
-     * loudest band's RMS. Un-normalized, Levinson-Durbin would fit whatever
-     * band has the most energy and ignore quieter ones -- but pre-echo is
-     * audible in quiet bands too, so the filter needs to whiten across the
-     * whole range, not just the peak. */
+    /* Per-band RMS-normalize into wspec, floored at 1% of the loudest band's
+     * RMS. Un-normalized, Levinson-Durbin would fit whatever band has the
+     * most energy and ignore quieter ones -- but pre-echo is audible in
+     * quiet bands too, so the filter needs to whiten across the whole range,
+     * not just the peak. */
     {
         float maxrms = 0.0f, floorrms;
         float sum_rms = 0.0f, sum_log_rms = 0.0f;
+        float total_energy = 0.0f;
         int nbands = b_stop - b_start;
+        float rms_band[MAX_SCFAC_BANDS];
         int b;
 
         for (b = b_start; b < b_stop; b++) {
@@ -264,7 +252,9 @@ static int tns_fit_range(int b_start, int b_stop, int *sfbOffsetTable,
 
             for (i = s0; i < s1; i++)
                 e += (float)(spec[i] * spec[i]);
+            total_energy += e;
             rms = sqrtf(e / (float)(s1 - s0));
+            rms_band[b - b_start] = rms;
             if (rms > maxrms) maxrms = rms;
 
             /* rms_fl keeps logf() away from 0 for silent bands; folded into
@@ -273,6 +263,9 @@ static int tns_fit_range(int b_start, int b_stop, int *sfbOffsetTable,
             sum_rms += rms_fl;
             sum_log_rms += logf(rms_fl);
         }
+
+        if (total_energy < TNS_MIN_ENERGY)
+            return 0;
 
         /* Spectral flatness (geomean/arithmean of per-band RMS) near 1.0
          * means the band is noise-like, which PNS (quantize.c) is about to
@@ -286,12 +279,8 @@ static int tns_fit_range(int b_start, int b_stop, int *sfbOffsetTable,
 
         for (b = b_start; b < b_stop; b++) {
             int s0 = sfbOffsetTable[b], s1 = sfbOffsetTable[b + 1];
-            float e = 0.0f, rms, wgt;
-
-            for (i = s0; i < s1; i++)
-                e += (float)(spec[i] * spec[i]);
-            rms = sqrtf(e / (float)(s1 - s0));
-            wgt = 1.0f / (rms > floorrms ? rms : floorrms);
+            float rms = rms_band[b - b_start];
+            float wgt = 1.0f / (rms > floorrms ? rms : floorrms);
             for (i = s0; i < s1; i++)
                 wspec[i - i_start] = (float)spec[i] * wgt;
         }
@@ -343,37 +332,40 @@ static int tns_fit_range(int b_start, int b_stop, int *sfbOffsetTable,
      * transmitted no longer pays for itself. Re-check on a trial run of the
      * real (quantized) filter before committing to writing it out. */
     {
-        float trial[BLOCK_LEN_LONG];
-        float orig_e = 0.0f, filt_e = 0.0f;
+        /* The unfiltered energy is r[0]: calc_autocorr_f's lag-0 term is the
+         * same sum(wspec[i]^2) over the same range, and compute_lpc only reads
+         * r. Only the filtered energy needs a pass here. */
+        float filt_e = 0.0f;
 
-        memcpy(trial, wspec, length * sizeof(float));
-        filter_spec(length, order, filter->direction, filter->aCoeffs, trial);
-        for (i = 0; i < length; i++) {
-            orig_e += wspec[i] * wspec[i];
+        filter_spec(length, order, filter->aCoeffs, wspec, trial);
+        for (i = 0; i < length; i++)
             filt_e += trial[i] * trial[i];
-        }
         if (filt_e < TNS_MIN_ENERGY)
             filt_e = TNS_MIN_ENERGY;
-        if (orig_e < TNS_MEASURED_GAIN * filt_e)
+        if (r[0] < TNS_MEASURED_GAIN * filt_e)
             return 0;
     }
 
-    filter_spec(length, order, filter->direction, filter->aCoeffs, band);
+    filter_spec(length, order, filter->aCoeffs, band, trial);
+    memcpy(band, trial, length * sizeof(float));
     return 1;
 }
 
-void TnsEncode(TnsInfo* tnsInfo, int numBands, enum WINDOW_TYPE blockType, int* sfbOffsetTable,
-               float* spec)
+void TnsEncode(CoderInfo *coderInfo, float *spec)
 {
+    TnsInfo *tnsInfo = &coderInfo->tnsInfo;
+    int numBands = coderInfo->sfbn;
+    const int *sfbOffsetTable = coderInfo->sfb_offset;
     int b_start, b_stop;
 
+    /* Long blocks only: the caller screens ONLY_SHORT_WINDOW out, since short
+     * windows already have the temporal resolution to not need TNS. */
     tnsInfo->tnsDataPresent = 0;
     tnsInfo->windowData.numFilters = 0;
 
-    /* Short windows already have the temporal resolution to not need TNS. */
-    if (blockType == ONLY_SHORT_WINDOW)
-        return;
-
+    /* Frame-invariant: the band limits come from the sample rate's TNS table and
+     * numBands is aacquantCfg.max_cbl for every long channel. Recomputed rather
+     * than latched in TnsInit only because TnsInit runs before CalcBW. */
     b_start = min(tnsInfo->tnsMinBandNumberLong, numBands);
     b_stop = min(tnsInfo->tnsMaxBandsLong, numBands);
     if (b_stop <= b_start)

--- a/libfaac/tns.h
+++ b/libfaac/tns.h
@@ -32,10 +32,9 @@ extern "C" {
 /* Latch the per-channel band limits from the sample rate's TNS tool table. */
 void TnsInit(faacEncStruct* hEncoder);
 
-/* Analyse one channel and, if it pays off, whiten `spec` in place. */
-void TnsEncode(TnsInfo* tnsInfo, int numBands,
-               enum WINDOW_TYPE blockType, int* sfbOffsetTable,
-               float* spec);
+/* Analyse one channel and, if it pays off, whiten `spec` in place.
+ * Long blocks only -- the caller must not pass an ONLY_SHORT_WINDOW channel. */
+void TnsEncode(CoderInfo *coderInfo, float *spec);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Enable TNS by default across the library, CLI, and GUI, while optimizing TNS processing and reducing memory/computation footprint.

This is change in behavior should be fine as we're bumping the ABI anyway with regard to mp4write and other things. The other benefit here is also that TNS will never rot because its disabled by default right now.

## Summary of Changes

### Default Configuration Changes
- **Enabled by Default**: TNS is now enabled by default in `libfaac` (`faacEncOpen`, `faac_params_init`), the CLI (`encode_engine.c`/`main.c`), and the GUI (`maingui.c`).
- **CLI Options**: Removed `--tns` (now redundant). Moved `--no-tns` out of testing-only options into standard quality options.

### TNS & Code Optimizations (`tns.c`, `coder.h`, `frame.c`, `quantize.c`)
- **Buffer & Loop Optimizations**: `filter_spec` eliminates the dead `direction` branch (direction is always `0`) and internal `hist[]` allocation, filtering directly between source and destination buffers.
- **RMS Caching & Energy Pre-Checks**: `tns_fit_range` merges standalone energy pre-checks into the per-band RMS loop and caches band RMS values to avoid redundant recomputations. Early-exits short blocks before entering TNS logic.
- **Array Sizing & Bounds**: Reduced `TNS_MAX_ORDER` (12 → 8) and `TNS_MAX_FILTERS` (4 → 1) in `coder.h` to match actual encoder output, backed by `_Static_assert`s.
- **Prebuilt Tables**: Converted `sfb_offset` to a pointer referencing an encoder-level table built once inside `CalcBW`, avoiding per-channel, per-frame array population.

## Benchmarks & Validation

Tested via `faac-benchmark` against `master` across LC/HE profiles and multiple bitrates:
- **AAC-LC**: Complete no-op. Output is bit-exact to TNS-off across all test scenarios.
- **HE-AAC**: Net positive quality improvement (21/22 scenarios improved, avg +0.0008 MOS at identical bitrate). CPU overhead is negligible (~+0.01% Cachegrind Ir cost).
- **Verification**: Output with `--no-tns` is bit-exact to `master`'s legacy default.
- Benchmark: https://github.com/nschimme/faac/actions/runs/34491712335