### PR TITLE
sbr: signal psPresentFlag = 0 explicitly for mono HE-AAC

### DIFF
--- a/libfaac/sbr.c
+++ b/libfaac/sbr.c
@@ -236,24 +236,38 @@ int SbrContextGetASC(SBRContext *sbrCtx, int coreSRIdx, int channels, unsigned c
 {
     /* Explicit-hierarchy ASC: AAC-LC core wrapped with an SBR extension
      * (sync 0x2b7, type 5) carrying the full output rate. The core rate is
-     * Fs/2 (dual-rate SBR); the extension declares the full output rate. */
-    *pSize = 5;
-    unsigned char *buf = (unsigned char *)malloc(5);
-    if (!buf) return -3;
-    *ppBuffer = buf;
+     * Fs/2 (dual-rate SBR); the extension declares the full output rate.
+     *
+     * A mono core also carries the PS sync extension with psPresentFlag = 0:
+     * without it a decoder may assume parametric stereo is implied and return
+     * two channels. */
+    const int signalPS = (channels == 1);
+    const unsigned long size = signalPS ? 7 : 5;
+
+    unsigned char *buf = (unsigned char *)malloc(size);
+    if (buf == NULL) return -3;
 
     BitStream bs;
-    InitBitStream(&bs, buf, 5); /* zeroes the buffer, so the 3 trailing pad bits need no write */
+    InitBitStream(&bs, buf, (uint32_t)size); /* zeroes the buffer, so the trailing pad bits need no write */
 
-    PutBit(&bs, LOW,      5);  /* core object type */
-    PutBit(&bs, coreSRIdx, 4); /* core rate (Fs/2, dual-rate) */
-    PutBit(&bs, channels,  4);
-    PutBit(&bs, 0,         3); /* frameLengthFlag, dependsOnCoreCoder, extensionFlag */
-    PutBit(&bs, 0x2b7,    11); /* syncExtensionType */
-    PutBit(&bs, HE_V1,     5); /* extObjectType = SBR */
-    PutBit(&bs, 1,         1); /* sbrPresentFlag */
-    PutBit(&bs, sbrCtx->fullSampleRateIdx, 4); /* SBR output rate (2*core) */
+    BitAccumulator a;
+    AccumBegin(&a, &bs);
+    AccumPutBits(&a, LOW,       5); /* core object type */
+    AccumPutBits(&a, coreSRIdx, 4); /* core rate (Fs/2, dual-rate) */
+    AccumPutBits(&a, channels,  4);
+    AccumPutBits(&a, 0,         3); /* frameLengthFlag, dependsOnCoreCoder, extensionFlag */
+    AccumPutBits(&a, 0x2b7,    11); /* syncExtensionType */
+    AccumPutBits(&a, HE_V1,     5); /* extObjectType = SBR */
+    AccumPutBits(&a, 1,         1); /* sbrPresentFlag */
+    AccumPutBits(&a, sbrCtx->fullSampleRateIdx, 4); /* SBR output rate (2*core) */
+    if (signalPS) {
+        AccumPutBits(&a, 0x548, 11); /* syncExtensionType = PS */
+        AccumPutBits(&a, 0,      1); /* psPresentFlag */
+    }
+    AccumEnd(&a);
 
+    *ppBuffer = buf;
+    *pSize = size;
     return 0;
 }
 


### PR DESCRIPTION
A mono HE-AAC `AudioSpecificConfig` ends three bits after the SBR extension, and the spec only looks for the PS sync extension with twelve bits left. Nothing states whether parametric stereo is present, so decoders guess — ffmpeg assumes PS is implied on a mono core and returns two channels.

The 5-byte config is conformant; this is explicit signalling, not a conformance fix.

Reported by @Allmight97, whose candidate patch this follows in https://github.com/knik0/faac/issues/191

## Fix

Write the `0x548` sync extension with `psPresentFlag = 0` when `channelConfiguration` is 1. Stereo keeps the 5-byte config, since PS only ever applies to a mono core.

| | ASC |
|---|---|
| mono, master | `130856e598` |
| mono, this PR | `130856e59d4800` |
| stereo | `131056e598`, unchanged |

## Decoder matrix

Channels returned from muxed MP4 output:

| source | ffmpeg 9.0 | faad2 2.11.3 | Apple AudioToolbox |
|---|---|---|---|
| mono, master | 2 | 2 | 1 |
| mono, this PR | **1** | 2 | 1 |
| stereo, master | 2 | 2 | 2 |
| stereo, this PR | 2 | 2 | 2 |

faad2 and AudioToolbox decodes are byte-identical before and after, so nothing regresses. Note that faad2 ignores `psPresentFlag` and still returns two channels for a mono core — #191 suggested it would follow the flag, and it does not. Apple was already correct without it. The fix is ffmpeg-specific.

LC output is unchanged.

## Footprint

The config is built through `BitAccumulator` over a stack `BitStream` instead of a heap one. gcc 15.2 `--buildtype=release` + LTO, `.text+.rodata`: **−192 B** vs master, PS signalling included.

The ASC is built once per encoder and cached (`faac_encoder_asc`), so this path has no throughput component.

Benchmark: https://github.com/nschimme/faac/actions/runs/34500233469