### PR TITLE
sbr: drain the SBR tail on HE-AAC flush frames

### DIFF
--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -687,7 +687,8 @@ __attribute__((cold, noinline))
 static void doHEAACFrame(faacEncStruct *hEncoder, unsigned int realPerCh,
                          float *heHalfRate[MAX_CHANNELS])
 {
-    SbrContextProcessFrame(hEncoder->sbrContext, hEncoder->numChannels, (int)realPerCh, hEncoder->inputFifo, heHalfRate);
+    SbrContextProcessFrame(hEncoder->sbrContext, hEncoder->numChannels, (int)realPerCh,
+                           (int)hEncoder->flushFrame, hEncoder->inputFifo, heHalfRate);
 }
 
 /* Admission gate: TNS shapes noise along the temporal envelope, so a window
@@ -730,6 +731,11 @@ int faacEncEncode(faacEncHandle hpEncoder,
     unsigned int frameSamplesPerCh = faacFrameSamples(hEncoder);
     int flushing = (samplesInput == 0 || inputBuffer == NULL);
 
+    /* SBR's coded-payload ring (frameFIFO) trails the core FIFO by one
+     * extra tick, so HE-AAC needs one more flush tick than LC to drain. */
+    unsigned int flushBudget = (hEncoder->config.aacObjectType == HE_V1) ?
+        SBR_FRAME_FIFO : (LOOKAHEAD_DEPTH + 1);
+
     if (samplesInput > 0 && inputBuffer != NULL)
     {
         if (appendInputFifo(hEncoder, inputBuffer, samplesInput) < 0)
@@ -759,10 +765,6 @@ int faacEncEncode(faacEncHandle hpEncoder,
         if (realPerCh == 0)
             hEncoder->flushFrame++;
 
-        /* SBR's coded-payload ring (frameFIFO) trails the core FIFO by one
-         * extra tick, so HE-AAC needs one more flush tick than LC to drain. */
-        unsigned int flushBudget = (hEncoder->config.aacObjectType == HE_V1) ?
-            SBR_FRAME_FIFO : (LOOKAHEAD_DEPTH + 1);
         if (hEncoder->flushFrame > flushBudget)
             return 0;
 
@@ -783,15 +785,15 @@ int faacEncEncode(faacEncHandle hpEncoder,
             hEncoder->audioFIFO[channel][FIFO_AHEAD1]  = hEncoder->audioFIFO[channel][FIFO_AHEAD2];
             hEncoder->audioFIFO[channel][FIFO_AHEAD2] = tmp;
 
-            if (realPerCh == 0)
+            if (hEncoder->config.aacObjectType == HE_V1 && heHalfRate[channel])
+            {
+                /* ahead of the flush case: this carries the resampler's tail */
+                memcpy(hEncoder->audioFIFO[channel][FIFO_AHEAD2], heHalfRate[channel], FRAME_LEN * sizeof(float));
+            }
+            else if (realPerCh == 0)
             {
                 /* start flushing*/
                 memset(hEncoder->audioFIFO[channel][FIFO_AHEAD2], 0, FRAME_LEN * sizeof(float));
-            }
-            else if (hEncoder->config.aacObjectType == HE_V1 && heHalfRate[channel])
-            {
-                /* core feeds on the SBR-downsampled signal, not the raw input */
-                memcpy(hEncoder->audioFIFO[channel][FIFO_AHEAD2], heHalfRate[channel], FRAME_LEN * sizeof(float));
             }
             else
             {

--- a/libfaac/sbr.c
+++ b/libfaac/sbr.c
@@ -275,7 +275,7 @@ void SbrContextUpdateConfig(SBRContext *sCtx, int channels, unsigned long bitrat
         SbrUpdate(sCtx->sbrInfo, bitrate);
 }
 
-void SbrContextProcessFrame(SBRContext *sCtx, int numChannels, int realPerCh, float *inputFifo[MAX_CHANNELS], float *heHalfRate[MAX_CHANNELS])
+void SbrContextProcessFrame(SBRContext *sCtx, int numChannels, int realPerCh, int flushTick, float *inputFifo[MAX_CHANNELS], float *heHalfRate[MAX_CHANNELS])
 {
     unsigned int channel;
     Resampler *rs = sCtx->resampler;
@@ -286,23 +286,22 @@ void SbrContextProcessFrame(SBRContext *sCtx, int numChannels, int realPerCh, fl
     sCtx->frameHead = (sCtx->frameHead + 1) % SBR_FRAME_FIFO;
     SbrFrameData *fd = &sCtx->frameFIFO[sCtx->frameHead];
 
-    /* Flush frames are silence, whose analysis result is known up front: no
-     * transient, one FIXFIX envelope, floored levels, default noise floors.
-     * Skip straight to it -- the core signal is substituted with silence in
-     * frame.c anyway -- but keep the delay lines advancing so the payloads
-     * still in flight drain out. */
-    if (realPerCh == 0) {
-        sbr_frame_silence(fd);
+    /* Tick 1 still has real signal in the QMF overlap and the decimation FIR;
+     * by tick 2 both are zero, so the rest of the drain is known silence. */
+    if (realPerCh == 0 && flushTick > 1) {
         for (channel = 0; channel < (unsigned int)numChannels; channel++) {
+            memset(rs->halfRate[channel], 0, FRAME_LEN * sizeof(float));
+            heHalfRate[channel] = rs->halfRate[channel];
             sCtx->signalAnalysis.ch[channel].transientStrength = 0.0f;
             sCtx->signalAnalysis.ch[channel].wantShort = 0;
-            heHalfRate[channel] = rs->halfRate[channel];
         }
+        sbr_frame_silence(fd);
     } else {
         for (channel = 0; channel < (unsigned int)numChannels; channel++) {
             float *fullRate = rs->fullRate[channel];
             fullPtrs[channel] = fullRate;
-            memcpy(fullRate, inputFifo[channel], realPerCh * sizeof(float));
+            if (realPerCh)
+                memcpy(fullRate, inputFifo[channel], realPerCh * sizeof(float));
             /* Final partial frame: silence-pad the unfilled full-rate tail to
              * prevent the resampler from consuming stale data. */
             if (realPerCh < 2 * FRAME_LEN)
@@ -320,9 +319,9 @@ void SbrContextProcessFrame(SBRContext *sCtx, int numChannels, int realPerCh, fl
         Resample(rs, 2 * FRAME_LEN);
     }
 
-    /* Update the transient FIFO. Shift down by one and push the newest
-     * decision at SBR_DETECT_FIFO-1; index 0 stays aligned with the core
-     * frame being coded (LOOKAHEAD_DEPTH frames behind this analysis). */
+    /* Update the transient FIFO. Shift down by one and push
+     * the newest decision at SBR_DETECT_FIFO-1; index 0 stays aligned with the
+     * core frame being coded (LOOKAHEAD_DEPTH frames behind this analysis). */
     for (channel = 0; channel < (unsigned int)numChannels; channel++) {
         memmove(&sCtx->transientStrengthFIFO[channel][0], &sCtx->transientStrengthFIFO[channel][1], (SBR_DETECT_FIFO - 1) * sizeof(float));
         sCtx->transientStrengthFIFO[channel][SBR_DETECT_FIFO - 1] = sCtx->signalAnalysis.ch[channel].transientStrength;

--- a/libfaac/sbr.h
+++ b/libfaac/sbr.h
@@ -115,7 +115,7 @@ void SbrContextEnd(SBRContext *sbrCtx);
 int SbrContextGetASC(SBRContext *sbrCtx, int coreSRIdx, int channels, unsigned char** ppBuffer, unsigned long* pSize);
 unsigned int SbrContextGetXOverBandwidth(SBRContext *sbrCtx);
 void SbrContextUpdateConfig(SBRContext *sCtx, int channels, unsigned long bitrate, FFT_Tables *fft_tables);
-void SbrContextProcessFrame(SBRContext *sCtx, int numChannels, int realPerCh, float *inputFifo[MAX_CHANNELS], float *heHalfRate[MAX_CHANNELS]);
+void SbrContextProcessFrame(SBRContext *sCtx, int numChannels, int realPerCh, int flushTick, float *inputFifo[MAX_CHANNELS], float *heHalfRate[MAX_CHANNELS]);
 int SbrContextIsPresent(SBRContext *sCtx);
 void SbrContextRestoreRate(SBRContext *sCtx, unsigned long *sampleRate, unsigned int *sampleRateIdx, SR_INFO **srInfo);
 unsigned long SbrContextGetFullRate(SBRContext *sCtx, unsigned long defaultRate);


### PR DESCRIPTION
Fixes the tail loss reported in knik0/faac#191 (where #180 previously fixed the flush contract for LC, but HE-AAC still discarded its tail).

Reported and diagnosed by @Allmight97, whose candidate patch this builds upon.

### Defect
On an HE flush tick (`realPerCh == 0`):
- `SbrContextProcessFrame()` short-circuits to a synthetic silence payload without running `SbrAnalyze`/`SbrEncode` or `Resample`. Consequently, the QMF overlap still holds the last `SBR_QMF_OVL_LEN_64` input samples and the decimation FIR retains its history.
- `faacEncEncode()` checks `realPerCh == 0` before reaching the HE branch, causing the core buffer to be zero-set and the downsampled signal to be ignored.

As a result, the trailing access units describe silence that was never actually encoded.

### Fix
- The first flush tick now routes through the same analysis and resampling path over a zero-filled frame, while the core processes the downsampled signal before the flush zero-fill.
- By the second tick, both the QMF overlap and FIR history are cleared, ensuring remaining frames are true silence without altering the overall flush budget.
- Processing silence via the full path remains safe: the envelope quantizer floors with `SBR_LOG_ENERGY_FLOOR` and clamps to `[0,127]`, while the transient detector divides by `ssum + SBR_ENERGY_FLOOR`.

### Results & Performance
Validated on the issue's fixture (48 kHz stereo, 12,117 samples), comparing normal flush against a flush following two silent input frames:

| Implementation | Differing Samples | First / Last | Max Abs Diff |
|---|---:|---|---:|
| Master | 821 | 11296 / 12116 | 0.112998 |
| This PR | **0** | — | 0.0 |

**Overhead (gcc 15.2 `--buildtype=release` + LTO):**
Adds a fixed ~0.7M instructions per stream (amortizing over duration). `.text+.rodata` increases by 32 bytes. LC performance and binary footprint remain byte-identical.

| HE-AAC v1 @64k, stereo | Master Ir | This PR | Δ |
|---|---:|---:|---:|
| 6 s | 133,471,480 | 134,165,168 | +0.52% |
| 60 s | 1,319,264,529 | 1,320,047,017 | **+0.06%** |

Benchmark: https://github.com/nschimme/faac/actions/runs/34503217021

### Compatibility
- Final access units differ, but FFmpeg 9.0, FAAD2 2.11.3, and Apple AudioToolbox decode the output cleanly with identical channel counts and durations.
- Verified on short streams (1, 100, 2047, and 4096 samples/ch for both HE and LC): correct packet counts with no premature 0-byte returns.
