### PR TITLE
refit ABR bandwidth curve and decouple HE-AAC VBR ceiling

### DIFF
--- a/libfaac/faac.c
+++ b/libfaac/faac.c
@@ -188,9 +188,10 @@ static faac_status validate_params(const faac_params *p)
             if (p->channel_map[i] < 0 || (uint32_t)p->channel_map[i] >= p->num_channels)
                 return FAAC_ERR_INVALID_ARGUMENT;
     }
-    /* bit_rate is per channel; reject a target above what a channel can carry
-     * under the ISO/IEC 14496-3 per-frame ceiling regardless of max_bit_rate. */
-    if (p->bit_rate && p->bit_rate > MaxBitrate(p->sample_rate))
+    /* bit_rate is per channel, as is the bound. Only a ceiling: it is the
+     * ISO/IEC 14496-3 per-frame limit and therefore real, whereas the format
+     * sets no minimum and the encoder's own floor already ends the descent. */
+    if (p->bit_rate && (p->bit_rate > MaxBitrate(p->sample_rate)))
         return FAAC_ERR_INVALID_ARGUMENT;
     if (p->max_bit_rate) {
         /* Bounded because it is converted into a per-frame bit budget; an

--- a/libfaac/frame.c
+++ b/libfaac/frame.c
@@ -36,9 +36,15 @@
  * lands, the more spectrum SBR is rescuing. 8000 is HE-AAC's design floor and
  * the lowest rate measured. */
 #define HE_MIN_BITRATE_PER_CH 8000
-#define HE_MAX_BITRATE_PER_CH 48000  /* above ceiling LC wins: SBR costs up to 1 MOS on transients */
-/* quantqual == totalBitrate/1280 (see faacEncApplyConfig); derived to stay in sync with HE_MAX_BITRATE_PER_CH. */
-#define HE_VBR_QUANTQUAL_MAX  (2 * HE_MAX_BITRATE_PER_CH / 1280)
+/* Crossover measured on the refitted LC curve: HE leads by 0.070 MOS at 24000
+ * per channel and trails by 0.011 at 28000. A wider LC core moves this down --
+ * refit the curve and this constant has to be re-measured with it. */
+#define HE_MAX_BITRATE_PER_CH 26000
+/* Frozen, not derived: quantqual doesn't map onto a bitrate ceiling cleanly
+ * (the two are off by 2-4.5x across the range), so this is set by measurement.
+ * Deriving it from HE_MAX_BITRATE_PER_CH instead would flip -q 42+ to LC for
+ * 13.1% more bits. */
+#define HE_VBR_QUANTQUAL_MAX  75
 
 #if (defined WIN32 || defined _WIN32 || defined WIN64 || defined _WIN64) && !defined(PACKAGE_VERSION)
 #include "win32_ver.h"
@@ -70,28 +76,26 @@ static unsigned int CalcBandwidth(unsigned long bitRate, unsigned long sampleRat
 
     if (!bitRate) return nyquist;
 
-    if (bitRate <= 16000) {
-        /* Segment 1: Telephony (4kHz to 6kHz) */
-        bw = 4000 + (bitRate / 8);
+    /* Anchors land on long-block band edges, so CalcBW()'s snap is a no-op and
+     * these constants are the cutoff you actually get. Divisors are powers of
+     * two. LC in effect: HE reaches here too, but faacEncApplyConfig then
+     * overwrites bandWidth with the SBR crossover, which the core must meet. */
+    if (bitRate <= 12000) {
+        /* Unmeasured below here; ramp rather than extend the plateau down.
+         * bitRate is unsigned, so guard the subtraction. */
+        bw = (bitRate > 8000) ? 9250 + ((bitRate - 8000) * 5 / 4) : 9250;
     }
     else if (bitRate <= 32000) {
-        /* Segment 2: Low-tier (6kHz to 11kHz)
-         */
-        bw = 6000 + ((bitRate - 16000) * 5 / 16);
+        /* Flat by measurement: the optimum does not move across this range. */
+        bw = 14250;
     }
-    else if (bitRate <= 64000) {
-        /* Segment 3: Mid-tier expansion (11kHz to 18.5kHz)
-         */
-        bw = 11000 + ((bitRate - 32000) * 15 / 64);
-    }
-    else if (bitRate <= 128000) {
-        /* Segment 4: High-fidelity catch-up (18.5kHz to 20kHz) */
-        bw = 18500 + ((bitRate - 64000) * 3 / 128);
+    else if (bitRate <= 48000) {
+        bw = 14250 + ((bitRate - 32000) * 9 / 32);
     }
     else {
-        /* Segment 5: Transparency plateau (20kHz+) */
-        bw = 20000 + ((bitRate - 128000) / 16);
-        if (bw > 20000) bw = 20000;
+        /* Widening past this loses at every reachable rate -- the band above
+         * holds ~0.006% of programme energy and sits at the edge of hearing. */
+        bw = 18750;
     }
 
     /* Safety clamp to Shannon-Nyquist limit */

--- a/libfaac/quantize.c
+++ b/libfaac/quantize.c
@@ -437,7 +437,10 @@ void CalcBW(unsigned *bw, int rate, SR_INFO *sr, AACQuantCfg *aacquantCfg)
     for (i = 0; i < sr->num_cb_short && l < max; i++)
         l += sr->cb_width_short[i];
     aacquantCfg->max_cbs = i;
-    if (aacquantCfg->pnslevel) *bw = (float)l * rate / (BLOCK_LEN_SHORT << 1);
+
+    /* Snap on the long grid only. Both loops round up, so also snapping to the
+     * 14-band short grid compounds two round-ups and leaves the cutoff far
+     * coarser than the long grid can express. */
 
     l = 0, max = *bw * (BLOCK_LEN_LONG << 1) / rate;
     for (i = 0; i < sr->num_cb_long && l < max; i++)


### PR DESCRIPTION
This is a quality improvement that was noticed when comparing FAAC to the competition using faac-benchmark. HE needs another pass to see why its not competitive anymore later, but HE also uses the LC core so this is an overall win.

Refits the ABR bandwidth selection curve against empirical sweep data and eliminates redundant grid snapping. Removing secondary short-block quantization grants fine-grained bandwidth control, eliminating artificial bandwidth bottlenecks across low and mid bitrates.

---

## Technical Changes

- **Grid Snapping (`CalcBW`)**: Removed short-grid quantization under PNS (`pnslevel`). [PR #93](https://github.com/knik0/faac/pull/93) replaced the old linear bandwidth formula with a piecewise curve but left behind its short-block snapping logic, causing coarse staircasing in reachable cutoffs. Quantization is now restricted strictly to the long-block grid.
- **Curve Refit (`CalcBandwidth`)**: Updated cutoff logic based on a 110-point per-channel sweep over the 49-clip corpus:
  - **$\le$ 12 kbps/ch**: Gradual ramp up from 9.25 kHz.
  - **12–32 kbps/ch**: Flat 14.25 kHz plateau (measured optimum).
  - **32–48 kbps/ch**: Linear scale from 14.25 kHz to 18.75 kHz.
  - **> 48 kbps/ch**: Capped at 18.75 kHz.
- **LC/HE Crossover (`HE_MAX_BITRATE_PER_CH`)**: Lowered the crossover ceiling from 48,000 to 26,000 bps/ch. With the wider LC core, LC outperforms HE-AAC starting at 28 kbps/ch. AUTO mode now selects HE for $\le$ 48k stereo and LC for $\ge$ 56k stereo.
- **VBR Decoupling (`HE_VBR_QUANTQUAL_MAX`)**: Pinned the VBR gate to a constant `75` instead of deriving it from the ABR ceiling, preventing ABR changes from unintentionally shifting VBR streams to LC.

---

## Cutoff & Crossover Impact

### Measured Cutoffs (48 kHz Stereo)

```mermaid
xychart-beta
    title "ABR Bandwidth Selection: Before vs. After"
    x-axis "Target bitrate (kbps, stereo)" [24, 40, 48, 64, 96, 128, 256]
    y-axis "Cutoff (kHz)" 0 --> 25
    line [6.843, 8.250, 10.500, 12.750, 15.000, 18.000, 21.000]
    line [14.250, 14.250, 14.250, 14.250, 18.750, 18.750, 18.750]
```

| Setting | Pre-patch Cutoff | New Cutoff |
| :--- | :--- | :--- |
| `-b 24` | 6,843 Hz | **14,250 Hz** |
| `-b 40` | 8,250 Hz | **14,250 Hz** |
| `-b 64` | 12,750 Hz | **14,250 Hz** |
| `-b 96` | 15,000 Hz | **18,750 Hz** |
| `-b 256` | 21,000 Hz | **18,750 Hz** |

### HE-AAC vs. LC Profile Crossover Delta (MOS)

| Rate (bps/ch) | Delta (HE − LC) | Selected Profile |
| ---: | ---: | :--- |
| 12,000 | +0.281 | HE-AAC |
| 16,000 | +0.288 | HE-AAC |
| 20,000 | +0.183 | HE-AAC |
| 24,000 | +0.070 | HE-AAC |
| **28,000** | **−0.011** | **LC** |
| **32,000** | **−0.060** | **LC** |
| **48,000** | **−0.176** | **LC** |

---

## Quality Verification

Benchmark: https://github.com/nschimme/faac/actions/runs/34599220643

Across the full test corpus, **suite average improved by +0.153 MOS** (777 clips improved, 117 degraded). Overall library size decreased by **−0.29%**.

| Scenario | Cutoff (Hz) | MOS $\Delta$ | Wins / Losses |
| :--- | :--- | ---: | :--- |
| `48k_stereo_24k` | 6,844 $\rightarrow$ 14,250 | **+0.657** | 49 / 0 |
| `48k_stereo_32k` | 6,844 $\rightarrow$ 14,250 | **+0.776** | 49 / 0 |
| `48k_stereo_40k` | 8,250 $\rightarrow$ 14,250 | **+0.997** | 49 / 0 |
| `48k_stereo_48k` | 10,500 $\rightarrow$ 14,250 | **+0.554** | 48 / 0 |
| `48k_stereo_56k` | 10,500 $\rightarrow$ 14,250 | **+0.640** | 49 / 0 |
| `48k_stereo_64k` | 12,750 $\rightarrow$ 14,250 | **+0.164** | 49 / 0 |
| `48k_stereo_96k` | 15,000 $\rightarrow$ 18,750 | **+0.016** | 29 / 12 |
| `48k_stereo_128k…256k` | 21,000 $\rightarrow$ 18,750 | **+0.002…+0.010** | 82 / 4 |
| `16k_mono_16k` | 7,000 $\rightarrow$ 8,000 | **+0.075** | 285 / 101 |

---

## Known Trade-offs & Limitations

1. **Bitrate Overshoot at Low Rates**: At 24k stereo, target bitrate overshoot increases from +27% to +35%.
2. **`16k_mono_16k` Regressions**: While net MOS improves (+0.075), 101 of 386 clips show a regression, causing an expected MOS gate warning in CI.
3. **High-Bitrate Sampling Bounds**: The upper plateau sweep was executed up to 147 kbps/channel.
4. **Scope Constraints**:
   - **Sample Rates**: Directly measured on 48 kHz and 16 kHz streams.
   - **Encoding Mode**: Applies exclusively to ABR. VBR output remains 100% byte-identical.